### PR TITLE
fix: circuit breaker in ModelDiscoveryService can never trip

### DIFF
--- a/src/Shared/AI/Service/ModelDiscoveryService.php
+++ b/src/Shared/AI/Service/ModelDiscoveryService.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Shared\AI\Service;
 
+use App\Shared\AI\ValueObject\CircuitBreakerState;
 use App\Shared\AI\ValueObject\ModelId;
 use App\Shared\AI\ValueObject\ModelIdCollection;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -14,21 +16,20 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
 {
     private const string CACHE_KEY = 'openrouter_free_models';
 
-    private const int CACHE_TTL = 3600; // 1 hour
+    private const int CACHE_TTL = 3600;
 
-    private const string CIRCUIT_BREAKER_KEY = 'openrouter_circuit_breaker';
+    private const string BREAKER_KEY = 'openrouter_cb';
 
-    private const int CIRCUIT_BREAKER_THRESHOLD = 3;
+    private const int BREAKER_THRESHOLD = 3;
 
-    private const int CIRCUIT_BREAKER_RESET_SECONDS = 86400; // 24 hours
+    private const int BREAKER_RESET_SECONDS = 86400;
 
     private const int MIN_CONTEXT_LENGTH = 8192;
-
-    private int $failureCount = 0;
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly CacheItemPoolInterface $cache,
+        private readonly ClockInterface $clock,
         private readonly LoggerInterface $logger,
         private readonly string $blockedModels = '',
     ) {
@@ -36,33 +37,40 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
 
     public function discoverFreeModels(): ModelIdCollection
     {
-        // Check circuit breaker
-        $breakerItem = $this->cache->getItem(self::CIRCUIT_BREAKER_KEY);
-        if ($breakerItem->isHit()) {
+        $state = $this->getState();
+
+        if ($state === CircuitBreakerState::Open) {
             $this->logger->debug('Circuit breaker open, using cached model list');
 
             return $this->getCachedModels();
         }
 
-        // Check cache
-        $cacheItem = $this->cache->getItem(self::CACHE_KEY);
-        if ($cacheItem->isHit()) {
-            /** @var list<string> $cached */
-            $cached = $cacheItem->get();
+        // Closed state: check model cache first
+        if ($state === CircuitBreakerState::Closed) {
+            $cacheItem = $this->cache->getItem(self::CACHE_KEY);
+            if ($cacheItem->isHit()) {
+                /** @var list<string> $cached */
+                $cached = $cacheItem->get();
 
-            return $this->toCollection($cached);
+                return $this->toCollection($cached);
+            }
         }
 
-        // Fetch from API
+        // Closed (cache miss) or HalfOpen: probe the API
+        if ($state === CircuitBreakerState::HalfOpen) {
+            $this->logger->debug('Circuit breaker half-open, attempting probe request');
+        }
+
+        return $this->fetchWithCircuitBreaker($state);
+    }
+
+    private function fetchWithCircuitBreaker(CircuitBreakerState $state): ModelIdCollection
+    {
         try {
             $models = $this->fetchFreeModels();
-            $this->failureCount = 0;
 
-            // Cache raw strings (serializable)
-            $rawIds = array_map(static fn (ModelId $m): string => $m->value, $models->toArray());
-            $cacheItem->set($rawIds);
-            $cacheItem->expiresAfter(self::CACHE_TTL);
-            $this->cache->save($cacheItem);
+            $this->resetBreaker();
+            $this->cacheModels($models);
 
             $this->logger->info('Discovered {count} free OpenRouter models', [
                 'count' => $models->count(),
@@ -70,19 +78,119 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
 
             return $models;
         } catch (\Throwable $e) {
-            $this->failureCount++;
-            $this->logger->warning('Model discovery failed ({count}/{threshold}): {error}', [
-                'count' => $this->failureCount,
-                'threshold' => self::CIRCUIT_BREAKER_THRESHOLD,
-                'error' => $e->getMessage(),
-            ]);
-
-            if ($this->failureCount >= self::CIRCUIT_BREAKER_THRESHOLD) {
-                $this->openCircuitBreaker();
-            }
-
-            return $this->getCachedModels();
+            return $this->handleFailure($e, $state);
         }
+    }
+
+    private function handleFailure(\Throwable $e, CircuitBreakerState $state): ModelIdCollection
+    {
+        $failures = $this->incrementFailures();
+
+        $this->logger->warning('Model discovery failed ({count}/{threshold}): {error}', [
+            'count' => $failures,
+            'threshold' => self::BREAKER_THRESHOLD,
+            'error' => $e->getMessage(),
+        ]);
+
+        // HalfOpen probe failed or threshold reached: open the breaker
+        if ($state === CircuitBreakerState::HalfOpen || $failures >= self::BREAKER_THRESHOLD) {
+            $this->openBreaker();
+        }
+
+        return $this->getCachedModels();
+    }
+
+    /**
+     * @return array{state: string, failures: int, opened_at: ?int}
+     */
+    private function getBreakerData(): array
+    {
+        $item = $this->cache->getItem(self::BREAKER_KEY);
+        if (! $item->isHit()) {
+            return [
+                'state' => CircuitBreakerState::Closed->value,
+                'failures' => 0,
+                'opened_at' => null,
+            ];
+        }
+
+        /** @var array{state: string, failures: int, opened_at: ?int} $data */
+        $data = $item->get();
+
+        return $data;
+    }
+
+    private function getState(): CircuitBreakerState
+    {
+        $data = $this->getBreakerData();
+        $state = CircuitBreakerState::tryFrom($data['state']) ?? CircuitBreakerState::Closed;
+
+        if ($state !== CircuitBreakerState::Open) {
+            return $state;
+        }
+
+        // Check if Open state has expired → transition to HalfOpen
+        $openedAt = $data['opened_at'];
+        if ($openedAt !== null) {
+            $elapsed = $this->clock->now()->getTimestamp() - $openedAt;
+            if ($elapsed >= self::BREAKER_RESET_SECONDS) {
+                $this->saveBreakerData(CircuitBreakerState::HalfOpen, $data['failures'], $openedAt);
+
+                return CircuitBreakerState::HalfOpen;
+            }
+        }
+
+        return CircuitBreakerState::Open;
+    }
+
+    private function incrementFailures(): int
+    {
+        $data = $this->getBreakerData();
+        $failures = $data['failures'] + 1;
+        $state = CircuitBreakerState::tryFrom($data['state']) ?? CircuitBreakerState::Closed;
+        $this->saveBreakerData($state, $failures, $data['opened_at']);
+
+        return $failures;
+    }
+
+    private function openBreaker(): void
+    {
+        $this->saveBreakerData(
+            CircuitBreakerState::Open,
+            self::BREAKER_THRESHOLD,
+            $this->clock->now()->getTimestamp(),
+        );
+
+        $this->logger->warning('Circuit breaker opened for model discovery ({seconds}s)', [
+            'seconds' => self::BREAKER_RESET_SECONDS,
+        ]);
+    }
+
+    private function resetBreaker(): void
+    {
+        $this->cache->deleteItem(self::BREAKER_KEY);
+    }
+
+    private function saveBreakerData(CircuitBreakerState $state, int $failures, ?int $openedAt): void
+    {
+        $item = $this->cache->getItem(self::BREAKER_KEY);
+        $item->set([
+            'state' => $state->value,
+            'failures' => $failures,
+            'opened_at' => $openedAt,
+        ]);
+        // Long TTL — state transitions managed in code, not by cache expiry
+        $item->expiresAfter(self::BREAKER_RESET_SECONDS * 2);
+        $this->cache->save($item);
+    }
+
+    private function cacheModels(ModelIdCollection $models): void
+    {
+        $rawIds = array_map(static fn (ModelId $m): string => $m->value, $models->toArray());
+        $cacheItem = $this->cache->getItem(self::CACHE_KEY);
+        $cacheItem->set($rawIds);
+        $cacheItem->expiresAfter(self::CACHE_TTL);
+        $this->cache->save($cacheItem);
     }
 
     private function fetchFreeModels(): ModelIdCollection
@@ -129,7 +237,6 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
             return $this->toCollection($cached);
         }
 
-        // No cache, return empty — callers should fall back to openrouter/free
         return new ModelIdCollection();
     }
 
@@ -139,17 +246,5 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
     private function toCollection(array $ids): ModelIdCollection
     {
         return new ModelIdCollection(array_map(static fn (string $id): ModelId => new ModelId($id), $ids));
-    }
-
-    private function openCircuitBreaker(): void
-    {
-        $item = $this->cache->getItem(self::CIRCUIT_BREAKER_KEY);
-        $item->set(true);
-        $item->expiresAfter(self::CIRCUIT_BREAKER_RESET_SECONDS);
-        $this->cache->save($item);
-
-        $this->logger->warning('Circuit breaker opened for model discovery ({seconds}s)', [
-            'seconds' => self::CIRCUIT_BREAKER_RESET_SECONDS,
-        ]);
     }
 }

--- a/src/Shared/AI/ValueObject/CircuitBreakerState.php
+++ b/src/Shared/AI/ValueObject/CircuitBreakerState.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\AI\ValueObject;
+
+enum CircuitBreakerState: string
+{
+    case Closed = 'closed';
+    case Open = 'open';
+    case HalfOpen = 'half_open';
+}

--- a/tests/Unit/Shared/AI/Service/ModelDiscoveryServiceTest.php
+++ b/tests/Unit/Shared/AI/Service/ModelDiscoveryServiceTest.php
@@ -5,20 +5,251 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Shared\AI\Service;
 
 use App\Shared\AI\Service\ModelDiscoveryService;
+use App\Shared\AI\ValueObject\CircuitBreakerState;
 use App\Shared\AI\ValueObject\ModelId;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
 #[CoversClass(ModelDiscoveryService::class)]
+#[UsesClass(CircuitBreakerState::class)]
 final class ModelDiscoveryServiceTest extends TestCase
 {
+    private const string BREAKER_KEY = 'openrouter_cb';
+
     public function testDiscoversFreeModels(): void
     {
-        $responseBody = json_encode([
+        $service = $this->createService($this->successClient());
+
+        $models = $service->discoverFreeModels();
+
+        self::assertCount(2, $models);
+        self::assertContainsOnlyInstancesOf(ModelId::class, $models->toArray());
+
+        $values = array_map(static fn (ModelId $m): string => $m->value, $models->toArray());
+        self::assertContains('free-model-1', $values);
+        self::assertContains('free-model-2', $values);
+        self::assertNotContains('paid-model', $values);
+        self::assertNotContains('free-small', $values);
+    }
+
+    public function testFilterBlockedModels(): void
+    {
+        $service = $this->createService(
+            $this->clientWithModels([
+                [
+                    'id' => 'good-model',
+                    'context_length' => 32768,
+                    'pricing' => [
+                        'prompt' => '0',
+                        'completion' => '0',
+                    ],
+                ],
+                [
+                    'id' => 'blocked-model',
+                    'context_length' => 32768,
+                    'pricing' => [
+                        'prompt' => '0',
+                        'completion' => '0',
+                    ],
+                ],
+            ]),
+            blockedModels: 'blocked-model',
+        );
+
+        $models = $service->discoverFreeModels();
+
+        self::assertCount(1, $models);
+        $first = $models->first();
+        self::assertInstanceOf(ModelId::class, $first);
+        self::assertSame('good-model', $first->value);
+    }
+
+    public function testCachesResults(): void
+    {
+        $callCount = 0;
+        $factory = function () use (&$callCount): MockResponse {
+            $callCount++;
+
+            return new MockResponse($this->modelsJson());
+        };
+
+        $service = $this->createService(new MockHttpClient($factory));
+
+        $service->discoverFreeModels();
+        $service->discoverFreeModels();
+
+        self::assertSame(1, $callCount);
+    }
+
+    public function testCircuitBreakerOpensAfterThresholdFailures(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+        $service = $this->createService($this->failingClient(), cache: $cache, clock: $clock);
+
+        // Three failures should open circuit breaker (persisted across instances)
+        $service->discoverFreeModels();
+
+        // Simulate new request (new service instance, same cache)
+        $service2 = $this->createService($this->failingClient(), cache: $cache, clock: $clock);
+        $service2->discoverFreeModels();
+
+        $service3 = $this->createService($this->failingClient(), cache: $cache, clock: $clock);
+        $service3->discoverFreeModels();
+
+        // Verify breaker is open in cache
+        $breakerItem = $cache->getItem(self::BREAKER_KEY);
+        self::assertTrue($breakerItem->isHit());
+
+        /** @var array{state: string, failures: int, opened_at: ?int} $data */
+        $data = $breakerItem->get();
+        self::assertSame(CircuitBreakerState::Open->value, $data['state']);
+    }
+
+    public function testOpenBreakerReturnsCachedModelsWithoutApiCall(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        // Pre-populate model cache
+        $populateService = $this->createService($this->successClient(), cache: $cache, clock: $clock);
+        $populateService->discoverFreeModels();
+
+        // Open the breaker (opened_at = now, so not expired)
+        $this->setBreakerState($cache, CircuitBreakerState::Open, openedAt: $clock->now()->getTimestamp());
+
+        // New call should return cached models without hitting API
+        $apiCallCount = 0;
+        $factory = function () use (&$apiCallCount): MockResponse {
+            $apiCallCount++;
+
+            return new MockResponse('error', [
+                'error' => 'should not be called',
+            ]);
+        };
+
+        $service = $this->createService(new MockHttpClient($factory), cache: $cache, clock: $clock);
+        $models = $service->discoverFreeModels();
+
+        self::assertSame(0, $apiCallCount);
+        self::assertCount(2, $models);
+    }
+
+    public function testHalfOpenAfterResetPeriod(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        // Open breaker at time 0
+        $this->setBreakerState($cache, CircuitBreakerState::Open, openedAt: $clock->now()->getTimestamp());
+
+        // Advance clock past reset period (24h)
+        $clock->modify('+25 hours');
+
+        // Service should detect expired Open → HalfOpen → probe API
+        $service = $this->createService($this->successClient(), cache: $cache, clock: $clock);
+        $models = $service->discoverFreeModels();
+
+        self::assertCount(2, $models);
+
+        // Breaker should be reset after successful probe
+        $breakerItem = $cache->getItem(self::BREAKER_KEY);
+        self::assertFalse($breakerItem->isHit());
+    }
+
+    public function testHalfOpenProbeFailureReopensBreaker(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        // Open breaker at time 0
+        $this->setBreakerState($cache, CircuitBreakerState::Open, openedAt: $clock->now()->getTimestamp());
+
+        // Advance clock past reset period
+        $clock->modify('+25 hours');
+
+        // Probe request fails
+        $service = $this->createService($this->failingClient(), cache: $cache, clock: $clock);
+        $service->discoverFreeModels();
+
+        // Breaker should be re-opened
+        $breakerItem = $cache->getItem(self::BREAKER_KEY);
+        self::assertTrue($breakerItem->isHit());
+
+        /** @var array{state: string, failures: int, opened_at: ?int} $data */
+        $data = $breakerItem->get();
+        self::assertSame(CircuitBreakerState::Open->value, $data['state']);
+    }
+
+    public function testFailureCountPersistsAcrossInstances(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        // Two failures from separate instances
+        $service1 = $this->createService($this->failingClient(), cache: $cache, clock: $clock);
+        $service1->discoverFreeModels();
+
+        $service2 = $this->createService($this->failingClient(), cache: $cache, clock: $clock);
+        $service2->discoverFreeModels();
+
+        // Verify failure count is 2 (not 1)
+        $breakerItem = $cache->getItem(self::BREAKER_KEY);
+        self::assertTrue($breakerItem->isHit());
+
+        /** @var array{state: string, failures: int, opened_at: ?int} $data */
+        $data = $breakerItem->get();
+        self::assertSame(2, $data['failures']);
+    }
+
+    private function createService(
+        MockHttpClient $client,
+        ?ArrayAdapter $cache = null,
+        ?MockClock $clock = null,
+        string $blockedModels = '',
+    ): ModelDiscoveryService {
+        return new ModelDiscoveryService(
+            $client,
+            $cache ?? new ArrayAdapter(),
+            $clock ?? new MockClock(),
+            new NullLogger(),
+            $blockedModels,
+        );
+    }
+
+    private function successClient(): MockHttpClient
+    {
+        return new MockHttpClient(new MockResponse($this->modelsJson()));
+    }
+
+    private function failingClient(): MockHttpClient
+    {
+        return new MockHttpClient(new MockResponse('', [
+            'error' => 'timeout',
+        ]));
+    }
+
+    /**
+     * @param list<array{id: string, context_length: int, pricing: array{prompt: string, completion: string}}> $models
+     */
+    private function clientWithModels(array $models): MockHttpClient
+    {
+        return new MockHttpClient(new MockResponse(
+            json_encode([
+                'data' => $models,
+            ], JSON_THROW_ON_ERROR),
+        ));
+    }
+
+    private function modelsJson(): string
+    {
+        return json_encode([
             'data' => [
                 [
                     'id' => 'free-model-1',
@@ -54,106 +285,21 @@ final class ModelDiscoveryServiceTest extends TestCase
                 ],
             ],
         ], JSON_THROW_ON_ERROR);
-
-        $client = new MockHttpClient(new MockResponse($responseBody));
-        $service = new ModelDiscoveryService($client, new ArrayAdapter(), new NullLogger());
-
-        $models = $service->discoverFreeModels();
-
-        self::assertCount(2, $models);
-        self::assertContainsOnlyInstancesOf(ModelId::class, $models->toArray());
-
-        $values = array_map(static fn (ModelId $m): string => $m->value, $models->toArray());
-        self::assertContains('free-model-1', $values);
-        self::assertContains('free-model-2', $values);
-        self::assertNotContains('paid-model', $values);
-        self::assertNotContains('free-small', $values); // context_length < 8192
     }
 
-    public function testFilterBlockedModels(): void
-    {
-        $responseBody = json_encode([
-            'data' => [
-                [
-                    'id' => 'good-model',
-                    'context_length' => 32768,
-                    'pricing' => [
-                        'prompt' => '0',
-                        'completion' => '0',
-                    ],
-                ],
-                [
-                    'id' => 'blocked-model',
-                    'context_length' => 32768,
-                    'pricing' => [
-                        'prompt' => '0',
-                        'completion' => '0',
-                    ],
-                ],
-            ],
-        ], JSON_THROW_ON_ERROR);
-
-        $client = new MockHttpClient(new MockResponse($responseBody));
-        $service = new ModelDiscoveryService(
-            $client,
-            new ArrayAdapter(),
-            new NullLogger(),
-            'blocked-model',
-        );
-
-        $models = $service->discoverFreeModels();
-
-        self::assertCount(1, $models);
-        self::assertContainsOnlyInstancesOf(ModelId::class, $models->toArray());
-
-        $first = $models->first();
-        self::assertInstanceOf(ModelId::class, $first);
-        self::assertSame('good-model', $first->value);
-    }
-
-    public function testCachesResults(): void
-    {
-        $callCount = 0;
-        $body = json_encode([
-            'data' => [[
-                'id' => 'cached-model',
-                'context_length' => 32768,
-                'pricing' => [
-                    'prompt' => '0',
-                    'completion' => '0',
-                ],
-            ]],
-        ], JSON_THROW_ON_ERROR);
-
-        $factory = static function () use (&$callCount, $body): MockResponse {
-            $callCount++;
-
-            return new MockResponse($body);
-        };
-
-        $client = new MockHttpClient($factory);
-        $service = new ModelDiscoveryService($client, new ArrayAdapter(), new NullLogger());
-
-        $service->discoverFreeModels();
-        $service->discoverFreeModels();
-
-        self::assertSame(1, $callCount);
-    }
-
-    public function testCircuitBreakerOpensAfterThreeFailures(): void
-    {
-        $client = new MockHttpClient(new MockResponse('', [
-            'error' => 'timeout',
-        ]));
-        $service = new ModelDiscoveryService($client, new ArrayAdapter(), new NullLogger());
-
-        // Three failures should open circuit breaker
-        $service->discoverFreeModels();
-        $service->discoverFreeModels();
-        $service->discoverFreeModels();
-
-        // Fourth call should not hit the API (circuit breaker open)
-        $models = $service->discoverFreeModels();
-        self::assertTrue($models->isEmpty()); // empty because no cache exists
+    private function setBreakerState(
+        ArrayAdapter $cache,
+        CircuitBreakerState $state,
+        int $failures = 3,
+        ?int $openedAt = null,
+    ): void {
+        $item = $cache->getItem(self::BREAKER_KEY);
+        $item->set([
+            'state' => $state->value,
+            'failures' => $failures,
+            'opened_at' => $openedAt ?? 1_735_689_600,
+        ]);
+        $item->expiresAfter(172_800);
+        $cache->save($item);
     }
 }


### PR DESCRIPTION
## Summary

Closes #42

The circuit breaker's failure counter was stored as an in-memory instance property that reset every PHP-FPM request. Since `discoverFreeModels()` runs once per request, the breaker could **never trip** (required 3 consecutive failures in a single request).

### Changes

- Persist failure count + state to PSR-6 cache (survives across requests)
- Add `CircuitBreakerState` enum: `Closed`, `Open`, `HalfOpen`
- Implement half-open state: after 24h reset period, allow one probe request
  - Probe succeeds → reset to Closed
  - Probe fails → reopen breaker
- Store `opened_at` timestamp for expiry detection (uses `ClockInterface`)

## Test plan

- [x] `testCircuitBreakerOpensAfterThresholdFailures` — 3 failures across separate instances opens breaker
- [x] `testFailureCountPersistsAcrossInstances` — verifies cache persistence
- [x] `testOpenBreakerReturnsCachedModelsWithoutApiCall` — open breaker skips API
- [x] `testHalfOpenAfterResetPeriod` — expired open → half-open → successful probe → closed
- [x] `testHalfOpenProbeFailureReopensBreaker` — failed probe → back to open
- [x] All quality checks pass (`make quality`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)