### PR TITLE
Add inline search-as-you-type filter (#22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Start database
         run: docker compose up -d database pgbouncer && docker compose exec -T database sh -c 'until pg_isready -U app; do sleep 1; done'
       - name: Build TypeScript assets
-        run: docker compose run --rm --no-deps --entrypoint "" php bun build assets/ts/theme-toggle.ts assets/ts/timeago.ts assets/ts/mark-as-read.ts assets/ts/infinite-scroll.ts --outdir=assets/js
+        run: docker compose run --rm --no-deps --entrypoint "" php bun build assets/ts/theme-toggle.ts assets/ts/timeago.ts assets/ts/mark-as-read.ts assets/ts/infinite-scroll.ts assets/ts/article-filter.ts --outdir=assets/js
       - name: Start app (vendor already installed — entrypoint skips composer install)
         run: docker compose up -d --wait --no-build php
       # Tests bypass PgBouncer and connect directly to database.

--- a/assets/app.js
+++ b/assets/app.js
@@ -9,3 +9,4 @@ import './js/theme-toggle.js';
 import './js/timeago.js';
 import './js/mark-as-read.js';
 import './js/infinite-scroll.js';
+import './js/article-filter.js';

--- a/assets/ts/article-filter.ts
+++ b/assets/ts/article-filter.ts
@@ -1,0 +1,32 @@
+const DEBOUNCE_MS = 200;
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+function filterArticles(query: string): void {
+    const cards = document.querySelectorAll<HTMLElement>('[data-searchable]');
+    const normalizedQuery = query.toLowerCase().trim();
+
+    for (const card of cards) {
+        const searchable = card.dataset['searchable'] ?? '';
+
+        if (normalizedQuery.length === 0 || searchable.includes(normalizedQuery)) {
+            card.classList.remove('hidden');
+        } else {
+            card.classList.add('hidden');
+        }
+    }
+}
+
+const input = document.querySelector<HTMLInputElement>('#article-filter');
+
+if (input) {
+    input.addEventListener('input', () => {
+        if (debounceTimer !== null) {
+            clearTimeout(debounceTimer);
+        }
+
+        debounceTimer = setTimeout(() => {
+            filterArticles(input.value);
+        }, DEBOUNCE_MS);
+    });
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,7 +19,7 @@ parameters:
         - src
         - tests
     excludePaths:
-        - config/reference.php
+        - config/reference.php (?)
         - config/preload.php
         - ecs.php
     ignoreErrors:

--- a/templates/components/_article_card.html.twig
+++ b/templates/components/_article_card.html.twig
@@ -1,5 +1,5 @@
 {# Expects: article (Article entity) #}
-<div class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow {{ article_read is defined and article_read ? 'opacity-60' : '' }}" data-article-id="{{ article.id }}">
+<div class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow {{ article_read is defined and article_read ? 'opacity-60' : '' }}" data-article-id="{{ article.id }}" data-searchable="{{ article.title|lower }} {{ article.summary|default('')|lower }}">
     <div class="card-body p-4">
         <div class="flex items-start gap-2">
             <div class="flex-1">

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -30,6 +30,7 @@
             <input type="hidden" name="_token" value="{{ csrf_token('mark_all_read') }}">
             <button type="submit" class="btn btn-sm btn-ghost">Mark All Read</button>
         </form>
+        <input id="article-filter" type="text" placeholder="Filter articles..." class="input input-bordered input-sm flex-1" />
     </div>
 
     {# Article feed #}


### PR DESCRIPTION
## Summary
- Add client-side article filter input with 200ms debounce above the news feed
- Filter matches against article title + summary text via `data-searchable` attribute
- Toggle `hidden` class on non-matching cards; empty input shows all
- Add `article-filter.ts` to CI bun build step
- Fix PHPStan optional exclude path for `config/reference.php`

## Test plan
- [ ] Type in the filter input on the dashboard and verify articles filter in real-time
- [ ] Verify clearing the input restores all articles
- [ ] Verify debounce works (rapid typing does not cause excessive DOM updates)
- [ ] Verify `make quality` passes
- [ ] Verify CI pipeline builds the new TypeScript file

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)