### PR TITLE
fix: AiSummarizationService bypasses quality gate

### DIFF
--- a/src/Enrichment/Service/AiSummarizationService.php
+++ b/src/Enrichment/Service/AiSummarizationService.php
@@ -24,11 +24,12 @@ PROMPT;
     public function __construct(
         private PlatformInterface $platform,
         private RuleBasedSummarizationService $ruleBasedFallback,
+        private AiQualityGateServiceInterface $qualityGate,
         private LoggerInterface $logger,
     ) {
     }
 
-    public function summarize(string $contentText): EnrichmentResult
+    public function summarize(string $contentText, string $title = ''): EnrichmentResult
     {
         try {
             $prompt = sprintf(self::PROMPT_TEMPLATE, mb_substr($contentText, 0, 2000));
@@ -36,13 +37,12 @@ PROMPT;
             $input = new MessageBag(Message::ofUser($prompt));
             $summary = trim($this->platform->invoke(self::MODEL, $input)->asText());
 
-            $length = mb_strlen($summary);
-            if ($length >= 20 && $length <= 500) {
+            if ($this->qualityGate->validateSummary($summary, $title)) {
                 return new EnrichmentResult($summary, EnrichmentMethod::Ai, self::MODEL);
             }
 
-            $this->logger->info('AI summary rejected: {length} chars (expected 20-500)', [
-                'length' => $length,
+            $this->logger->info('AI summary rejected by quality gate', [
+                'length' => mb_strlen($summary),
                 'model' => self::MODEL,
             ]);
         } catch (\Throwable $e) {
@@ -52,6 +52,6 @@ PROMPT;
             ]);
         }
 
-        return $this->ruleBasedFallback->summarize($contentText);
+        return $this->ruleBasedFallback->summarize($contentText, $title);
     }
 }

--- a/src/Enrichment/Service/ArticleEnrichmentService.php
+++ b/src/Enrichment/Service/ArticleEnrichmentService.php
@@ -43,7 +43,7 @@ final readonly class ArticleEnrichmentService implements ArticleEnrichmentServic
         $this->applyCategory($article, $catResult, $source);
 
         if ($item->contentText !== null) {
-            $sumResult = $this->summarization->summarize($item->contentText);
+            $sumResult = $this->summarization->summarize($item->contentText, $item->title);
             $this->applyEnrichment($article, $catResult, $sumResult);
         }
 

--- a/src/Enrichment/Service/RuleBasedSummarizationService.php
+++ b/src/Enrichment/Service/RuleBasedSummarizationService.php
@@ -13,7 +13,7 @@ final readonly class RuleBasedSummarizationService implements SummarizationServi
 
     private const int MAX_SUMMARY_LENGTH = 500;
 
-    public function summarize(string $contentText): EnrichmentResult
+    public function summarize(string $contentText, string $title = ''): EnrichmentResult
     {
         $text = trim($contentText);
 

--- a/src/Enrichment/Service/SummarizationServiceInterface.php
+++ b/src/Enrichment/Service/SummarizationServiceInterface.php
@@ -12,5 +12,5 @@ interface SummarizationServiceInterface
      * Generate a summary for article content.
      * Returns EnrichmentResult with summary value, method used, and optional model name.
      */
-    public function summarize(string $contentText): EnrichmentResult;
+    public function summarize(string $contentText, string $title = ''): EnrichmentResult;
 }

--- a/tests/Unit/Enrichment/Service/AiSummarizationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiSummarizationServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Enrichment\Service;
 
+use App\Enrichment\Service\AiQualityGateService;
 use App\Enrichment\Service\AiSummarizationService;
 use App\Enrichment\Service\RuleBasedSummarizationService;
 use App\Shared\ValueObject\EnrichmentMethod;
@@ -29,10 +30,11 @@ final class AiSummarizationServiceTest extends TestCase
         $service = new AiSummarizationService(
             $platform,
             new RuleBasedSummarizationService(),
+            new AiQualityGateService(),
             new NullLogger(),
         );
 
-        $result = $service->summarize('Long article content about government economic measures and inflation...');
+        $result = $service->summarize('Long article content about government economic measures and inflation...', 'Economy News');
 
         self::assertSame($aiSummary, $result->value);
         self::assertSame(EnrichmentMethod::Ai, $result->method);
@@ -47,13 +49,13 @@ final class AiSummarizationServiceTest extends TestCase
         $service = new AiSummarizationService(
             $platform,
             new RuleBasedSummarizationService(),
+            new AiQualityGateService(),
             new NullLogger(),
         );
 
         $content = 'This is the first sentence of a long article. This is the second sentence with more detail. And a third one.';
-        $result = $service->summarize($content);
+        $result = $service->summarize($content, 'Test Title');
 
-        // Should get rule-based: first 2 sentences
         self::assertStringContainsString('first sentence', $result->value ?? '');
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
     }
@@ -66,14 +68,34 @@ final class AiSummarizationServiceTest extends TestCase
         $service = new AiSummarizationService(
             $platform,
             new RuleBasedSummarizationService(),
+            new AiQualityGateService(),
             new NullLogger(),
         );
 
         $content = 'This is a sufficiently long article content for testing purposes. It should trigger the rule-based fallback.';
-        $result = $service->summarize($content);
+        $result = $service->summarize($content, 'Test Title');
 
-        // AI response too short, should fall back
         self::assertNotSame('Short.', $result->value);
+        self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+    }
+
+    public function testRejectsSummaryThatMatchesTitle(): void
+    {
+        $title = 'Breaking News: Major Economic Policy Change';
+        $platform = $this->createStub(PlatformInterface::class);
+        $platform->method('invoke')->willReturn($this->makeDeferredResult($title));
+
+        $service = new AiSummarizationService(
+            $platform,
+            new RuleBasedSummarizationService(),
+            new AiQualityGateService(),
+            new NullLogger(),
+        );
+
+        $content = 'This is a sufficiently long article content for testing purposes. It should trigger the rule-based fallback.';
+        $result = $service->summarize($content, $title);
+
+        // Summary that's just the title repeated should be rejected by quality gate
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
     }
 


### PR DESCRIPTION
## Summary

Closes #44

`AiSummarizationService` performed inline length validation (`>= 20 && <= 500`) instead of delegating to `AiQualityGateService.validateSummary()`, which also includes a title-similarity check. This meant AI summaries that were just the title repeated could pass through.

### Changes

- Add `$title` parameter to `SummarizationServiceInterface::summarize()` (with default `''` for backward compat)
- Inject `AiQualityGateServiceInterface` into `AiSummarizationService`
- Replace inline validation with `$this->qualityGate->validateSummary($summary, $title)`
- Add test for title-similarity rejection
- Pass `$item->title` from `ArticleEnrichmentService`

## Test plan

- [x] `testRejectsSummaryThatMatchesTitle` — new test for title-similarity gate
- [x] All quality checks pass (`make quality`)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)