### PR TITLE
fix: integrate ModelQualityTracker into AI enrichment services

### DIFF
--- a/src/Enrichment/Service/AiCategorizationService.php
+++ b/src/Enrichment/Service/AiCategorizationService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Enrichment\Service;
 
 use App\Enrichment\ValueObject\EnrichmentResult;
+use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\ValueObject\EnrichmentMethod;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Platform\Message\Message;
@@ -28,6 +29,7 @@ PROMPT;
         private PlatformInterface $platform,
         private CategorizationServiceInterface $ruleBasedFallback,
         private AiQualityGateServiceInterface $qualityGate,
+        private ModelQualityTrackerInterface $qualityTracker,
         private LoggerInterface $logger,
     ) {
     }
@@ -45,9 +47,12 @@ PROMPT;
             $categorySlug = trim(mb_strtolower($this->platform->invoke(self::MODEL, $input)->asText()));
 
             if ($this->qualityGate->validateCategorization($categorySlug)) {
+                $this->qualityTracker->recordAcceptance(self::MODEL);
+
                 return new EnrichmentResult($categorySlug, EnrichmentMethod::Ai, self::MODEL);
             }
 
+            $this->qualityTracker->recordRejection(self::MODEL);
             $this->logger->info('AI categorization rejected by quality gate: {slug}', [
                 'slug' => $categorySlug,
                 'model' => self::MODEL,

--- a/src/Enrichment/Service/AiSummarizationService.php
+++ b/src/Enrichment/Service/AiSummarizationService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Enrichment\Service;
 
 use App\Enrichment\ValueObject\EnrichmentResult;
+use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\ValueObject\EnrichmentMethod;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Platform\Message\Message;
@@ -25,6 +26,7 @@ PROMPT;
         private PlatformInterface $platform,
         private SummarizationServiceInterface $ruleBasedFallback,
         private AiQualityGateServiceInterface $qualityGate,
+        private ModelQualityTrackerInterface $qualityTracker,
         private LoggerInterface $logger,
     ) {
     }
@@ -38,9 +40,12 @@ PROMPT;
             $summary = trim($this->platform->invoke(self::MODEL, $input)->asText());
 
             if ($this->qualityGate->validateSummary($summary, $title)) {
+                $this->qualityTracker->recordAcceptance(self::MODEL);
+
                 return new EnrichmentResult($summary, EnrichmentMethod::Ai, self::MODEL);
             }
 
+            $this->qualityTracker->recordRejection(self::MODEL);
             $this->logger->info('AI summary rejected by quality gate', [
                 'length' => mb_strlen($summary),
                 'model' => self::MODEL,

--- a/tests/Unit/Enrichment/Service/AiCategorizationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiCategorizationServiceTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Enrichment\Service;
 use App\Enrichment\Service\AiCategorizationService;
 use App\Enrichment\Service\AiQualityGateService;
 use App\Enrichment\Service\RuleBasedCategorizationService;
+use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\ValueObject\EnrichmentMethod;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -29,6 +30,7 @@ final class AiCategorizationServiceTest extends TestCase
             $platform,
             new RuleBasedCategorizationService(),
             new AiQualityGateService(),
+            $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
 
@@ -48,6 +50,7 @@ final class AiCategorizationServiceTest extends TestCase
             $platform,
             new RuleBasedCategorizationService(),
             new AiQualityGateService(),
+            $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
 
@@ -70,6 +73,7 @@ final class AiCategorizationServiceTest extends TestCase
             $platform,
             new RuleBasedCategorizationService(),
             new AiQualityGateService(),
+            $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
 

--- a/tests/Unit/Enrichment/Service/AiSummarizationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiSummarizationServiceTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Enrichment\Service;
 use App\Enrichment\Service\AiQualityGateService;
 use App\Enrichment\Service\AiSummarizationService;
 use App\Enrichment\Service\RuleBasedSummarizationService;
+use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\ValueObject\EnrichmentMethod;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,7 @@ final class AiSummarizationServiceTest extends TestCase
             $platform,
             new RuleBasedSummarizationService(),
             new AiQualityGateService(),
+            $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
 
@@ -50,6 +52,7 @@ final class AiSummarizationServiceTest extends TestCase
             $platform,
             new RuleBasedSummarizationService(),
             new AiQualityGateService(),
+            $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
 
@@ -69,6 +72,7 @@ final class AiSummarizationServiceTest extends TestCase
             $platform,
             new RuleBasedSummarizationService(),
             new AiQualityGateService(),
+            $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
 
@@ -89,6 +93,7 @@ final class AiSummarizationServiceTest extends TestCase
             $platform,
             new RuleBasedSummarizationService(),
             new AiQualityGateService(),
+            $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
 


### PR DESCRIPTION
## Summary

Closes #46

`ModelQualityTracker` was wired in the container but never called. Added `recordAcceptance()`/`recordRejection()` calls to `AiCategorizationService` and `AiSummarizationService` after quality gate validation passes or fails. The `app:ai-stats` command will now show real data.

## Test plan

- [x] All quality checks pass (`make quality`)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)