### PR TITLE
Update docs for post-release features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Post-Release Features
+- Keyword extraction from articles — AI extracts key entities (people, orgs, places), displayed as badges, searchable (#21)
+- Inline search-as-you-type filter on dashboard — client-side article filtering with debounce (#22)
+- Article translation by source language — auto-translates German (and other) titles/summaries to English, preserves originals (#23)
+- Alert rule fixtures — YAML-based alert strategies loadable via `app:load-alert-rules` command with `--dry-run` and `--purge` (#25)
+- Auto-reindex search on article persist/update via Doctrine event listener (#29)
+- Maintenance scheduler — daily `app:search-reindex` + `app:cleanup` via `#[AsSchedule('maintenance')]`
+- Source and alert rule CRUD forms in the UI
+- CSRF protection on mark-all-read and delete forms
+- Search bar visible on all screen sizes (mobile hamburger menu + medium+ navbar)
+
+### Fixed
+- Auth switched from in-memory provider to entity provider — fixes mark-as-read, dashboard read state
+- Dashboard sort by publishedAt (not fetchedAt) to match displayed timestamps
+- Worker now consumes `scheduler_fetch` transport for automatic periodic feed fetching
+- TypeScript modules (theme toggle, timeago, mark-as-read) now loaded via app.js imports
+- CI builds TypeScript assets before functional tests
+- Untracked auto-generated `config/reference.php`
+
 #### Infrastructure & Scaffolding
 - Project scaffolding with dunglas/symfony-docker (FrankenPHP + Caddy)
 - Docker Compose setup with PostgreSQL 17, PgBouncer (transaction pooling), and Messenger worker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ make hooks       # Install git hooks
 ```
 src/
 ├── Article/         # Core: articles, scoring, deduplication, content fingerprinting
-├── Enrichment/      # Rule-based + AI categorization/summarization (decorator pattern)
+├── Enrichment/      # Rule-based + AI categorization/summarization/keywords/translation (decorator pattern)
 ├── Source/          # Feed management, fetching (laminas-feed), health tracking
 ├── Notification/    # Unified alert rules (keyword/AI/both) + Notifier dispatch
 ├── Digest/          # Periodic AI-generated editorial summaries
@@ -94,6 +94,7 @@ src/
     ├── Search/      # SEAL + Loupe full-text search (zero infrastructure)
     ├── Entity/      # Category (shared lookup)
     ├── ValueObject/ # EnrichmentMethod (cross-domain)
+    ├── Scheduler/   # MaintenanceScheduleProvider (daily reindex + cleanup)
     ├── Command/     # app:cleanup, app:search-reindex, app:check-sources, app:process-digests
     ├── Controller/  # DashboardController, HealthController
     └── Twig/        # Extensions, NavigationExtension
@@ -106,7 +107,11 @@ src/
 - **Rule-based fallback**: Always active — AI is an enhancement layer, not a dependency
 - **Quality gates**: `AiQualityGateService` — structured output validation, confidence >= 0.7, summary length heuristic
 - **Circuit breaker**: `ModelDiscoveryService` — 3 consecutive failures → 24h fallback to DB-persisted model list
+- **Keyword extraction**: AI extracts 3-5 entities per article (people, orgs, places), displayed as tags
+- **Translation**: Auto-translates non-English articles (originals preserved), configurable per source
+- **Alert fixtures**: YAML-based alert rule definitions, loadable via `app:load-alert-rules`
 - **Keyword-first**: Alert rules always run keyword matching first; AI evaluation only on keyword matches (~10-20 calls/day)
+- **Auto-reindex**: Doctrine listener indexes articles on persist/update; daily full reindex via maintenance scheduler
 - **Model stats**: `app:ai-stats` command shows model quality metrics
 - **Blocked models**: `OPENROUTER_BLOCKED_MODELS` env var (comma-separated) for persistent manual overrides
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,17 @@ Self-hosted, AI-enhanced RSS/Atom news aggregator built with Symfony 8 + Franken
 
 - **RSS/Atom feed aggregation** from configurable sources
 - **AI-powered categorization & summarization** via OpenRouter free models (with rule-based fallback)
+- **Keyword extraction** — AI-extracted entities (people, orgs, places) displayed as tags, searchable
+- **Article translation** — automatic title/summary translation based on source language (original preserved)
 - **Smart alerts** with keyword and AI-based evaluation
+- **Alert rule fixtures** — define alert strategies in YAML files, load via CLI
 - **Periodic digests** with AI-generated editorial summaries
-- **Full-text search** via SEAL + Loupe (zero infrastructure, SQLite-based)
+- **Full-text search** via SEAL + Loupe (zero infrastructure, SQLite-based) with auto-reindexing
+- **Inline article filter** — client-side search-as-you-type on the dashboard
 - **Article scoring & ranking** based on recency, source reliability, and category weights
 - **Deduplication** across sources (URL, title similarity, content fingerprint)
 - **Data retention** with configurable cleanup intervals
+- **Scheduled maintenance** — daily search reindex + cleanup via Symfony Scheduler
 - Single-user auth, multi-user ready architecture
 
 ## Tech Stack
@@ -124,7 +129,33 @@ NOTIFIER_CHATTER_DSN=pushover://USER_KEY@TOKEN
 
 ## Alert Rules
 
-Alert rules watch incoming articles and send notifications when matched. Each rule has a **type**:
+Alert rules watch incoming articles and send notifications when matched.
+
+### Loading from fixtures
+
+Define alert strategies in YAML and load them via CLI:
+
+```bash
+make sf c="app:load-alert-rules fixtures/alert-rules/portfolio.yaml"
+make sf c="app:load-alert-rules fixtures/alert-rules/"  # load all files in directory
+make sf c="app:load-alert-rules fixtures/alert-rules/portfolio.yaml --dry-run"  # preview
+make sf c="app:load-alert-rules fixtures/alert-rules/portfolio.yaml --purge"    # remove rules not in file
+```
+
+Fixture format (`fixtures/alert-rules/portfolio.yaml`):
+```yaml
+- name: "Hormuz De-escalation"
+  type: ai
+  keywords: ["hormuz ceasefire", "iran diplomacy", "iran peace deal"]
+  context_prompt: "I hold CF Industries and K+S stocks that profit from the Hormuz blockade..."
+  urgency: high
+  severity_threshold: 6
+  cooldown_minutes: 30
+```
+
+### Creating via UI
+
+Navigate to **Alerts** in the sidebar. Each rule has a **type**:
 
 | Type | Behavior |
 |------|----------|
@@ -169,9 +200,35 @@ AI features use [OpenRouter](https://openrouter.ai) free models via `symfony/ai-
 - **Blocked models**: Set `OPENROUTER_BLOCKED_MODELS=model-id-1,model-id-2` to permanently skip unreliable models.
 - **Stats**: Run `make sf c="app:ai-stats"` to see model quality metrics.
 
+### AI enrichment pipeline
+
+Each fetched article goes through this pipeline:
+
+1. **Categorization** — assigns a category (politics, tech, business, science, sports)
+2. **Summarization** — generates a 1-2 sentence summary
+3. **Keyword extraction** — extracts 3-5 key entities (people, organizations, places, topics)
+4. **Translation** — translates title and summary if the source language differs from English
+
+All four steps use the same decorator pattern: AI tries first, rule-based fallback on failure. Keywords and translations are stored alongside the original content.
+
+### Source language & translation
+
+Sources have a `language` field (e.g. `de`, `en`). When a source's language is not English, the AI translates the title and summary after enrichment. The original text is preserved (`titleOriginal`, `summaryOriginal`) and shown via a tooltip on the article card.
+
+Add a language when creating a source in the UI, or set it in the seed data.
+
+## Search
+
+Articles are indexed via SEAL + Loupe (SQLite-based, zero infrastructure). Search covers title, content, summary, source name, category, and extracted keywords.
+
+- **Navbar search** — full-text search via `/search?q=...`
+- **Inline filter** — type in the filter input above the dashboard article list for instant client-side filtering
+- **Auto-reindex** — new articles are indexed automatically via a Doctrine event listener. A daily full reindex runs as a safety net via the maintenance scheduler.
+- **Manual reindex**: `make sf c="app:search-reindex"`
+
 ## Data Retention
 
-Old articles and logs are pruned automatically by the `app:cleanup` command (run daily via the Messenger scheduler).
+Old articles and logs are pruned automatically by the `app:cleanup` command (run daily via the maintenance scheduler).
 
 | Variable | Default | Description |
 |----------|---------|-------------|


### PR DESCRIPTION
## Summary

Documentation was not updated when PRs #21-#31 were merged. This adds:

**README.md:**
- New features in features list (keywords, translation, fixtures, inline filter, auto-reindex, maintenance scheduler)
- Alert rule fixtures section with CLI usage and YAML format example
- AI enrichment pipeline section (categorization → summarization → keywords → translation)
- Source language & translation documentation
- Search section (navbar, inline filter, auto-reindex, manual reindex)
- Updated data retention to mention maintenance scheduler

**CLAUDE.md:**
- Updated domain overview (Enrichment includes keywords/translation, Shared includes Scheduler)
- Added AI integration entries for keyword extraction, translation, fixtures, auto-reindex

**CHANGELOG.md:**
- All post-release features and fixes documented under [Unreleased]

## Test plan

- [x] README renders correctly on GitHub
- [x] No broken links
- [x] Feature descriptions match actual behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)