### PR TITLE
refactor: break up FetchSourceHandler into focused services

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Article\MessageHandler\FetchSourceHandler;
 use App\Article\Service\AiDeduplicationService;
 use App\Article\Service\DeduplicationService;
 use App\Article\Service\DeduplicationServiceInterface;
@@ -11,6 +10,7 @@ use App\Enrichment\Service\AiCategorizationService;
 use App\Enrichment\Service\AiKeywordExtractionService;
 use App\Enrichment\Service\AiSummarizationService;
 use App\Enrichment\Service\AiTranslationService;
+use App\Enrichment\Service\ArticleEnrichmentService;
 use App\Enrichment\Service\CategorizationServiceInterface;
 use App\Enrichment\Service\KeywordExtractionServiceInterface;
 use App\Enrichment\Service\SummarizationServiceInterface;
@@ -165,8 +165,8 @@ return static function (ContainerConfigurator $container): void {
     $services->set(NotificationDispatchService::class)
         ->arg('$notifierDsn', '%env(default::NOTIFIER_CHATTER_DSN)%');
 
-    // Wire DISPLAY_LANGUAGES env var for FetchSourceHandler
-    $services->set(FetchSourceHandler::class)
+    // Wire DISPLAY_LANGUAGES env var for ArticleEnrichmentService
+    $services->set(ArticleEnrichmentService::class)
         ->arg('$displayLanguages', '%env(string:DISPLAY_LANGUAGES)%');
 
     // Search: SEAL/Loupe engine wired by argument name (loupeEngine → cmsig_seal.engine.loupe alias)

--- a/src/Article/MessageHandler/FetchSourceHandler.php
+++ b/src/Article/MessageHandler/FetchSourceHandler.php
@@ -7,21 +7,12 @@ namespace App\Article\MessageHandler;
 use App\Article\Entity\Article;
 use App\Article\Repository\ArticleRepositoryInterface;
 use App\Article\Service\DeduplicationServiceInterface;
-use App\Article\Service\ScoringServiceInterface;
 use App\Article\ValueObject\ArticleCollection;
 use App\Article\ValueObject\ArticleFingerprint;
 use App\Article\ValueObject\FetchResult;
 use App\Article\ValueObject\PersistItemResult;
-use App\Enrichment\Service\CategorizationServiceInterface;
-use App\Enrichment\Service\KeywordExtractionServiceInterface;
-use App\Enrichment\Service\SummarizationServiceInterface;
-use App\Enrichment\Service\TranslationServiceInterface;
-use App\Enrichment\ValueObject\EnrichmentResult;
-use App\Notification\Message\SendNotificationMessage;
-use App\Notification\Service\ArticleMatcherServiceInterface;
-use App\Shared\Entity\Category;
-use App\Shared\Repository\CategoryRepositoryInterface;
-use App\Shared\ValueObject\EnrichmentMethod;
+use App\Enrichment\Service\ArticleEnrichmentServiceInterface;
+use App\Notification\Service\AlertDispatchServiceInterface;
 use App\Source\Entity\Source;
 use App\Source\Exception\FeedFetchException;
 use App\Source\Message\FetchSourceMessage;
@@ -34,41 +25,22 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
 final readonly class FetchSourceHandler
 {
-    /**
-     * @var list<string>
-     */
-    private array $parsedDisplayLanguages;
-
     public function __construct(
         private ArticleRepositoryInterface $articleRepository,
         private SourceRepositoryInterface $sourceRepository,
-        private CategoryRepositoryInterface $categoryRepository,
         private EntityManagerInterface $entityManager,
         private FeedFetcherServiceInterface $feedFetcher,
         private FeedParserServiceInterface $feedParser,
         private DeduplicationServiceInterface $deduplication,
-        private CategorizationServiceInterface $categorization,
-        private SummarizationServiceInterface $summarization,
-        private TranslationServiceInterface $translation,
-        private KeywordExtractionServiceInterface $keywordExtraction,
-        private ScoringServiceInterface $scoring,
-        private ArticleMatcherServiceInterface $articleMatcher,
-        private MessageBusInterface $messageBus,
+        private ArticleEnrichmentServiceInterface $enrichment,
+        private AlertDispatchServiceInterface $alertDispatch,
         private ClockInterface $clock,
         private LoggerInterface $logger,
-        private string $displayLanguages = 'en',
     ) {
-        $this->parsedDisplayLanguages = array_values(
-            array_filter(
-                array_map(trim(...), explode(',', $this->displayLanguages)),
-                static fn (string $lang): bool => $lang !== '',
-            ),
-        );
     }
 
     public function __invoke(FetchSourceMessage $message): void
@@ -88,7 +60,7 @@ final readonly class FetchSourceHandler
             if ($result->source instanceof Source) {
                 $result->source->recordSuccess($now);
                 $this->articleRepository->flush();
-                $this->dispatchAlerts($result->newArticles);
+                $this->alertDispatch->dispatchAlerts($result->newArticles);
                 $this->logger->info('Fetched {source}: {count} new articles from {total} items', [
                     'source' => $result->source->getName(),
                     'count' => $result->persistedCount,
@@ -135,11 +107,6 @@ final readonly class FetchSourceHandler
         return new FetchResult($persisted, new ArticleCollection($newArticles), $source);
     }
 
-    /**
-     * Attempts to build and persist one article. Returns null if the EM is
-     * irrecoverably broken and the loop must abort, or a PersistItemResult
-     * otherwise (article is null when the item was skipped due to an error).
-     */
     private function persistItem(
         FeedItem $item,
         Source $source,
@@ -148,7 +115,13 @@ final readonly class FetchSourceHandler
         ?string $fingerprint,
     ): ?PersistItemResult {
         try {
-            $article = $this->buildArticle($item, $source, $now, $fingerprint);
+            $article = new Article($item->title, $item->url, $source, $now);
+            $article->setContentRaw($item->contentRaw);
+            $article->setContentText($item->contentText);
+            $article->setPublishedAt($item->publishedAt);
+            $article->setFingerprint($fingerprint);
+
+            $this->enrichment->enrich($article, $item, $source);
             $this->articleRepository->save($article, flush: true);
 
             return new PersistItemResult($article, $source);
@@ -166,157 +139,6 @@ final readonly class FetchSourceHandler
             $source = $this->sourceRepository->findById($sourceId);
 
             return $source instanceof Source ? new PersistItemResult(null, $source) : null;
-        }
-    }
-
-    private function buildArticle(
-        FeedItem $item,
-        Source $source,
-        \DateTimeImmutable $now,
-        ?string $fingerprint,
-    ): Article {
-        $article = new Article($item->title, $item->url, $source, $now);
-        $article->setContentRaw($item->contentRaw);
-        $article->setContentText($item->contentText);
-        $article->setPublishedAt($item->publishedAt);
-        $article->setFingerprint($fingerprint);
-
-        $catResult = $this->categorization->categorize($item->title, $item->contentText);
-        $this->applyCategory($article, $catResult, $source);
-
-        if ($item->contentText !== null) {
-            $sumResult = $this->summarization->summarize($item->contentText);
-            $this->applyEnrichment($article, $catResult, $sumResult);
-        }
-
-        // Extract keywords before translation so they're available in the translations map
-        $keywords = $this->keywordExtraction->extract($item->title, $item->contentText);
-        if ($keywords !== []) {
-            $article->setKeywords($keywords);
-        }
-
-        $this->applyTranslation($article, $source);
-
-        $article->setScore($this->scoring->score($article));
-
-        return $article;
-    }
-
-    private function applyCategory(Article $article, EnrichmentResult $catResult, Source $source): void
-    {
-        if ($catResult->value !== null) {
-            $category = $this->categoryRepository->findBySlug($catResult->value);
-            if ($category instanceof Category) {
-                $article->setCategory($category);
-            }
-        }
-
-        if (! $article->getCategory() instanceof Category) {
-            $article->setCategory($source->getCategory());
-        }
-    }
-
-    private function applyEnrichment(Article $article, EnrichmentResult $catResult, EnrichmentResult $sumResult): void
-    {
-        if ($sumResult->value === null) {
-            return;
-        }
-
-        $article->setSummary($sumResult->value);
-
-        $aiResult = $sumResult->method === EnrichmentMethod::Ai ? $sumResult : null;
-        $aiResult ??= $catResult->method === EnrichmentMethod::Ai ? $catResult : null;
-
-        $article->setEnrichmentMethod($aiResult instanceof EnrichmentResult ? EnrichmentMethod::Ai : EnrichmentMethod::RuleBased);
-        $article->setAiModelUsed($aiResult?->modelUsed);
-    }
-
-    private function applyTranslation(Article $article, Source $source): void
-    {
-        $sourceLanguage = $source->getLanguage() ?? 'en';
-        $originalTitle = $article->getTitle();
-        $originalSummary = $article->getSummary();
-
-        // Store originals in the source language (backward compat)
-        $article->setTitleOriginal($originalTitle);
-        $article->setSummaryOriginal($originalSummary);
-
-        // Build translations map for all display languages
-        $translations = [];
-        $originalKeywords = $article->getKeywords() ?? [];
-
-        // Source language entry — always the original text, no API call
-        $translations[$sourceLanguage] = [
-            'title' => $originalTitle,
-            'summary' => $originalSummary,
-            'keywords' => $originalKeywords,
-        ];
-
-        foreach ($this->parsedDisplayLanguages as $targetLang) {
-            if ($targetLang === $sourceLanguage) {
-                continue;
-            }
-
-            $translations[$targetLang] = $this->translateToLanguage($originalTitle, $originalSummary, $originalKeywords, $sourceLanguage, $targetLang);
-        }
-
-        $article->setTranslations($translations);
-
-        // Set the primary display language (first display language, or English)
-        $primaryLang = $this->parsedDisplayLanguages[0] ?? 'en';
-        if ($primaryLang !== $sourceLanguage && isset($translations[$primaryLang])) {
-            $article->setTitle($translations[$primaryLang]['title']);
-            if ($translations[$primaryLang]['summary'] !== null) {
-                $article->setSummary($translations[$primaryLang]['summary']);
-            }
-        }
-    }
-
-    /**
-     * @param list<string> $keywords
-     *
-     * @return array{title: string, summary: ?string, keywords: list<string>}
-     */
-    private function translateToLanguage(string $title, ?string $summary, array $keywords, string $from, string $to): array
-    {
-        $translatedTitle = $this->translation->translate($title, $from, $to);
-        $translatedSummary = $summary !== null
-            ? $this->translation->translate($summary, $from, $to)
-            : null;
-
-        $translatedKeywords = $keywords;
-        if ($keywords !== []) {
-            $keywordsText = implode(', ', $keywords);
-            $translatedText = $this->translation->translate($keywordsText, $from, $to);
-            $translatedKeywords = array_map('trim', explode(',', $translatedText));
-        }
-
-        return [
-            'title' => $translatedTitle,
-            'summary' => $translatedSummary,
-            'keywords' => $translatedKeywords,
-        ];
-    }
-
-    private function dispatchAlerts(ArticleCollection $articles): void
-    {
-        foreach ($articles as $article) {
-            $articleId = $article->getId();
-            if ($articleId === null) {
-                continue;
-            }
-
-            $matches = $this->articleMatcher->match($article);
-            foreach ($matches as $match) {
-                $ruleId = $match->alertRule->getId();
-                if ($ruleId === null) {
-                    continue;
-                }
-
-                $this->messageBus->dispatch(
-                    new SendNotificationMessage($ruleId, $articleId, $match->matchedKeywords),
-                );
-            }
         }
     }
 }

--- a/src/Enrichment/Service/ArticleEnrichmentService.php
+++ b/src/Enrichment/Service/ArticleEnrichmentService.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enrichment\Service;
+
+use App\Article\Entity\Article;
+use App\Article\Service\ScoringServiceInterface;
+use App\Enrichment\ValueObject\EnrichmentResult;
+use App\Shared\Entity\Category;
+use App\Shared\Repository\CategoryRepositoryInterface;
+use App\Shared\ValueObject\EnrichmentMethod;
+use App\Source\Entity\Source;
+use App\Source\Service\FeedItem;
+
+final readonly class ArticleEnrichmentService implements ArticleEnrichmentServiceInterface
+{
+    /**
+     * @var list<string>
+     */
+    private array $parsedDisplayLanguages;
+
+    public function __construct(
+        private CategorizationServiceInterface $categorization,
+        private SummarizationServiceInterface $summarization,
+        private TranslationServiceInterface $translation,
+        private KeywordExtractionServiceInterface $keywordExtraction,
+        private ScoringServiceInterface $scoring,
+        private CategoryRepositoryInterface $categoryRepository,
+        private string $displayLanguages = 'en',
+    ) {
+        $this->parsedDisplayLanguages = array_values(
+            array_filter(
+                array_map(trim(...), explode(',', $this->displayLanguages)),
+                static fn (string $lang): bool => $lang !== '',
+            ),
+        );
+    }
+
+    public function enrich(Article $article, FeedItem $item, Source $source): void
+    {
+        $catResult = $this->categorization->categorize($item->title, $item->contentText);
+        $this->applyCategory($article, $catResult, $source);
+
+        if ($item->contentText !== null) {
+            $sumResult = $this->summarization->summarize($item->contentText);
+            $this->applyEnrichment($article, $catResult, $sumResult);
+        }
+
+        $keywords = $this->keywordExtraction->extract($item->title, $item->contentText);
+        if ($keywords !== []) {
+            $article->setKeywords($keywords);
+        }
+
+        $this->applyTranslation($article, $source);
+        $article->setScore($this->scoring->score($article));
+    }
+
+    private function applyCategory(Article $article, EnrichmentResult $catResult, Source $source): void
+    {
+        if ($catResult->value !== null) {
+            $category = $this->categoryRepository->findBySlug($catResult->value);
+            if ($category instanceof Category) {
+                $article->setCategory($category);
+            }
+        }
+
+        if (! $article->getCategory() instanceof Category) {
+            $article->setCategory($source->getCategory());
+        }
+    }
+
+    private function applyEnrichment(Article $article, EnrichmentResult $catResult, EnrichmentResult $sumResult): void
+    {
+        if ($sumResult->value === null) {
+            return;
+        }
+
+        $article->setSummary($sumResult->value);
+
+        $aiResult = $sumResult->method === EnrichmentMethod::Ai ? $sumResult : null;
+        $aiResult ??= $catResult->method === EnrichmentMethod::Ai ? $catResult : null;
+
+        $article->setEnrichmentMethod($aiResult instanceof EnrichmentResult ? EnrichmentMethod::Ai : EnrichmentMethod::RuleBased);
+        $article->setAiModelUsed($aiResult?->modelUsed);
+    }
+
+    private function applyTranslation(Article $article, Source $source): void
+    {
+        $sourceLanguage = $source->getLanguage() ?? 'en';
+        $originalTitle = $article->getTitle();
+        $originalSummary = $article->getSummary();
+
+        $article->setTitleOriginal($originalTitle);
+        $article->setSummaryOriginal($originalSummary);
+
+        $translations = [];
+        $originalKeywords = $article->getKeywords() ?? [];
+
+        $translations[$sourceLanguage] = [
+            'title' => $originalTitle,
+            'summary' => $originalSummary,
+            'keywords' => $originalKeywords,
+        ];
+
+        foreach ($this->parsedDisplayLanguages as $targetLang) {
+            if ($targetLang === $sourceLanguage) {
+                continue;
+            }
+
+            $translations[$targetLang] = $this->translateToLanguage($originalTitle, $originalSummary, $originalKeywords, $sourceLanguage, $targetLang);
+        }
+
+        $article->setTranslations($translations);
+
+        $primaryLang = $this->parsedDisplayLanguages[0] ?? 'en';
+        if ($primaryLang !== $sourceLanguage && isset($translations[$primaryLang])) {
+            $article->setTitle($translations[$primaryLang]['title']);
+            if ($translations[$primaryLang]['summary'] !== null) {
+                $article->setSummary($translations[$primaryLang]['summary']);
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $keywords
+     *
+     * @return array{title: string, summary: ?string, keywords: list<string>}
+     */
+    private function translateToLanguage(string $title, ?string $summary, array $keywords, string $from, string $to): array
+    {
+        $translatedTitle = $this->translation->translate($title, $from, $to);
+        $translatedSummary = $summary !== null
+            ? $this->translation->translate($summary, $from, $to)
+            : null;
+
+        $translatedKeywords = $keywords;
+        if ($keywords !== []) {
+            $keywordsText = implode(', ', $keywords);
+            $translatedText = $this->translation->translate($keywordsText, $from, $to);
+            $translatedKeywords = array_map('trim', explode(',', $translatedText));
+        }
+
+        return [
+            'title' => $translatedTitle,
+            'summary' => $translatedSummary,
+            'keywords' => $translatedKeywords,
+        ];
+    }
+}

--- a/src/Enrichment/Service/ArticleEnrichmentServiceInterface.php
+++ b/src/Enrichment/Service/ArticleEnrichmentServiceInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enrichment\Service;
+
+use App\Article\Entity\Article;
+use App\Source\Entity\Source;
+use App\Source\Service\FeedItem;
+
+interface ArticleEnrichmentServiceInterface
+{
+    public function enrich(Article $article, FeedItem $item, Source $source): void;
+}

--- a/src/Notification/Service/AlertDispatchService.php
+++ b/src/Notification/Service/AlertDispatchService.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Service;
+
+use App\Article\ValueObject\ArticleCollection;
+use App\Notification\Message\SendNotificationMessage;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final readonly class AlertDispatchService implements AlertDispatchServiceInterface
+{
+    public function __construct(
+        private ArticleMatcherServiceInterface $articleMatcher,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function dispatchAlerts(ArticleCollection $articles): void
+    {
+        foreach ($articles as $article) {
+            $articleId = $article->getId();
+            if ($articleId === null) {
+                continue;
+            }
+
+            $matches = $this->articleMatcher->match($article);
+            foreach ($matches as $match) {
+                $ruleId = $match->alertRule->getId();
+                if ($ruleId === null) {
+                    continue;
+                }
+
+                $this->messageBus->dispatch(
+                    new SendNotificationMessage($ruleId, $articleId, $match->matchedKeywords),
+                );
+            }
+        }
+    }
+}

--- a/src/Notification/Service/AlertDispatchServiceInterface.php
+++ b/src/Notification/Service/AlertDispatchServiceInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Service;
+
+use App\Article\ValueObject\ArticleCollection;
+
+interface AlertDispatchServiceInterface
+{
+    public function dispatchAlerts(ArticleCollection $articles): void;
+}

--- a/tests/Unit/Article/MessageHandler/FetchSourceHandlerTest.php
+++ b/tests/Unit/Article/MessageHandler/FetchSourceHandlerTest.php
@@ -8,16 +8,9 @@ use App\Article\Entity\Article;
 use App\Article\MessageHandler\FetchSourceHandler;
 use App\Article\Repository\ArticleRepositoryInterface;
 use App\Article\Service\DeduplicationServiceInterface;
-use App\Article\Service\ScoringServiceInterface;
-use App\Enrichment\Service\CategorizationServiceInterface;
-use App\Enrichment\Service\KeywordExtractionServiceInterface;
-use App\Enrichment\Service\SummarizationServiceInterface;
-use App\Enrichment\Service\TranslationServiceInterface;
-use App\Enrichment\ValueObject\EnrichmentResult;
-use App\Notification\Service\ArticleMatcherServiceInterface;
+use App\Enrichment\Service\ArticleEnrichmentServiceInterface;
+use App\Notification\Service\AlertDispatchServiceInterface;
 use App\Shared\Entity\Category;
-use App\Shared\Repository\CategoryRepositoryInterface;
-use App\Shared\ValueObject\EnrichmentMethod;
 use App\Source\Entity\Source;
 use App\Source\Exception\FeedFetchException;
 use App\Source\Message\FetchSourceMessage;
@@ -33,7 +26,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Clock\MockClock;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 #[CoversClass(FetchSourceHandler::class)]
 final class FetchSourceHandlerTest extends TestCase
@@ -80,39 +72,20 @@ final class FetchSourceHandlerTest extends TestCase
         $dedup = $this->createStub(DeduplicationServiceInterface::class);
         $dedup->method('isDuplicate')->willReturn(false);
 
-        $categorization = $this->createStub(CategorizationServiceInterface::class);
-        $categorization->method('categorize')->willReturn(new EnrichmentResult(null, EnrichmentMethod::RuleBased));
-
-        $summarization = $this->createStub(SummarizationServiceInterface::class);
-        $summarization->method('summarize')->willReturn(new EnrichmentResult('A test summary.', EnrichmentMethod::RuleBased));
-
-        $keywordExtraction = $this->createStub(KeywordExtractionServiceInterface::class);
-        $keywordExtraction->method('extract')->willReturn(['Test', 'Keyword']);
-
-        $translation = $this->createStub(TranslationServiceInterface::class);
-        $translation->method('translate')->willReturnArgument(0);
-
         $em = $this->createStub(EntityManagerInterface::class);
         $em->method('isOpen')->willReturn(true);
 
         $this->handler = new FetchSourceHandler(
             $this->articleRepository,
             $this->sourceRepository,
-            $this->createStub(CategoryRepositoryInterface::class),
             $em,
             $this->fetcher,
             $this->parser,
             $dedup,
-            $categorization,
-            $summarization,
-            $translation,
-            $keywordExtraction,
-            $this->createStub(ScoringServiceInterface::class),
-            $this->createStub(ArticleMatcherServiceInterface::class),
-            $this->createStub(MessageBusInterface::class),
+            $this->createStub(ArticleEnrichmentServiceInterface::class),
+            $this->createStub(AlertDispatchServiceInterface::class),
             $this->clock,
             new NullLogger(),
-            'en',
         );
     }
 
@@ -134,9 +107,6 @@ final class FetchSourceHandlerTest extends TestCase
         self::assertCount(2, $saved);
         self::assertSame('Article 1', $saved[0]->getTitle());
         self::assertSame(SourceHealth::Healthy, $this->source->getHealthStatus());
-        // First article has content, so it gets rule-based enrichment
-        self::assertSame(EnrichmentMethod::RuleBased, $saved[0]->getEnrichmentMethod());
-        self::assertSame('A test summary.', $saved[0]->getSummary());
     }
 
     public function testRecordsFailureOnFetchError(): void


### PR DESCRIPTION
## Summary

Closes #43

Extract two focused services from FetchSourceHandler (322 lines, 17 deps → 135 lines, 10 deps):

- **`ArticleEnrichmentService`** (Enrichment module) — categorization, summarization, keyword extraction, translation, scoring
- **`AlertDispatchService`** (Notification module) — alert rule matching + notification message dispatch

FetchSourceHandler is now a thin orchestrator: fetch → parse → dedup → enrich → persist → dispatch alerts.

## Test plan

- [x] All 175 tests pass (`make test`)
- [x] PHPStan clean (`make phpstan`)
- [x] ECS clean (`make ecs`)
- [x] Rector clean (`make rector`)
- [x] No phpat architectural dependency violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)