### PR TITLE
Add loadable alert rule fixtures (#25)

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -10,6 +10,7 @@ use App\Enrichment\Service\AiCategorizationService;
 use App\Enrichment\Service\AiSummarizationService;
 use App\Enrichment\Service\CategorizationServiceInterface;
 use App\Enrichment\Service\SummarizationServiceInterface;
+use App\Notification\Command\LoadAlertRulesCommand;
 use App\Notification\Service\AiAlertEvaluationService;
 use App\Shared\AI\Command\AiSmokeTestCommand;
 use App\Shared\AI\Platform\ModelFailoverPlatform;
@@ -106,6 +107,10 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set(AiSmokeTestCommand::class)
         ->arg('$platform', service('ai.platform.openrouter.failover'));
+
+    // Wire admin email for LoadAlertRulesCommand
+    $services->set(LoadAlertRulesCommand::class)
+        ->arg('$adminEmail', '%env(ADMIN_EMAIL)%');
 
     // Wire admin credentials for SeedDataCommand
     $services->set(SeedDataCommand::class)

--- a/fixtures/alert-rules/portfolio.yaml
+++ b/fixtures/alert-rules/portfolio.yaml
@@ -1,0 +1,378 @@
+# Portfolio Alert Rules — Seed Data
+# Load with: bin/console app:load-alert-rules fixtures/alert-rules/portfolio.yaml
+
+# --- Hormuz / Energy Crisis ---
+
+- name: "Hormuz De-escalation"
+  type: ai
+  keywords:
+    - "hormuz ceasefire"
+    - "hormuz reopen"
+    - "strait reopen"
+    - "iran diplomacy"
+    - "iran negotiations"
+    - "iran peace deal"
+    - "iran ceasefire"
+    - "hormuz shipping resume"
+    - "hormuz escort"
+    - "tanker convoy"
+    - "iran nuclear deal"
+  context_prompt: >
+    I hold CF Industries (nitrogen fertilizer) and K+S (potash) stocks that profit
+    directly from the Hormuz blockade. Any credible signal toward reopening the strait
+    or de-escalation with Iran would mean these positions lose their scarcity premium
+    rapidly — potentially -20 to -30% within days. Rate severity HIGH for concrete
+    diplomatic breakthroughs, peace talks with deadlines, or confirmed escort operations.
+    Rate LOW for vague diplomatic language without actionable outcomes.
+  urgency: high
+  severity_threshold: 6
+  cooldown_minutes: 30
+  categories: ["politics", "business"]
+  enabled: true
+
+- name: "Hormuz Escalation"
+  type: keyword
+  keywords:
+    - "hormuz attack"
+    - "hormuz mine"
+    - "tanker struck"
+    - "tanker attacked"
+    - "iran navy"
+    - "hormuz blockade"
+    - "oil $150"
+    - "oil $200"
+    - "oil record"
+    - "iran power plant strike"
+    - "iran infrastructure strike"
+    - "gulf war"
+  context_prompt: ~
+  urgency: medium
+  severity_threshold: 5
+  cooldown_minutes: 60
+  categories: ["politics", "business"]
+  enabled: true
+
+- name: "Fertilizer Supply Crisis"
+  type: keyword
+  keywords:
+    - "fertilizer shortage"
+    - "urea price"
+    - "ammonia price"
+    - "sulfur shortage"
+    - "fertilizer crisis"
+    - "planting season"
+    - "crop yield decline"
+    - "CF Industries"
+    - "Nutrien"
+    - "food security"
+    - "fertilizer export ban"
+  context_prompt: ~
+  urgency: medium
+  severity_threshold: 5
+  cooldown_minutes: 120
+  categories: ["business"]
+  enabled: true
+
+# --- European Defence ---
+
+- name: "EU Defence Budget & Contracts"
+  type: keyword
+  keywords:
+    - "Rheinmetall contract"
+    - "Rheinmetall order"
+    - "Hensoldt contract"
+    - "Hensoldt order"
+    - "Hensoldt radar"
+    - "Renk contract"
+    - "TKMS contract"
+    - "TKMS submarine"
+    - "european defence budget"
+    - "european defense budget"
+    - "nato spending"
+    - "bundeswehr order"
+    - "eu defence fund"
+    - "european rearmament"
+    - "defence procurement europe"
+    - "Sondervermögen"
+  context_prompt: ~
+  urgency: low
+  severity_threshold: 5
+  cooldown_minutes: 180
+  categories: ["politics", "business"]
+  enabled: true
+
+- name: "Defence Threat — Peace or Budget Cuts"
+  type: ai
+  keywords:
+    - "ukraine ceasefire"
+    - "ukraine peace"
+    - "russia peace deal"
+    - "russia ceasefire"
+    - "minsk agreement"
+    - "nato dissolve"
+    - "defence budget cut"
+    - "defense budget cut"
+    - "peace dividend"
+    - "european defence cut"
+    - "nato withdrawal"
+    - "us troops withdraw europe"
+  context_prompt: >
+    I hold a concentrated European defence portfolio: Rheinmetall, Hensoldt, Renk,
+    TKMS, and a NATO Defence ETF — together ~35% of my total portfolio. A credible
+    peace deal in Ukraine or significant NATO budget cuts would trigger a sharp
+    correction in these positions (-15 to -25%). Rate severity HIGH for signed
+    agreements, formal ceasefire announcements, or confirmed budget reduction votes.
+    Rate LOW for diplomatic rhetoric without concrete outcomes. Note: a frozen conflict
+    (no peace, no escalation) is actually neutral-to-positive for defence stocks.
+  urgency: high
+  severity_threshold: 5
+  cooldown_minutes: 30
+  categories: ["politics"]
+  enabled: true
+
+- name: "Drone & Autonomous Warfare"
+  type: keyword
+  keywords:
+    - "drone warfare"
+    - "autonomous weapons"
+    - "drone swarm"
+    - "FPV drone"
+    - "loitering munition"
+    - "Switchblade"
+    - "drone production"
+    - "counter-drone"
+    - "electronic warfare"
+    - "drone regulation"
+    - "drone ban"
+    - "Swarmer"
+    - "AeroVironment"
+  context_prompt: ~
+  urgency: low
+  severity_threshold: 5
+  cooldown_minutes: 180
+  categories: ["politics", "tech"]
+  enabled: true
+
+# --- China EV / BYD ---
+
+- name: "BYD & China EV"
+  type: ai
+  keywords:
+    - "BYD"
+    - "BYD europe"
+    - "BYD sales"
+    - "BYD recall"
+    - "BYD battery"
+    - "china ev tariff"
+    - "eu china electric"
+    - "china ev ban"
+    - "china ev export"
+    - "CATL"
+    - "china battery"
+    - "ev price war"
+  context_prompt: >
+    I hold BYD stock as ~8% of my portfolio, betting on China's dominance in EV
+    and battery tech. Positive catalysts: sales records, new battery breakthroughs,
+    EU market share gains, new factory openings. Negative catalysts: EU tariff
+    escalation beyond current minimum price agreement, major recalls, Taiwan
+    crisis affecting sentiment, China export restrictions. Rate severity based on
+    direct financial impact to BYD's revenue or market access.
+  urgency: medium
+  severity_threshold: 5
+  cooldown_minutes: 120
+  categories: ["business", "tech"]
+  enabled: true
+
+- name: "China Geopolitical Risk"
+  type: ai
+  keywords:
+    - "taiwan crisis"
+    - "taiwan invasion"
+    - "china sanctions"
+    - "china trade war"
+    - "china decoupling"
+    - "china military"
+    - "south china sea"
+    - "china embargo"
+    - "xi jinping"
+  context_prompt: >
+    I hold BYD stock and a China EV position. A serious China-West confrontation
+    (Taiwan, trade war escalation, sanctions) would devastate Chinese stocks
+    regardless of fundamentals. Rate severity HIGH only for military action, formal
+    sanctions packages, or investment bans. Rate LOW for diplomatic tensions and
+    rhetoric. The EU-China minimum price agreement on EVs (Jan 2026) is the current
+    baseline — any reversal to full tariffs would be medium severity.
+  urgency: high
+  severity_threshold: 7
+  cooldown_minutes: 30
+  categories: ["politics"]
+  enabled: true
+
+# --- Gold & Macro ---
+
+- name: "Gold Significant Move"
+  type: keyword
+  keywords:
+    - "gold crash"
+    - "gold surge"
+    - "gold record"
+    - "gold all-time"
+    - "central bank gold"
+    - "gold reserve"
+    - "fed rate hike"
+    - "fed rate cut"
+    - "ecb rate"
+    - "gold $5000"
+    - "gold $4000"
+    - "gold $3000"
+    - "de-dollarization"
+  context_prompt: ~
+  urgency: medium
+  severity_threshold: 5
+  cooldown_minutes: 120
+  categories: ["business"]
+  enabled: true
+
+- name: "European Recession Signal"
+  type: ai
+  keywords:
+    - "europe recession"
+    - "eurozone recession"
+    - "ecb emergency"
+    - "european gdp contract"
+    - "eurozone downturn"
+    - "european stagflation"
+    - "germany recession"
+    - "eu industrial output"
+    - "european unemployment"
+    - "energy rationing europe"
+  context_prompt: >
+    I hold 15% in MSCI Europe ETF and ~35% in European defence stocks. A European
+    recession would hurt the MSCI Europe position directly, but defence stocks are
+    partially immune because budgets are politically fixed. However, a severe recession
+    could eventually force budget cuts even in defence. Rate severity based on whether
+    this is a data point (quarterly GDP miss = medium) or a structural shift
+    (energy rationing, industrial collapse = high).
+  urgency: medium
+  severity_threshold: 6
+  cooldown_minutes: 120
+  categories: ["business", "politics"]
+  enabled: true
+
+# --- Portfolio-Specific Positions ---
+
+- name: "K+S Specific Risk"
+  type: ai
+  keywords:
+    - "K+S"
+    - "K+S AG"
+    - "potash price"
+    - "belarus potash"
+    - "belarus sanctions"
+    - "belarus fertilizer"
+    - "Uralkali"
+    - "Belaruskali"
+  context_prompt: >
+    I hold K+S AG (3% of portfolio). The biggest risk is lifting of Belarus potash
+    sanctions — Belarus is one of the world's largest potash exporters, and their
+    return to the market would flood supply and crush K+S margins. Rate severity
+    HIGH for confirmed sanction relief or waivers. Also rate HIGH for any major
+    potash price collapse (>15% in a week). Rate LOW for diplomatic noise about
+    Belarus without concrete action.
+  urgency: high
+  severity_threshold: 5
+  cooldown_minutes: 60
+  categories: ["business", "politics"]
+  enabled: true
+
+- name: "CF Industries Risk"
+  type: ai
+  keywords:
+    - "CF Industries"
+    - "CF earnings"
+    - "nitrogen price crash"
+    - "ammonia price drop"
+    - "DOJ fertilizer"
+    - "fertilizer antitrust"
+    - "fertilizer price fixing"
+  context_prompt: >
+    I hold CF Industries (6% of portfolio). Key risks: DOJ antitrust investigation
+    into fertilizer price-fixing (ongoing), sudden Hormuz reopening collapsing
+    the scarcity premium, or a major earnings miss. Rate severity HIGH for DOJ
+    charges filed, settlement announcements, or Hormuz reopening confirmation.
+    Rate LOW for routine analyst downgrades or minor price fluctuations.
+  urgency: high
+  severity_threshold: 6
+  cooldown_minutes: 60
+  categories: ["business"]
+  enabled: true
+
+- name: "Rheinmetall Earnings & Guidance"
+  type: keyword
+  keywords:
+    - "Rheinmetall earnings"
+    - "Rheinmetall guidance"
+    - "Rheinmetall revenue"
+    - "Rheinmetall profit"
+    - "Rheinmetall forecast"
+    - "Rheinmetall downgrade"
+    - "Rheinmetall upgrade"
+    - "Rheinmetall acquisition"
+    - "Rheinmetall backlog"
+  context_prompt: ~
+  urgency: medium
+  severity_threshold: 5
+  cooldown_minutes: 60
+  categories: ["business"]
+  enabled: true
+
+# --- Meta / Systemic ---
+
+- name: "Trump Policy Shift"
+  type: ai
+  keywords:
+    - "trump nato"
+    - "trump europe"
+    - "trump tariff europe"
+    - "trump iran"
+    - "trump hormuz"
+    - "trump defence"
+    - "trump defense"
+    - "trump ceasefire"
+    - "trump executive order"
+    - "trump sanctions"
+  context_prompt: >
+    My entire portfolio is built on geopolitical theses that are sensitive to US
+    policy shifts. Trump's actions (not words) are the primary signal. Rate severity
+    based on ACTIONS: executive orders, troop movements, signed deals, confirmed
+    policy changes. Rate LOW for tweets, press conferences, or rhetoric without
+    follow-through. Key scenarios: Trump withdrawing from Iran = Hormuz stays closed
+    (positive for my portfolio). Trump forcing NATO allies to pay = Europe rearms
+    faster (positive). Trump making a deal with Russia on Ukraine = defence stocks
+    at risk (negative).
+  urgency: high
+  severity_threshold: 6
+  cooldown_minutes: 60
+  categories: ["politics"]
+  enabled: true
+
+- name: "Black Swan / Market Crash"
+  type: keyword
+  keywords:
+    - "market crash"
+    - "stock market crash"
+    - "circuit breaker"
+    - "trading halt"
+    - "flash crash"
+    - "lehman moment"
+    - "systemic risk"
+    - "banking crisis"
+    - "sovereign default"
+    - "nuclear"
+    - "world war"
+  context_prompt: ~
+  urgency: high
+  severity_threshold: 5
+  cooldown_minutes: 15
+  categories: []
+  enabled: true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,7 +19,7 @@ parameters:
         - src
         - tests
     excludePaths:
-        - config/reference.php
+        - config/reference.php (?)
         - config/preload.php
         - ecs.php
     ignoreErrors:

--- a/src/Notification/Command/LoadAlertRulesCommand.php
+++ b/src/Notification/Command/LoadAlertRulesCommand.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Command;
+
+use App\Notification\Dto\AlertRuleFixture;
+use App\Notification\Entity\AlertRule;
+use App\Notification\Service\AlertRuleFixtureLoaderInterface;
+use App\User\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:load-alert-rules',
+    description: 'Load alert rules from a YAML fixture file or directory',
+)]
+final class LoadAlertRulesCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ClockInterface $clock,
+        private readonly AlertRuleFixtureLoaderInterface $fixtureLoader,
+        private readonly string $adminEmail,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('path', InputArgument::REQUIRED, 'Path to YAML file or directory');
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Preview changes without persisting');
+        $this->addOption('purge', null, InputOption::VALUE_NONE, 'Remove rules not present in the fixture');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        /** @var string $path */
+        $path = $input->getArgument('path');
+        $dryRun = (bool) $input->getOption('dry-run');
+        $purge = (bool) $input->getOption('purge');
+
+        $user = $this->findAdminUser($io);
+
+        if (! $user instanceof User) {
+            return Command::FAILURE;
+        }
+
+        $fixtures = $this->fixtureLoader->loadFromPath($path);
+        $stats = $this->upsertRules($io, $fixtures, $user);
+
+        if ($purge) {
+            $stats['purged'] = $this->purgeAbsentRules($io, $fixtures, $user);
+        }
+
+        $this->finalize($io, $stats, $dryRun);
+
+        return Command::SUCCESS;
+    }
+
+    private function findAdminUser(SymfonyStyle $io): ?User
+    {
+        /** @var User|null $user */
+        $user = $this->entityManager->getRepository(User::class)->findOneBy([
+            'email' => $this->adminEmail,
+        ]);
+
+        if (! $user instanceof User) {
+            $io->error(sprintf('Admin user "%s" not found.', $this->adminEmail));
+        }
+
+        return $user;
+    }
+
+    /**
+     * @param list<AlertRuleFixture> $fixtures
+     *
+     * @return array{created: int, updated: int, purged: int}
+     */
+    private function upsertRules(SymfonyStyle $io, array $fixtures, User $user): array
+    {
+        $stats = [
+            'created' => 0,
+            'updated' => 0,
+            'purged' => 0,
+        ];
+        $repository = $this->entityManager->getRepository(AlertRule::class);
+
+        foreach ($fixtures as $fixture) {
+            /** @var AlertRule|null $existing */
+            $existing = $repository->findOneBy([
+                'name' => $fixture->name,
+                'user' => $user,
+            ]);
+
+            if ($existing instanceof AlertRule) {
+                $this->updateRule($existing, $fixture);
+                $io->text(sprintf('  Updated: %s', $fixture->name));
+                ++$stats['updated'];
+            } else {
+                $this->createRule($fixture, $user);
+                $io->text(sprintf('  Created: %s', $fixture->name));
+                ++$stats['created'];
+            }
+        }
+
+        return $stats;
+    }
+
+    private function updateRule(AlertRule $rule, AlertRuleFixture $fixture): void
+    {
+        $rule->setKeywords($fixture->keywords);
+        $rule->setContextPrompt($fixture->contextPrompt);
+        $rule->setUrgency($fixture->urgency);
+        $rule->setSeverityThreshold($fixture->severityThreshold);
+        $rule->setCooldownMinutes($fixture->cooldownMinutes);
+        $rule->setCategories($fixture->categories);
+        $rule->setEnabled($fixture->enabled);
+        $rule->setUpdatedAt($this->clock->now());
+    }
+
+    private function createRule(AlertRuleFixture $fixture, User $user): void
+    {
+        $rule = new AlertRule($fixture->name, $fixture->type, $user, $this->clock->now());
+        $rule->setKeywords($fixture->keywords);
+        $rule->setContextPrompt($fixture->contextPrompt);
+        $rule->setUrgency($fixture->urgency);
+        $rule->setSeverityThreshold($fixture->severityThreshold);
+        $rule->setCooldownMinutes($fixture->cooldownMinutes);
+        $rule->setCategories($fixture->categories);
+        $rule->setEnabled($fixture->enabled);
+        $this->entityManager->persist($rule);
+    }
+
+    /**
+     * @param list<AlertRuleFixture> $fixtures
+     */
+    private function purgeAbsentRules(SymfonyStyle $io, array $fixtures, User $user): int
+    {
+        $fixtureNames = array_map(static fn (AlertRuleFixture $f): string => $f->name, $fixtures);
+        /** @var list<AlertRule> $existingRules */
+        $existingRules = $this->entityManager->getRepository(AlertRule::class)->findBy([
+            'user' => $user,
+        ]);
+        $purged = 0;
+
+        foreach ($existingRules as $rule) {
+            if (! in_array($rule->getName(), $fixtureNames, true)) {
+                $io->text(sprintf('  Purged: %s', $rule->getName()));
+                $this->entityManager->remove($rule);
+                ++$purged;
+            }
+        }
+
+        return $purged;
+    }
+
+    /**
+     * @param array{created: int, updated: int, purged: int} $stats
+     */
+    private function finalize(SymfonyStyle $io, array $stats, bool $dryRun): void
+    {
+        if ($dryRun) {
+            $io->warning(sprintf(
+                'Dry run: %d to create, %d to update, %d to purge. No changes persisted.',
+                $stats['created'],
+                $stats['updated'],
+                $stats['purged'],
+            ));
+
+            return;
+        }
+
+        $this->entityManager->flush();
+        $io->success(sprintf(
+            'Done: %d created, %d updated, %d purged.',
+            $stats['created'],
+            $stats['updated'],
+            $stats['purged'],
+        ));
+    }
+}

--- a/src/Notification/Dto/AlertRuleFixture.php
+++ b/src/Notification/Dto/AlertRuleFixture.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Dto;
+
+use App\Notification\ValueObject\AlertRuleType;
+use App\Notification\ValueObject\AlertUrgency;
+
+final readonly class AlertRuleFixture
+{
+    /**
+     * @param list<string> $keywords
+     * @param list<string> $categories
+     */
+    public function __construct(
+        public string $name,
+        public AlertRuleType $type,
+        public array $keywords,
+        public ?string $contextPrompt,
+        public AlertUrgency $urgency,
+        public int $severityThreshold,
+        public int $cooldownMinutes,
+        public array $categories,
+        public bool $enabled,
+    ) {
+    }
+}

--- a/src/Notification/Service/AlertRuleFixtureLoader.php
+++ b/src/Notification/Service/AlertRuleFixtureLoader.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Service;
+
+use App\Notification\Dto\AlertRuleFixture;
+use App\Notification\ValueObject\AlertRuleType;
+use App\Notification\ValueObject\AlertUrgency;
+use Symfony\Component\Yaml\Yaml;
+
+final class AlertRuleFixtureLoader implements AlertRuleFixtureLoaderInterface
+{
+    /**
+     * @return list<AlertRuleFixture>
+     */
+    public function loadFromPath(string $path): array
+    {
+        if (is_dir($path)) {
+            return $this->loadFromDirectory($path);
+        }
+
+        return $this->loadFromFile($path);
+    }
+
+    /**
+     * @return list<AlertRuleFixture>
+     */
+    private function loadFromDirectory(string $directory): array
+    {
+        $fixtures = [];
+        $globResult = glob($directory . '/*.yaml');
+        $files = is_array($globResult) ? $globResult : [];
+        sort($files);
+
+        foreach ($files as $file) {
+            $fixtures = [...$fixtures, ...$this->loadFromFile($file)];
+        }
+
+        return $fixtures;
+    }
+
+    /**
+     * @return list<AlertRuleFixture>
+     */
+    private function loadFromFile(string $file): array
+    {
+        if (! is_file($file) || ! is_readable($file)) {
+            throw new \InvalidArgumentException(sprintf('File "%s" does not exist or is not readable.', $file));
+        }
+
+        $data = Yaml::parseFile($file);
+
+        if (! is_array($data)) {
+            throw new \InvalidArgumentException(sprintf('File "%s" does not contain a valid YAML list.', $file));
+        }
+
+        /** @var list<array<string, mixed>> $data */
+        return array_map($this->parseEntry(...), $data);
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     */
+    private function parseEntry(array $entry): AlertRuleFixture
+    {
+        $name = is_string($entry['name'] ?? null) ? $entry['name'] : '';
+        $type = is_string($entry['type'] ?? null) ? $entry['type'] : 'keyword';
+        $urgency = is_string($entry['urgency'] ?? null) ? $entry['urgency'] : 'medium';
+        $prompt = is_string($entry['context_prompt'] ?? null) ? $entry['context_prompt'] : null;
+        $threshold = is_int($entry['severity_threshold'] ?? null) ? $entry['severity_threshold'] : 5;
+        $cooldown = is_int($entry['cooldown_minutes'] ?? null) ? $entry['cooldown_minutes'] : 60;
+
+        /** @var list<string> $keywords */
+        $keywords = $entry['keywords'] ?? [];
+        /** @var list<string> $categories */
+        $categories = $entry['categories'] ?? [];
+
+        return new AlertRuleFixture(
+            name: $name,
+            type: AlertRuleType::from($type),
+            keywords: $keywords,
+            contextPrompt: $prompt,
+            urgency: AlertUrgency::from($urgency),
+            severityThreshold: $threshold,
+            cooldownMinutes: $cooldown,
+            categories: $categories,
+            enabled: (bool) ($entry['enabled'] ?? true),
+        );
+    }
+}

--- a/src/Notification/Service/AlertRuleFixtureLoaderInterface.php
+++ b/src/Notification/Service/AlertRuleFixtureLoaderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Service;
+
+use App\Notification\Dto\AlertRuleFixture;
+
+interface AlertRuleFixtureLoaderInterface
+{
+    /**
+     * @return list<AlertRuleFixture>
+     */
+    public function loadFromPath(string $path): array;
+}

--- a/tests/Unit/Notification/Command/LoadAlertRulesCommandTest.php
+++ b/tests/Unit/Notification/Command/LoadAlertRulesCommandTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification\Command;
+
+use App\Notification\Command\LoadAlertRulesCommand;
+use App\Notification\Dto\AlertRuleFixture;
+use App\Notification\Entity\AlertRule;
+use App\Notification\Service\AlertRuleFixtureLoaderInterface;
+use App\Notification\ValueObject\AlertRuleType;
+use App\Notification\ValueObject\AlertUrgency;
+use App\User\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(LoadAlertRulesCommand::class)]
+#[UsesClass(AlertRuleFixture::class)]
+#[UsesClass(AlertRule::class)]
+final class LoadAlertRulesCommandTest extends TestCase
+{
+    private MockObject&EntityManagerInterface $em;
+
+    private MockObject&AlertRuleFixtureLoaderInterface $loader;
+
+    private CommandTester $tester;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->loader = $this->createMock(AlertRuleFixtureLoaderInterface::class);
+
+        $command = new LoadAlertRulesCommand(
+            $this->em,
+            new MockClock('2026-04-05 10:00:00'),
+            $this->loader,
+            'admin@test.com',
+        );
+
+        $this->tester = new CommandTester($command);
+    }
+
+    public function testCreatesNewRules(): void
+    {
+        $this->stubNoExistingRules();
+        $this->loader->method('loadFromPath')->willReturn([$this->fixture('Rule A')]);
+
+        $this->em->expects(self::once())->method('persist');
+        $this->em->expects(self::once())->method('flush');
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+        ]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertStringContainsString('Created: Rule A', $this->tester->getDisplay());
+        self::assertStringContainsString('1 created', $this->tester->getDisplay());
+    }
+
+    public function testUpdatesExistingRules(): void
+    {
+        $user = new User('admin@test.com', 'hashed');
+        $existingRule = new AlertRule('Rule A', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
+
+        $this->stubExistingRules($existingRule, $user);
+        $this->loader->method('loadFromPath')->willReturn([$this->fixture('Rule A')]);
+
+        $this->em->expects(self::never())->method('persist');
+        $this->em->expects(self::once())->method('flush');
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+        ]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertStringContainsString('Updated: Rule A', $this->tester->getDisplay());
+        self::assertStringContainsString('1 updated', $this->tester->getDisplay());
+    }
+
+    public function testDryRunDoesNotFlush(): void
+    {
+        $this->stubNoExistingRules();
+        $this->loader->method('loadFromPath')->willReturn([$this->fixture('Rule A')]);
+
+        $this->em->expects(self::never())->method('flush');
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+            '--dry-run' => true,
+        ]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertStringContainsString('Dry run', $this->tester->getDisplay());
+    }
+
+    public function testPurgeRemovesAbsentRules(): void
+    {
+        $user = new User('admin@test.com', 'hashed');
+        $orphanRule = new AlertRule('Orphan', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
+
+        $this->stubExistingRulesForPurge($orphanRule, $user);
+        $this->loader->method('loadFromPath')->willReturn([$this->fixture('Rule A')]);
+
+        $this->em->expects(self::once())->method('remove')->with($orphanRule);
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+            '--purge' => true,
+        ]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertStringContainsString('Purged: Orphan', $this->tester->getDisplay());
+    }
+
+    public function testFailsWhenAdminNotFound(): void
+    {
+        $repo = $this->createStub(EntityRepository::class);
+        $repo->method('findOneBy')->willReturn(null);
+        $this->em->method('getRepository')->willReturn($repo);
+
+        $this->loader->method('loadFromPath')->willReturn([]);
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+        ]);
+
+        self::assertSame(1, $this->tester->getStatusCode());
+        self::assertStringContainsString('not found', $this->tester->getDisplay());
+    }
+
+    private function fixture(string $name): AlertRuleFixture
+    {
+        return new AlertRuleFixture(
+            name: $name,
+            type: AlertRuleType::Keyword,
+            keywords: ['test'],
+            contextPrompt: null,
+            urgency: AlertUrgency::Medium,
+            severityThreshold: 5,
+            cooldownMinutes: 60,
+            categories: [],
+            enabled: true,
+        );
+    }
+
+    private function stubNoExistingRules(): void
+    {
+        $ruleRepo = $this->createStub(EntityRepository::class);
+        $ruleRepo->method('findOneBy')->willReturn(null);
+        $ruleRepo->method('findBy')->willReturn([]);
+
+        $userRepo = $this->createStub(EntityRepository::class);
+        $userRepo->method('findOneBy')->willReturn(new User('admin@test.com', 'hashed'));
+
+        $this->em->method('getRepository')->willReturnCallback(
+            static fn (string $class): Stub => $class === User::class ? $userRepo : $ruleRepo,
+        );
+    }
+
+    private function stubExistingRules(AlertRule $rule, User $user): void
+    {
+        $ruleRepo = $this->createStub(EntityRepository::class);
+        $ruleRepo->method('findOneBy')->willReturn($rule);
+        $ruleRepo->method('findBy')->willReturn([$rule]);
+
+        $userRepo = $this->createStub(EntityRepository::class);
+        $userRepo->method('findOneBy')->willReturn($user);
+
+        $this->em->method('getRepository')->willReturnCallback(
+            static fn (string $class): Stub => $class === User::class ? $userRepo : $ruleRepo,
+        );
+    }
+
+    private function stubExistingRulesForPurge(AlertRule $orphanRule, User $user): void
+    {
+        $ruleRepo = $this->createStub(EntityRepository::class);
+        $ruleRepo->method('findOneBy')->willReturn(null);
+        $ruleRepo->method('findBy')->willReturn([$orphanRule]);
+
+        $userRepo = $this->createStub(EntityRepository::class);
+        $userRepo->method('findOneBy')->willReturn($user);
+
+        $this->em->method('getRepository')->willReturnCallback(
+            static fn (string $class): Stub => $class === User::class ? $userRepo : $ruleRepo,
+        );
+    }
+}

--- a/tests/Unit/Notification/Service/AlertRuleFixtureLoaderTest.php
+++ b/tests/Unit/Notification/Service/AlertRuleFixtureLoaderTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification\Service;
+
+use App\Notification\Dto\AlertRuleFixture;
+use App\Notification\Service\AlertRuleFixtureLoader;
+use App\Notification\ValueObject\AlertRuleType;
+use App\Notification\ValueObject\AlertUrgency;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+#[CoversClass(AlertRuleFixtureLoader::class)]
+#[UsesClass(AlertRuleFixture::class)]
+final class AlertRuleFixtureLoaderTest extends TestCase
+{
+    private AlertRuleFixtureLoader $loader;
+
+    protected function setUp(): void
+    {
+        $this->loader = new AlertRuleFixtureLoader();
+    }
+
+    public function testLoadFromFileParsesYaml(): void
+    {
+        $file = $this->createTempFixture([
+            [
+                'name' => 'Test Rule',
+                'type' => 'keyword',
+                'keywords' => ['foo'],
+                'urgency' => 'high',
+                'severity_threshold' => 7,
+                'cooldown_minutes' => 30,
+                'categories' => ['tech'],
+                'enabled' => true,
+            ],
+        ]);
+
+        $fixtures = $this->loader->loadFromPath($file);
+
+        self::assertCount(1, $fixtures);
+        self::assertSame('Test Rule', $fixtures[0]->name);
+        self::assertSame(AlertRuleType::Keyword, $fixtures[0]->type);
+        self::assertSame(['foo'], $fixtures[0]->keywords);
+        self::assertNull($fixtures[0]->contextPrompt);
+        self::assertSame(AlertUrgency::High, $fixtures[0]->urgency);
+        self::assertSame(7, $fixtures[0]->severityThreshold);
+        self::assertSame(30, $fixtures[0]->cooldownMinutes);
+        self::assertSame(['tech'], $fixtures[0]->categories);
+        self::assertTrue($fixtures[0]->enabled);
+    }
+
+    public function testLoadFromFileWithContextPrompt(): void
+    {
+        $file = $this->createTempFixture([
+            [
+                'name' => 'AI Rule',
+                'type' => 'ai',
+                'keywords' => ['bar'],
+                'context_prompt' => 'Evaluate this.',
+                'urgency' => 'medium',
+                'severity_threshold' => 5,
+                'cooldown_minutes' => 60,
+                'categories' => [],
+                'enabled' => false,
+            ],
+        ]);
+
+        $fixtures = $this->loader->loadFromPath($file);
+
+        self::assertCount(1, $fixtures);
+        self::assertSame(AlertRuleType::Ai, $fixtures[0]->type);
+        self::assertSame('Evaluate this.', $fixtures[0]->contextPrompt);
+        self::assertFalse($fixtures[0]->enabled);
+    }
+
+    public function testLoadFromDirectoryMergesFiles(): void
+    {
+        $dir = sys_get_temp_dir() . '/alert_fixtures_' . bin2hex(random_bytes(4));
+        mkdir($dir);
+
+        $this->writeYaml($dir . '/a.yaml', [
+            [
+                'name' => 'Rule A',
+                'type' => 'keyword',
+                'keywords' => ['a'],
+            ],
+        ]);
+        $this->writeYaml($dir . '/b.yaml', [
+            [
+                'name' => 'Rule B',
+                'type' => 'ai',
+                'keywords' => ['b'],
+            ],
+        ]);
+
+        $fixtures = $this->loader->loadFromPath($dir);
+
+        self::assertCount(2, $fixtures);
+        self::assertSame('Rule A', $fixtures[0]->name);
+        self::assertSame('Rule B', $fixtures[1]->name);
+
+        unlink($dir . '/a.yaml');
+        unlink($dir . '/b.yaml');
+        rmdir($dir);
+    }
+
+    public function testLoadFromNonExistentFileThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/does not exist/');
+
+        $this->loader->loadFromPath('/nonexistent/file.yaml');
+    }
+
+    public function testLoadAppliesDefaults(): void
+    {
+        $file = $this->createTempFixture([
+            [
+                'name' => 'Minimal',
+                'type' => 'keyword',
+                'keywords' => ['test'],
+            ],
+        ]);
+
+        $fixtures = $this->loader->loadFromPath($file);
+
+        self::assertSame(AlertUrgency::Medium, $fixtures[0]->urgency);
+        self::assertSame(5, $fixtures[0]->severityThreshold);
+        self::assertSame(60, $fixtures[0]->cooldownMinutes);
+        self::assertSame([], $fixtures[0]->categories);
+        self::assertTrue($fixtures[0]->enabled);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $data
+     */
+    private function createTempFixture(array $data): string
+    {
+        $file = tempnam(sys_get_temp_dir(), 'alert_fixture_') . '.yaml';
+        $this->writeYaml($file, $data);
+
+        return $file;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $data
+     */
+    private function writeYaml(string $path, array $data): void
+    {
+        file_put_contents($path, Yaml::dump($data, 4));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `app:load-alert-rules` command that upserts alert rules from YAML fixture files, with `--dry-run` preview and `--purge` to remove stale rules
- Convert `portfolio_alert_rules.md` into a proper YAML fixture at `fixtures/alert-rules/portfolio.yaml` (15 rules)
- Add `AlertRuleFixtureLoader` service (interface-first) for parsing YAML files/directories into `AlertRuleFixture` DTOs
- Wire `$adminEmail` from `ADMIN_EMAIL` env var in `services.php` for admin user lookup
- Fix pre-existing PHPStan excludePath error for optional `config/reference.php`

## Test plan

- [x] Unit tests for `LoadAlertRulesCommand` (create, update, dry-run, purge, admin-not-found)
- [x] Unit tests for `AlertRuleFixtureLoader` (parse YAML, context prompts, directory merge, defaults, missing file)
- [x] `make quality` passes (ECS + PHPStan level max + Rector)
- [x] `make test-unit` passes (105 tests, 278 assertions)
- [ ] Manual: `make sh` then `bin/console app:load-alert-rules fixtures/alert-rules/portfolio.yaml --dry-run`
- [ ] Manual: `bin/console app:load-alert-rules fixtures/alert-rules/portfolio.yaml` (creates 15 rules)
- [ ] Manual: `bin/console app:load-alert-rules fixtures/alert-rules/portfolio.yaml --purge` (idempotent re-run)

Closes #25

Generated with [Claude Code](https://claude.com/claude-code)