### PR TITLE
Auto-reindex search on article persist (#29)

### DIFF
--- a/src/Shared/Scheduler/MaintenanceScheduleProvider.php
+++ b/src/Shared/Scheduler/MaintenanceScheduleProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Scheduler;
+
+use Symfony\Component\Console\Messenger\RunCommandMessage;
+use Symfony\Component\Scheduler\Attribute\AsSchedule;
+use Symfony\Component\Scheduler\RecurringMessage;
+use Symfony\Component\Scheduler\Schedule;
+use Symfony\Component\Scheduler\ScheduleProviderInterface;
+
+#[AsSchedule('maintenance')]
+final class MaintenanceScheduleProvider implements ScheduleProviderInterface
+{
+    public function getSchedule(): Schedule
+    {
+        $schedule = new Schedule();
+
+        $schedule->add(
+            RecurringMessage::every('1 day', new RunCommandMessage('app:search-reindex')),
+        );
+
+        $schedule->add(
+            RecurringMessage::every('1 day', new RunCommandMessage('app:cleanup')),
+        );
+
+        return $schedule;
+    }
+}

--- a/src/Shared/Search/EventListener/ArticleIndexListener.php
+++ b/src/Shared/Search/EventListener/ArticleIndexListener.php
@@ -8,23 +8,56 @@ use App\Article\Entity\Article;
 use App\Shared\Search\Service\ArticleSearchServiceInterface;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\ORM\Events;
+use Psr\Log\LoggerInterface;
 
 #[AsEntityListener(event: Events::postPersist, entity: Article::class)]
 #[AsEntityListener(event: Events::postUpdate, entity: Article::class)]
+#[AsEntityListener(event: Events::preRemove, entity: Article::class)]
 final readonly class ArticleIndexListener
 {
     public function __construct(
         private ArticleSearchServiceInterface $searchService,
+        private LoggerInterface $logger,
     ) {
     }
 
     public function postPersist(Article $article): void
     {
-        $this->searchService->index($article);
+        $this->indexSafely($article, 'postPersist');
     }
 
     public function postUpdate(Article $article): void
     {
-        $this->searchService->index($article);
+        $this->indexSafely($article, 'postUpdate');
+    }
+
+    public function preRemove(Article $article): void
+    {
+        $id = $article->getId();
+        if ($id === null) {
+            return;
+        }
+
+        try {
+            $this->searchService->remove($id);
+        } catch (\Throwable $e) {
+            $this->logger->warning('Search de-index failed for article {id}: {error}', [
+                'id' => $id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function indexSafely(Article $article, string $event): void
+    {
+        try {
+            $this->searchService->index($article);
+        } catch (\Throwable $e) {
+            $this->logger->warning('Search index failed during {event} for article "{title}": {error}', [
+                'event' => $event,
+                'title' => $article->getTitle(),
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 }

--- a/tests/Unit/Shared/Scheduler/MaintenanceScheduleProviderTest.php
+++ b/tests/Unit/Shared/Scheduler/MaintenanceScheduleProviderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Scheduler;
+
+use App\Shared\Scheduler\MaintenanceScheduleProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Messenger\RunCommandMessage;
+use Symfony\Component\Scheduler\Generator\MessageContext;
+use Symfony\Component\Scheduler\RecurringMessage;
+use Symfony\Component\Scheduler\Trigger\PeriodicalTrigger;
+
+#[CoversClass(MaintenanceScheduleProvider::class)]
+final class MaintenanceScheduleProviderTest extends TestCase
+{
+    public function testScheduleContainsTwoRecurringMessages(): void
+    {
+        $provider = new MaintenanceScheduleProvider();
+        $schedule = $provider->getSchedule();
+
+        self::assertCount(2, $schedule->getRecurringMessages());
+    }
+
+    public function testScheduleIncludesSearchReindexAndCleanup(): void
+    {
+        $provider = new MaintenanceScheduleProvider();
+        $schedule = $provider->getSchedule();
+
+        $commands = $this->extractCommandInputs($schedule->getRecurringMessages());
+
+        self::assertContains('app:search-reindex', $commands);
+        self::assertContains('app:cleanup', $commands);
+    }
+
+    /**
+     * @param array<RecurringMessage> $recurringMessages
+     *
+     * @return list<string>
+     */
+    private function extractCommandInputs(array $recurringMessages): array
+    {
+        $context = new MessageContext(
+            'test',
+            'test-id',
+            new PeriodicalTrigger('1 day'),
+            new \DateTimeImmutable(),
+        );
+
+        $commands = [];
+        foreach ($recurringMessages as $recurring) {
+            foreach ($recurring->getMessages($context) as $message) {
+                if ($message instanceof RunCommandMessage) {
+                    $commands[] = $message->input;
+                }
+            }
+        }
+
+        return $commands;
+    }
+}

--- a/tests/Unit/Shared/Search/EventListener/ArticleIndexListenerTest.php
+++ b/tests/Unit/Shared/Search/EventListener/ArticleIndexListenerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Search\EventListener;
+
+use App\Article\Entity\Article;
+use App\Shared\Entity\Category;
+use App\Shared\Search\EventListener\ArticleIndexListener;
+use App\Shared\Search\Service\ArticleSearchServiceInterface;
+use App\Source\Entity\Source;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+#[CoversClass(ArticleIndexListener::class)]
+final class ArticleIndexListenerTest extends TestCase
+{
+    public function testPostPersistIndexesArticle(): void
+    {
+        $article = $this->createArticle();
+
+        $searchService = $this->createMock(ArticleSearchServiceInterface::class);
+        $searchService->expects(self::once())
+            ->method('index')
+            ->with($article);
+
+        $listener = new ArticleIndexListener($searchService, new NullLogger());
+        $listener->postPersist($article);
+    }
+
+    public function testPostUpdateIndexesArticle(): void
+    {
+        $article = $this->createArticle();
+
+        $searchService = $this->createMock(ArticleSearchServiceInterface::class);
+        $searchService->expects(self::once())
+            ->method('index')
+            ->with($article);
+
+        $listener = new ArticleIndexListener($searchService, new NullLogger());
+        $listener->postUpdate($article);
+    }
+
+    public function testPreRemoveRemovesFromIndex(): void
+    {
+        $article = $this->createArticle(42);
+
+        $searchService = $this->createMock(ArticleSearchServiceInterface::class);
+        $searchService->expects(self::once())
+            ->method('remove')
+            ->with(42);
+
+        $listener = new ArticleIndexListener($searchService, new NullLogger());
+        $listener->preRemove($article);
+    }
+
+    public function testPreRemoveSkipsArticleWithoutId(): void
+    {
+        $article = $this->createArticle(null);
+
+        $searchService = $this->createMock(ArticleSearchServiceInterface::class);
+        $searchService->expects(self::never())
+            ->method('remove');
+
+        $listener = new ArticleIndexListener($searchService, new NullLogger());
+        $listener->preRemove($article);
+    }
+
+    public function testPostPersistLogsWarningOnFailure(): void
+    {
+        $article = $this->createArticle();
+
+        $searchService = $this->createStub(ArticleSearchServiceInterface::class);
+        $searchService->method('index')
+            ->willThrowException(new \RuntimeException('Index failed'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning');
+
+        $listener = new ArticleIndexListener($searchService, $logger);
+        $listener->postPersist($article);
+    }
+
+    public function testPreRemoveLogsWarningOnFailure(): void
+    {
+        $article = $this->createArticle(42);
+
+        $searchService = $this->createStub(ArticleSearchServiceInterface::class);
+        $searchService->method('remove')
+            ->willThrowException(new \RuntimeException('Remove failed'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning');
+
+        $listener = new ArticleIndexListener($searchService, $logger);
+        $listener->preRemove($article);
+    }
+
+    private function createArticle(?int $id = 1): Article
+    {
+        $category = new Category('Tech', 'tech', 10, '#3B82F6');
+        $source = new Source('Test Source', 'https://example.com/feed', $category, new \DateTimeImmutable());
+        $article = new Article('Test Article', 'https://example.com/1', $source, new \DateTimeImmutable());
+
+        if ($id !== null) {
+            $ref = new \ReflectionProperty(Article::class, 'id');
+            $ref->setValue($article, $id);
+        }
+
+        return $article;
+    }
+}


### PR DESCRIPTION
## Summary

- **Enhanced `ArticleIndexListener`**: Added `preRemove` handler to de-index articles when removed via ORM, wrapped all index/remove calls in try/catch with PSR logger to prevent search failures from breaking article persistence
- **Added `MaintenanceScheduleProvider`**: Daily scheduled `app:search-reindex` and `app:cleanup` as a safety net for any articles missed by the real-time listener
- **Full test coverage**: 8 unit tests covering all listener events, error resilience, and schedule provider configuration

Closes #29

## Test plan

- [x] PHPStan passes on all changed files (level max)
- [x] ECS passes on all changed files
- [x] Rector dry-run passes on all changed files
- [x] 8 new unit tests pass (ArticleIndexListenerTest + MaintenanceScheduleProviderTest)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)