### PR TITLE
refactor: AI decorators inject interfaces instead of concrete classes

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -13,6 +13,10 @@ use App\Enrichment\Service\AiTranslationService;
 use App\Enrichment\Service\ArticleEnrichmentService;
 use App\Enrichment\Service\CategorizationServiceInterface;
 use App\Enrichment\Service\KeywordExtractionServiceInterface;
+use App\Enrichment\Service\RuleBasedCategorizationService;
+use App\Enrichment\Service\RuleBasedKeywordExtractionService;
+use App\Enrichment\Service\RuleBasedSummarizationService;
+use App\Enrichment\Service\RuleBasedTranslationService;
 use App\Enrichment\Service\SummarizationServiceInterface;
 use App\Enrichment\Service\TranslationServiceInterface;
 use App\Notification\Command\LoadAlertRulesCommand;
@@ -106,15 +110,19 @@ return static function (ContainerConfigurator $container): void {
 
     // All AI services use the failover-wrapped platform
     $services->set(AiCategorizationService::class)
+        ->arg('$ruleBasedFallback', service(RuleBasedCategorizationService::class))
         ->arg('$platform', service('ai.platform.openrouter.failover'));
 
     $services->set(AiSummarizationService::class)
+        ->arg('$ruleBasedFallback', service(RuleBasedSummarizationService::class))
         ->arg('$platform', service('ai.platform.openrouter.failover'));
 
     $services->set(AiTranslationService::class)
+        ->arg('$ruleBasedFallback', service(RuleBasedTranslationService::class))
         ->arg('$platform', service('ai.platform.openrouter.failover'));
 
     $services->set(AiKeywordExtractionService::class)
+        ->arg('$ruleBasedFallback', service(RuleBasedKeywordExtractionService::class))
         ->arg('$platform', service('ai.platform.openrouter.failover'));
 
     $services->set(AiDeduplicationService::class)

--- a/src/Enrichment/Service/AiCategorizationService.php
+++ b/src/Enrichment/Service/AiCategorizationService.php
@@ -26,7 +26,7 @@ PROMPT;
 
     public function __construct(
         private PlatformInterface $platform,
-        private RuleBasedCategorizationService $ruleBasedFallback,
+        private CategorizationServiceInterface $ruleBasedFallback,
         private AiQualityGateServiceInterface $qualityGate,
         private LoggerInterface $logger,
     ) {

--- a/src/Enrichment/Service/AiKeywordExtractionService.php
+++ b/src/Enrichment/Service/AiKeywordExtractionService.php
@@ -24,7 +24,7 @@ PROMPT;
 
     public function __construct(
         private PlatformInterface $platform,
-        private RuleBasedKeywordExtractionService $ruleBasedFallback,
+        private KeywordExtractionServiceInterface $ruleBasedFallback,
         private LoggerInterface $logger,
     ) {
     }

--- a/src/Enrichment/Service/AiSummarizationService.php
+++ b/src/Enrichment/Service/AiSummarizationService.php
@@ -23,7 +23,7 @@ PROMPT;
 
     public function __construct(
         private PlatformInterface $platform,
-        private RuleBasedSummarizationService $ruleBasedFallback,
+        private SummarizationServiceInterface $ruleBasedFallback,
         private AiQualityGateServiceInterface $qualityGate,
         private LoggerInterface $logger,
     ) {

--- a/src/Enrichment/Service/AiTranslationService.php
+++ b/src/Enrichment/Service/AiTranslationService.php
@@ -23,7 +23,7 @@ PROMPT;
 
     public function __construct(
         private PlatformInterface $platform,
-        private RuleBasedTranslationService $ruleBasedFallback,
+        private TranslationServiceInterface $ruleBasedFallback,
         private LoggerInterface $logger,
     ) {
     }


### PR DESCRIPTION
## Summary

Closes #45

### Changes

- `AiCategorizationService`: `RuleBasedCategorizationService` → `CategorizationServiceInterface`
- `AiSummarizationService`: `RuleBasedSummarizationService` → `SummarizationServiceInterface`
- `AiTranslationService`: `RuleBasedTranslationService` → `TranslationServiceInterface`
- `AiKeywordExtractionService`: `RuleBasedKeywordExtractionService` → `KeywordExtractionServiceInterface`
- DI config wires rule-based implementations via named `$ruleBasedFallback` args

## Test plan

- [x] All quality checks pass (`make quality`)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)