### PR TITLE
feat: always log alert matches regardless of notification transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 #### Post-Release Features
+- Alert matches always logged regardless of notification transport — `DeliveryStatus` enum (sent/skipped/failed), colored badges in notification log UI, `CleanupCommand` now purges old notification and digest logs (#37)
 - Multi-language translation with EN/DE/FR language selector — articles translated to all configured display languages, client-side dropdown to switch, translations stored as JSON on article (#36)
 - Keyword extraction from articles — AI extracts key entities (people, orgs, places), displayed as badges, searchable (#21)
 - Inline search-as-you-type filter on dashboard — client-side article filtering with debounce (#22)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ src/
 | `ADMIN_PASSWORD_HASH` | Bcrypt/argon2 hash | (required) |
 | `OPENROUTER_API_KEY` | OpenRouter API key for AI | (optional — rule-based fallback works without it) |
 | `OPENROUTER_BLOCKED_MODELS` | Comma-separated blocked model IDs | (empty) |
-| `NOTIFIER_CHATTER_DSN` | Notifier transport DSN | (optional — alerts disabled without it) |
+| `NOTIFIER_CHATTER_DSN` | Notifier transport DSN | (optional — matches logged as `skipped` without it) |
 | `FETCH_DEFAULT_INTERVAL_MINUTES` | Default fetch interval | `60` |
 | `DISPLAY_LANGUAGES` | Comma-separated display languages (e.g. `en,de,fr`) | `en` |
 | `RETENTION_ARTICLES` | Article retention period | `90` |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ NOTIFIER_CHATTER_DSN=pushover://USER_KEY@TOKEN
 
 ## Alert Rules
 
-Alert rules watch incoming articles and send notifications when matched.
+Alert rules watch incoming articles and send notifications when matched. All alert matches are logged to the notification log regardless of whether a notification transport is configured. The log shows delivery status: **sent** (green), **skipped** (gray, no transport), or **failed** (red).
 
 ### Loading from fixtures
 

--- a/config/services.php
+++ b/config/services.php
@@ -17,6 +17,7 @@ use App\Enrichment\Service\SummarizationServiceInterface;
 use App\Enrichment\Service\TranslationServiceInterface;
 use App\Notification\Command\LoadAlertRulesCommand;
 use App\Notification\Service\AiAlertEvaluationService;
+use App\Notification\Service\NotificationDispatchService;
 use App\Shared\AI\Command\AiSmokeTestCommand;
 use App\Shared\AI\Platform\ModelFailoverPlatform;
 use App\Shared\AI\Service\ModelDiscoveryService;
@@ -159,6 +160,10 @@ return static function (ContainerConfigurator $container): void {
         ->arg('$notifierDsn', '%env(default::NOTIFIER_CHATTER_DSN)%')
         ->arg('$retentionArticles', '%env(int:RETENTION_ARTICLES)%')
         ->arg('$retentionLogs', '%env(int:RETENTION_LOGS)%');
+
+    // Wire notifier DSN for NotificationDispatchService (to detect null transport)
+    $services->set(NotificationDispatchService::class)
+        ->arg('$notifierDsn', '%env(default::NOTIFIER_CHATTER_DSN)%');
 
     // Wire DISPLAY_LANGUAGES env var for FetchSourceHandler
     $services->set(FetchSourceHandler::class)

--- a/migrations/Version20260405200000.php
+++ b/migrations/Version20260405200000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260405200000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add delivery_status column to notification_log table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE notification_log ADD delivery_status VARCHAR(20) DEFAULT 'sent' NOT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE notification_log DROP delivery_status');
+    }
+}

--- a/src/Notification/Entity/NotificationLog.php
+++ b/src/Notification/Entity/NotificationLog.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Notification\Entity;
 
 use App\Article\Entity\Article;
+use App\Notification\ValueObject\DeliveryStatus;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -34,6 +35,11 @@ class NotificationLog
 
     #[ORM\Column]
     private bool $success;
+
+    #[ORM\Column(length: 20, enumType: DeliveryStatus::class, options: [
+        'default' => 'sent',
+    ])]
+    private DeliveryStatus $deliveryStatus = DeliveryStatus::Sent;
 
     #[ORM\Column(type: Types::SMALLINT, nullable: true)]
     private ?int $aiSeverity = null;
@@ -94,6 +100,16 @@ class NotificationLog
     public function isSuccess(): bool
     {
         return $this->success;
+    }
+
+    public function getDeliveryStatus(): DeliveryStatus
+    {
+        return $this->deliveryStatus;
+    }
+
+    public function setDeliveryStatus(DeliveryStatus $deliveryStatus): void
+    {
+        $this->deliveryStatus = $deliveryStatus;
     }
 
     public function getAiSeverity(): ?int

--- a/src/Notification/Service/NotificationDispatchService.php
+++ b/src/Notification/Service/NotificationDispatchService.php
@@ -8,6 +8,7 @@ use App\Article\Entity\Article;
 use App\Notification\Entity\AlertRule;
 use App\Notification\Entity\NotificationLog;
 use App\Notification\ValueObject\AlertUrgency;
+use App\Notification\ValueObject\DeliveryStatus;
 use App\Notification\ValueObject\EvaluationResult;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
@@ -20,6 +21,7 @@ final readonly class NotificationDispatchService implements NotificationDispatch
         private NotifierInterface $notifier,
         private EntityManagerInterface $entityManager,
         private ClockInterface $clock,
+        private string $notifierDsn = '',
     ) {
     }
 
@@ -32,6 +34,39 @@ final readonly class NotificationDispatchService implements NotificationDispatch
         array $matchedKeywords,
         ?EvaluationResult $evaluation = null,
     ): void {
+        $deliveryStatus = $this->sendNotification($rule, $article, $matchedKeywords, $evaluation);
+
+        $matchType = $evaluation instanceof EvaluationResult ? 'ai' : 'keyword';
+        $log = new NotificationLog($rule, $article, $matchType, $deliveryStatus === DeliveryStatus::Sent, $this->clock->now());
+        $log->setDeliveryStatus($deliveryStatus);
+        if ($evaluation instanceof EvaluationResult) {
+            $log->setAiSeverity($evaluation->severity);
+            $log->setAiExplanation($evaluation->explanation);
+            $log->setAiModelUsed($evaluation->modelUsed);
+        }
+
+        $this->entityManager->persist($log);
+        $this->entityManager->flush();
+    }
+
+    public function hasTransport(): bool
+    {
+        return $this->notifierDsn !== '' && $this->notifierDsn !== 'null://null';
+    }
+
+    /**
+     * @param list<string> $matchedKeywords
+     */
+    private function sendNotification(
+        AlertRule $rule,
+        Article $article,
+        array $matchedKeywords,
+        ?EvaluationResult $evaluation,
+    ): DeliveryStatus {
+        if (! $this->hasTransport()) {
+            return DeliveryStatus::Skipped;
+        }
+
         $subject = sprintf('[%s] %s', strtoupper($rule->getUrgency()->value), $article->getTitle());
         $content = $this->buildContent($rule, $article, $matchedKeywords, $evaluation);
 
@@ -45,23 +80,13 @@ final readonly class NotificationDispatchService implements NotificationDispatch
         $notification->content($content);
         $notification->importance($importance);
 
-        $success = true;
         try {
             $this->notifier->send($notification);
+
+            return DeliveryStatus::Sent;
         } catch (\Throwable) {
-            $success = false;
+            return DeliveryStatus::Failed;
         }
-
-        $matchType = $evaluation instanceof EvaluationResult ? 'ai' : 'keyword';
-        $log = new NotificationLog($rule, $article, $matchType, $success, $this->clock->now());
-        if ($evaluation instanceof EvaluationResult) {
-            $log->setAiSeverity($evaluation->severity);
-            $log->setAiExplanation($evaluation->explanation);
-            $log->setAiModelUsed($evaluation->modelUsed);
-        }
-
-        $this->entityManager->persist($log);
-        $this->entityManager->flush();
     }
 
     /**

--- a/src/Notification/ValueObject/DeliveryStatus.php
+++ b/src/Notification/ValueObject/DeliveryStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\ValueObject;
+
+enum DeliveryStatus: string
+{
+    case Sent = 'sent';
+    case Skipped = 'skipped';
+    case Failed = 'failed';
+}

--- a/src/Shared/Command/CleanupCommand.php
+++ b/src/Shared/Command/CleanupCommand.php
@@ -51,6 +51,26 @@ final class CleanupCommand extends Command
         );
         $io->info(sprintf('Deleted %d old articles.', (int) $articleDeleted));
 
+        $logCutoff = $this->clock->now()->modify(sprintf('-%d days', $this->retentionLogDays));
+
+        // Delete old notification logs
+        $notificationLogDeleted = $this->connection->executeStatement(
+            'DELETE FROM notification_log WHERE sent_at < :cutoff',
+            [
+                'cutoff' => $logCutoff->format('Y-m-d H:i:s'),
+            ],
+        );
+        $io->info(sprintf('Deleted %d old notification logs.', (int) $notificationLogDeleted));
+
+        // Delete old digest logs
+        $digestLogDeleted = $this->connection->executeStatement(
+            'DELETE FROM digest_log WHERE generated_at < :cutoff',
+            [
+                'cutoff' => $logCutoff->format('Y-m-d H:i:s'),
+            ],
+        );
+        $io->info(sprintf('Deleted %d old digest logs.', (int) $digestLogDeleted));
+
         $io->success(sprintf(
             'Cleanup complete. Retention: %d days articles, %d days logs.',
             $this->retentionArticleDays,

--- a/templates/notification/index.html.twig
+++ b/templates/notification/index.html.twig
@@ -5,7 +5,7 @@
 
     {% if logs is empty %}
         {% include 'components/_empty_state.html.twig' with {
-            message: 'No notifications sent yet.'
+            message: 'No alert matches logged yet.'
         } %}
     {% else %}
         <div class="overflow-x-auto">
@@ -31,8 +31,10 @@
                             <td><span class="badge badge-outline badge-sm">{{ log.matchType }}</span></td>
                             <td>{{ log.aiSeverity ?? '-' }}</td>
                             <td>
-                                {% if log.success %}
+                                {% if log.deliveryStatus.value == 'sent' %}
                                     <span class="badge badge-success badge-sm">sent</span>
+                                {% elseif log.deliveryStatus.value == 'skipped' %}
+                                    <span class="badge badge-ghost badge-sm">skipped</span>
                                 {% else %}
                                     <span class="badge badge-error badge-sm">failed</span>
                                 {% endif %}

--- a/tests/Unit/Notification/Entity/NotificationLogTest.php
+++ b/tests/Unit/Notification/Entity/NotificationLogTest.php
@@ -8,6 +8,7 @@ use App\Article\Entity\Article;
 use App\Notification\Entity\AlertRule;
 use App\Notification\Entity\NotificationLog;
 use App\Notification\ValueObject\AlertRuleType;
+use App\Notification\ValueObject\DeliveryStatus;
 use App\Shared\Entity\Category;
 use App\Source\Entity\Source;
 use App\User\Entity\User;
@@ -34,6 +35,7 @@ final class NotificationLogTest extends TestCase
         self::assertTrue($log->isSuccess());
         self::assertNull($log->getAiSeverity());
         self::assertNull($log->getAiExplanation());
+        self::assertSame(DeliveryStatus::Sent, $log->getDeliveryStatus());
     }
 
     public function testSetAiFields(): void
@@ -54,5 +56,23 @@ final class NotificationLogTest extends TestCase
         self::assertSame('Critical policy change affecting markets', $log->getAiExplanation());
         self::assertSame('openrouter/auto', $log->getAiModelUsed());
         self::assertSame('pushover', $log->getTransport());
+    }
+
+    public function testDeliveryStatusCanBeSet(): void
+    {
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('Rule', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
+        $category = new Category('Tech', 'tech', 10, '#3B82F6');
+        $source = new Source('Src', 'https://example.com/feed', $category, new \DateTimeImmutable());
+        $article = new Article('Title', 'https://example.com/3', $source, new \DateTimeImmutable());
+
+        $log = new NotificationLog($rule, $article, 'keyword', false, new \DateTimeImmutable());
+        $log->setDeliveryStatus(DeliveryStatus::Skipped);
+
+        self::assertSame(DeliveryStatus::Skipped, $log->getDeliveryStatus());
+
+        $log->setDeliveryStatus(DeliveryStatus::Failed);
+
+        self::assertSame(DeliveryStatus::Failed, $log->getDeliveryStatus());
     }
 }

--- a/tests/Unit/Notification/MessageHandler/SendNotificationHandlerTest.php
+++ b/tests/Unit/Notification/MessageHandler/SendNotificationHandlerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification\MessageHandler;
+
+use App\Article\Entity\Article;
+use App\Notification\Entity\AlertRule;
+use App\Notification\Message\SendNotificationMessage;
+use App\Notification\MessageHandler\SendNotificationHandler;
+use App\Notification\Service\AiAlertEvaluationServiceInterface;
+use App\Notification\Service\NotificationDispatchServiceInterface;
+use App\Notification\ValueObject\AlertRuleType;
+use App\Notification\ValueObject\EvaluationResult;
+use App\Shared\Entity\Category;
+use App\Source\Entity\Source;
+use App\User\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(SendNotificationHandler::class)]
+final class SendNotificationHandlerTest extends TestCase
+{
+    /**
+     * @var EntityManagerInterface&MockObject
+     */
+    private MockObject $em;
+
+    /**
+     * @var NotificationDispatchServiceInterface&MockObject
+     */
+    private MockObject $dispatchService;
+
+    /**
+     * @var AiAlertEvaluationServiceInterface&MockObject
+     */
+    private MockObject $aiEvaluationService;
+
+    private SendNotificationHandler $handler;
+
+    private AlertRule $rule;
+
+    private Article $article;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->dispatchService = $this->createMock(NotificationDispatchServiceInterface::class);
+        $this->aiEvaluationService = $this->createMock(AiAlertEvaluationServiceInterface::class);
+
+        $this->handler = new SendNotificationHandler(
+            $this->em,
+            $this->dispatchService,
+            $this->aiEvaluationService,
+            new NullLogger(),
+        );
+
+        $user = new User('admin@example.com', 'hashed');
+        $this->rule = new AlertRule('Test Rule', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
+        $category = new Category('Tech', 'tech', 10, '#3B82F6');
+        $source = new Source('Src', 'https://example.com/feed', $category, new \DateTimeImmutable());
+        $this->article = new Article('Test Article', 'https://example.com/1', $source, new \DateTimeImmutable());
+    }
+
+    public function testDispatchCalledForKeywordMatch(): void
+    {
+        $message = new SendNotificationMessage(1, 1, ['bitcoin']);
+
+        $this->em->method('find')
+            ->willReturnCallback(fn (string $class): AlertRule|\App\Article\Entity\Article|null => match ($class) {
+                AlertRule::class => $this->rule,
+                Article::class => $this->article,
+                default => null,
+            });
+
+        $this->dispatchService->expects(self::once())
+            ->method('dispatch')
+            ->with($this->rule, $this->article, ['bitcoin'], null);
+
+        ($this->handler)($message);
+    }
+
+    public function testSkipsWhenRuleNotFound(): void
+    {
+        $message = new SendNotificationMessage(999, 1, ['bitcoin']);
+
+        $this->em->method('find')
+            ->willReturn(null);
+
+        $this->dispatchService->expects(self::never())
+            ->method('dispatch');
+
+        ($this->handler)($message);
+    }
+
+    public function testSkipsWhenRuleDisabled(): void
+    {
+        $this->rule->setEnabled(false);
+        $message = new SendNotificationMessage(1, 1, ['bitcoin']);
+
+        $this->em->method('find')
+            ->willReturnCallback(fn (string $class): AlertRule|\App\Article\Entity\Article|null => match ($class) {
+                AlertRule::class => $this->rule,
+                Article::class => $this->article,
+                default => null,
+            });
+
+        $this->dispatchService->expects(self::never())
+            ->method('dispatch');
+
+        ($this->handler)($message);
+    }
+
+    public function testAiEvaluationPassedToDispatch(): void
+    {
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('AI Rule', AlertRuleType::Ai, $user, new \DateTimeImmutable());
+        $evaluation = new EvaluationResult(8, 'Critical event', 'openrouter/auto');
+
+        $message = new SendNotificationMessage(1, 1, ['bitcoin']);
+
+        $this->em->method('find')
+            ->willReturnCallback(fn (string $class): AlertRule|\App\Article\Entity\Article|null => match ($class) {
+                AlertRule::class => $rule,
+                Article::class => $this->article,
+                default => null,
+            });
+
+        $this->aiEvaluationService->method('evaluate')
+            ->willReturn($evaluation);
+
+        $this->dispatchService->expects(self::once())
+            ->method('dispatch')
+            ->with($rule, $this->article, ['bitcoin'], $evaluation);
+
+        ($this->handler)($message);
+    }
+
+    public function testAiEvaluationBelowThresholdSkipsDispatch(): void
+    {
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('AI Rule', AlertRuleType::Ai, $user, new \DateTimeImmutable());
+        $rule->setSeverityThreshold(7);
+        $evaluation = new EvaluationResult(3, 'Low impact', 'openrouter/auto');
+
+        $message = new SendNotificationMessage(1, 1, ['bitcoin']);
+
+        $this->em->method('find')
+            ->willReturnCallback(fn (string $class): AlertRule|\App\Article\Entity\Article|null => match ($class) {
+                AlertRule::class => $rule,
+                Article::class => $this->article,
+                default => null,
+            });
+
+        $this->aiEvaluationService->method('evaluate')
+            ->willReturn($evaluation);
+
+        $this->dispatchService->expects(self::never())
+            ->method('dispatch');
+
+        ($this->handler)($message);
+    }
+}

--- a/tests/Unit/Notification/Service/NotificationDispatchServiceTest.php
+++ b/tests/Unit/Notification/Service/NotificationDispatchServiceTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification\Service;
+
+use App\Article\Entity\Article;
+use App\Notification\Entity\AlertRule;
+use App\Notification\Entity\NotificationLog;
+use App\Notification\Service\NotificationDispatchService;
+use App\Notification\ValueObject\AlertRuleType;
+use App\Notification\ValueObject\DeliveryStatus;
+use App\Notification\ValueObject\EvaluationResult;
+use App\Shared\Entity\Category;
+use App\Source\Entity\Source;
+use App\User\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Notifier\NotifierInterface;
+
+#[CoversClass(NotificationDispatchService::class)]
+#[UsesClass(NotificationLog::class)]
+#[UsesClass(DeliveryStatus::class)]
+final class NotificationDispatchServiceTest extends TestCase
+{
+    /**
+     * @var NotifierInterface&MockObject
+     */
+    private MockObject $notifier;
+
+    /**
+     * @var EntityManagerInterface&MockObject
+     */
+    private MockObject $em;
+
+    private MockClock $clock;
+
+    private AlertRule $rule;
+
+    private Article $article;
+
+    protected function setUp(): void
+    {
+        $this->notifier = $this->createMock(NotifierInterface::class);
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->clock = new MockClock(new \DateTimeImmutable('2026-04-05 12:00:00'));
+
+        $user = new User('admin@example.com', 'hashed');
+        $this->rule = new AlertRule('Test Rule', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
+        $category = new Category('Tech', 'tech', 10, '#3B82F6');
+        $source = new Source('Src', 'https://example.com/feed', $category, new \DateTimeImmutable());
+        $this->article = new Article('Test Article', 'https://example.com/1', $source, new \DateTimeImmutable());
+    }
+
+    public function testDispatchWithTransportLogsSent(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->em,
+            $this->clock,
+            'pushover://USER@TOKEN',
+        );
+
+        $this->notifier->expects(self::once())->method('send');
+
+        $persistedLog = null;
+        $this->em->expects(self::once())
+            ->method('persist')
+            ->with(self::callback(static function (NotificationLog $log) use (&$persistedLog): bool {
+                $persistedLog = $log;
+
+                return true;
+            }));
+        $this->em->expects(self::once())->method('flush');
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin']);
+
+        self::assertInstanceOf(NotificationLog::class, $persistedLog);
+        self::assertSame(DeliveryStatus::Sent, $persistedLog->getDeliveryStatus());
+        self::assertTrue($persistedLog->isSuccess());
+    }
+
+    public function testDispatchWithoutTransportLogsSkipped(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->em,
+            $this->clock,
+            'null://null',
+        );
+
+        $this->notifier->expects(self::never())->method('send');
+
+        $persistedLog = null;
+        $this->em->expects(self::once())
+            ->method('persist')
+            ->with(self::callback(static function (NotificationLog $log) use (&$persistedLog): bool {
+                $persistedLog = $log;
+
+                return true;
+            }));
+        $this->em->expects(self::once())->method('flush');
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin']);
+
+        self::assertInstanceOf(NotificationLog::class, $persistedLog);
+        self::assertSame(DeliveryStatus::Skipped, $persistedLog->getDeliveryStatus());
+        self::assertFalse($persistedLog->isSuccess());
+    }
+
+    public function testDispatchWithEmptyDsnLogsSkipped(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->em,
+            $this->clock,
+            '',
+        );
+
+        $this->notifier->expects(self::never())->method('send');
+
+        $persistedLog = null;
+        $this->em->expects(self::once())
+            ->method('persist')
+            ->with(self::callback(static function (NotificationLog $log) use (&$persistedLog): bool {
+                $persistedLog = $log;
+
+                return true;
+            }));
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin']);
+
+        self::assertInstanceOf(NotificationLog::class, $persistedLog);
+        self::assertSame(DeliveryStatus::Skipped, $persistedLog->getDeliveryStatus());
+    }
+
+    public function testDispatchWithTransportFailureLogsFailed(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->em,
+            $this->clock,
+            'pushover://USER@TOKEN',
+        );
+
+        $this->notifier->expects(self::once())
+            ->method('send')
+            ->willThrowException(new \RuntimeException('Transport error'));
+
+        $persistedLog = null;
+        $this->em->expects(self::once())
+            ->method('persist')
+            ->with(self::callback(static function (NotificationLog $log) use (&$persistedLog): bool {
+                $persistedLog = $log;
+
+                return true;
+            }));
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin']);
+
+        self::assertInstanceOf(NotificationLog::class, $persistedLog);
+        self::assertSame(DeliveryStatus::Failed, $persistedLog->getDeliveryStatus());
+        self::assertFalse($persistedLog->isSuccess());
+    }
+
+    public function testDispatchWithAiEvaluationSetsFields(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->em,
+            $this->clock,
+            'pushover://USER@TOKEN',
+        );
+
+        $evaluation = new EvaluationResult(8, 'Critical supply chain disruption', 'openrouter/auto');
+
+        $persistedLog = null;
+        $this->em->expects(self::once())
+            ->method('persist')
+            ->with(self::callback(static function (NotificationLog $log) use (&$persistedLog): bool {
+                $persistedLog = $log;
+
+                return true;
+            }));
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin'], $evaluation);
+
+        self::assertInstanceOf(NotificationLog::class, $persistedLog);
+        self::assertSame(8, $persistedLog->getAiSeverity());
+        self::assertSame('Critical supply chain disruption', $persistedLog->getAiExplanation());
+        self::assertSame('openrouter/auto', $persistedLog->getAiModelUsed());
+        self::assertSame('ai', $persistedLog->getMatchType());
+    }
+
+    public function testHasTransportReturnsFalseForNullDsn(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->em,
+            $this->clock,
+            'null://null',
+        );
+
+        self::assertFalse($service->hasTransport());
+    }
+
+    public function testHasTransportReturnsTrueForRealDsn(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->em,
+            $this->clock,
+            'pushover://USER@TOKEN',
+        );
+
+        self::assertTrue($service->hasTransport());
+    }
+}


### PR DESCRIPTION
## Summary

- Alert matching now always creates a `NotificationLog` entry, even when no Notifier transport is configured (`NOTIFIER_CHATTER_DSN=null://null` or empty)
- New `DeliveryStatus` enum value object with three states: `sent`, `skipped`, `failed`
- `NotificationDispatchService` checks DSN before sending; skips Notifier call when no transport configured but still persists the log
- `CleanupCommand` now actually purges old `notification_log` and `digest_log` entries based on `RETENTION_LOGS` (previously only referenced the setting without deleting logs)
- Notification log UI shows colored status badges: green (sent), gray (skipped), red (failed)

Closes #37

## Test plan

- [x] `make quality` -- zero errors (ECS + PHPStan + Rector)
- [x] `make test` -- all 171 tests pass (146 unit + 11 integration + 14 functional)
- [x] New tests: `SendNotificationHandlerTest` (5 cases) and `NotificationDispatchServiceTest` (7 cases) covering sent/skipped/failed paths
- [x] Updated `NotificationLogTest` with `DeliveryStatus` assertions
- [x] Migration applies cleanly (adds `delivery_status` column with `'sent'` default for backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)