### PR TITLE
Add display language toggle on dashboard (#34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Start database
         run: docker compose up -d database pgbouncer && docker compose exec -T database sh -c 'until pg_isready -U app; do sleep 1; done'
       - name: Build TypeScript assets
-        run: docker compose run --rm --no-deps --entrypoint "" php bun build assets/ts/theme-toggle.ts assets/ts/timeago.ts assets/ts/mark-as-read.ts assets/ts/infinite-scroll.ts assets/ts/article-filter.ts --outdir=assets/js
+        run: docker compose run --rm --no-deps --entrypoint "" php bun build assets/ts/theme-toggle.ts assets/ts/timeago.ts assets/ts/mark-as-read.ts assets/ts/infinite-scroll.ts assets/ts/article-filter.ts assets/ts/language-toggle.ts --outdir=assets/js
       - name: Start app (vendor already installed — entrypoint skips composer install)
         run: docker compose up -d --wait --no-build php
       # Tests bypass PgBouncer and connect directly to database.

--- a/assets/app.js
+++ b/assets/app.js
@@ -10,3 +10,4 @@ import './js/timeago.js';
 import './js/mark-as-read.js';
 import './js/infinite-scroll.js';
 import './js/article-filter.js';
+import './js/language-toggle.js';

--- a/assets/ts/language-toggle.ts
+++ b/assets/ts/language-toggle.ts
@@ -1,0 +1,73 @@
+/**
+ * Language toggle — switches article cards between translated and original text.
+ *
+ * Articles from non-English sources have data-title-translated/data-title-original
+ * and data-summary-translated/data-summary-original attributes. This toggle swaps
+ * the displayed text between the two versions.
+ *
+ * Persists preference in localStorage.
+ */
+const STORAGE_KEY = "display-language";
+
+type Lang = "translated" | "original";
+
+function getPreference(): Lang {
+  return (localStorage.getItem(STORAGE_KEY) as Lang) || "translated";
+}
+
+function applyLanguage(lang: Lang): void {
+  const cards = document.querySelectorAll<HTMLElement>("[data-article-id]");
+
+  for (const card of cards) {
+    const titleEl = card.querySelector<HTMLElement>("[data-lang-title]");
+    const summaryEl = card.querySelector<HTMLElement>("[data-lang-summary]");
+
+    if (titleEl) {
+      const translated = card.dataset.titleTranslated;
+      const original = card.dataset.titleOriginal;
+      if (translated && original) {
+        titleEl.textContent = lang === "original" ? original : translated;
+      }
+    }
+
+    if (summaryEl) {
+      const translated = card.dataset.summaryTranslated;
+      const original = card.dataset.summaryOriginal;
+      if (translated && original) {
+        summaryEl.textContent = lang === "original" ? original : translated;
+      }
+    }
+  }
+
+  const btn = document.getElementById("lang-toggle");
+  const label = document.getElementById("lang-toggle-label");
+  if (label && btn) {
+    if (lang === "original") {
+      label.textContent = "Original";
+      btn.classList.add("btn-active");
+    } else {
+      label.textContent = "Translated";
+      btn.classList.remove("btn-active");
+    }
+  }
+}
+
+function init(): void {
+  const btn = document.getElementById("lang-toggle");
+  if (!btn) return;
+
+  const current = getPreference();
+  applyLanguage(current);
+
+  btn.addEventListener("click", () => {
+    const next: Lang = getPreference() === "translated" ? "original" : "translated";
+    localStorage.setItem(STORAGE_KEY, next);
+    applyLanguage(next);
+  });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init);
+} else {
+  init();
+}

--- a/templates/components/_article_card.html.twig
+++ b/templates/components/_article_card.html.twig
@@ -1,22 +1,27 @@
 {# Expects: article (Article entity) #}
-<div class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow {{ article_read is defined and article_read ? 'opacity-60' : '' }}" data-article-id="{{ article.id }}" data-searchable="{{ article.title|lower }} {{ article.summary|default('')|lower }}">
+<div class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow {{ article_read is defined and article_read ? 'opacity-60' : '' }}"
+    data-article-id="{{ article.id }}"
+    data-searchable="{{ article.title|lower }} {{ article.summary|default('')|lower }}"
+    {% if article.titleOriginal is not null and article.titleOriginal != article.title %}
+        data-title-translated="{{ article.title|e('html_attr') }}"
+        data-title-original="{{ article.titleOriginal|e('html_attr') }}"
+    {% endif %}
+    {% if article.summaryOriginal is not null and article.summaryOriginal != article.summary %}
+        data-summary-translated="{{ article.summary|e('html_attr') }}"
+        data-summary-original="{{ article.summaryOriginal|e('html_attr') }}"
+    {% endif %}
+>
     <div class="card-body p-4">
         <div class="flex items-start gap-2">
-            <div class="flex-1">
+            <div class="flex-1 min-w-0">
                 <h3 class="card-title text-base">
-                    <a href="{{ article.url }}" target="_blank" rel="noopener" class="link link-hover article-link" data-article-id="{{ article.id }}">
+                    <a href="{{ article.url }}" target="_blank" rel="noopener" class="link link-hover article-link" data-article-id="{{ article.id }}" data-lang-title>
                         {{ article.title }}
                     </a>
-                    {% if article.titleOriginal is not null and article.titleOriginal != article.title %}
-                        <span class="tooltip tooltip-bottom cursor-help text-base-content/40" data-tip="{{ article.titleOriginal }}">&#127760;</span>
-                    {% endif %}
                 </h3>
                 {% if article.summary %}
-                    <p class="text-sm text-base-content/70 mt-1">
+                    <p class="text-sm text-base-content/70 mt-1" data-lang-summary>
                         {{ article.summary }}
-                        {% if article.summaryOriginal is not null and article.summaryOriginal != article.summary %}
-                            <span class="tooltip tooltip-bottom cursor-help text-base-content/40" data-tip="{{ article.summaryOriginal }}">&#127760;</span>
-                        {% endif %}
                     </p>
                 {% endif %}
                 {% if article.keywords is not null and article.keywords is not empty %}

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -30,6 +30,9 @@
             <input type="hidden" name="_token" value="{{ csrf_token('mark_all_read') }}">
             <button type="submit" class="btn btn-sm btn-ghost">Mark All Read</button>
         </form>
+        <button id="lang-toggle" class="btn btn-sm btn-outline gap-1" title="Switch between translated and original article text">
+            <span id="lang-toggle-label">Translated</span>
+        </button>
         <input id="article-filter" type="text" placeholder="Filter articles..." class="input input-bordered input-sm flex-1" />
     </div>
 


### PR DESCRIPTION
## Summary

Adds a "Translated / Original" toggle button to the dashboard toolbar that switches article text between the AI-translated version and the original language.

### How it works

- Article cards with translations have `data-title-translated`, `data-title-original`, `data-summary-translated`, `data-summary-original` attributes
- The TypeScript module `language-toggle.ts` swaps the displayed text on click
- Preference persisted in `localStorage` — survives page reloads
- Button shows active state when viewing originals

### Limitations

Currently one-directional: German → English translations exist, but not English → German. The toggle shows originals for translated articles; non-translated articles are unaffected. Full bidirectional translation (EN↔DE) would require translating English articles to German in the pipeline — tracked separately.

## Test plan

- [ ] "Translated" button visible in dashboard toolbar
- [ ] Clicking toggles German article titles/summaries to original German text
- [ ] Clicking again restores English translations
- [ ] Preference persists after page reload
- [ ] Non-translated (English) articles unaffected by toggle
- [ ] Works on mobile
- [ ] `make quality` passes
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #34