### PR TITLE
Fix keywords missing from article cards

### DIFF
--- a/assets/ts/language-selector.ts
+++ b/assets/ts/language-selector.ts
@@ -69,9 +69,9 @@ function applyLanguage(lang: string): void {
       }
     }
 
-    // Swap keywords
+    // Swap keywords (only if translation has non-empty keywords)
     const keywordsEl = card.querySelector<HTMLElement>("[data-lang-keywords]");
-    if (keywordsEl && translation?.keywords) {
+    if (keywordsEl && translation?.keywords && translation.keywords.length > 0) {
       keywordsEl.innerHTML = translation.keywords
         .map((kw: string) => `<span class="badge badge-outline badge-xs">${kw}</span>`)
         .join("");

--- a/src/Article/MessageHandler/FetchSourceHandler.php
+++ b/src/Article/MessageHandler/FetchSourceHandler.php
@@ -184,13 +184,13 @@ final readonly class FetchSourceHandler
             $this->applyEnrichment($article, $catResult, $sumResult);
         }
 
-        $this->applyTranslation($article, $source);
-
-        // Extract keywords after translation so they're in the display language
-        $keywords = $this->keywordExtraction->extract($article->getTitle(), $article->getSummary() ?? $item->contentText);
+        // Extract keywords before translation so they're available in the translations map
+        $keywords = $this->keywordExtraction->extract($item->title, $item->contentText);
         if ($keywords !== []) {
             $article->setKeywords($keywords);
         }
+
+        $this->applyTranslation($article, $source);
 
         $article->setScore($this->scoring->score($article));
 


### PR DESCRIPTION
## Summary

Keywords were not showing on article cards due to two bugs:

1. **Pipeline order**: `applyTranslation()` ran before keyword extraction, reading `$article->getKeywords()` which was still null. Translations JSON stored `"keywords":[]` for all languages. The JS language selector then set `innerHTML` to empty, wiping the server-rendered badges.

2. **JS guard**: `language-selector.ts` overwrote keywords even when the translation had an empty array. Added `length > 0` check.

## Verified locally

- 20/20 article cards now show keyword badges (was 2/20 before fix)
- `make quality` passes
- `make test` passes (171 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)