### PR TITLE
fix: quality gate validates categories against database

### DIFF
--- a/src/Enrichment/Service/AiQualityGateService.php
+++ b/src/Enrichment/Service/AiQualityGateService.php
@@ -4,8 +4,16 @@ declare(strict_types=1);
 
 namespace App\Enrichment\Service;
 
+use App\Shared\Entity\Category;
+use App\Shared\Repository\CategoryRepositoryInterface;
+
 final readonly class AiQualityGateService implements AiQualityGateServiceInterface
 {
+    public function __construct(
+        private CategoryRepositoryInterface $categoryRepository,
+    ) {
+    }
+
     public function validateSummary(string $summary, string $title): bool
     {
         $length = mb_strlen($summary);
@@ -22,8 +30,6 @@ final readonly class AiQualityGateService implements AiQualityGateServiceInterfa
 
     public function validateCategorization(string $categorySlug): bool
     {
-        $validSlugs = ['politics', 'business', 'tech', 'science', 'sports'];
-
-        return in_array($categorySlug, $validSlugs, true);
+        return $this->categoryRepository->findBySlug($categorySlug) instanceof Category;
     }
 }

--- a/tests/Unit/Enrichment/Service/AiCategorizationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiCategorizationServiceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Enrichment\Service;
 
 use App\Enrichment\Service\AiCategorizationService;
-use App\Enrichment\Service\AiQualityGateService;
+use App\Enrichment\Service\AiQualityGateServiceInterface;
 use App\Enrichment\Service\RuleBasedCategorizationService;
 use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\ValueObject\EnrichmentMethod;
@@ -29,7 +29,7 @@ final class AiCategorizationServiceTest extends TestCase
         $service = new AiCategorizationService(
             $platform,
             new RuleBasedCategorizationService(),
-            new AiQualityGateService(),
+            $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
@@ -49,7 +49,7 @@ final class AiCategorizationServiceTest extends TestCase
         $service = new AiCategorizationService(
             $platform,
             new RuleBasedCategorizationService(),
-            new AiQualityGateService(),
+            $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
@@ -72,7 +72,7 @@ final class AiCategorizationServiceTest extends TestCase
         $service = new AiCategorizationService(
             $platform,
             new RuleBasedCategorizationService(),
-            new AiQualityGateService(),
+            $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
@@ -85,6 +85,17 @@ final class AiCategorizationServiceTest extends TestCase
 
         self::assertSame('science', $result->value);
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+    }
+
+    private function createQualityGateStub(): AiQualityGateServiceInterface
+    {
+        $stub = $this->createStub(AiQualityGateServiceInterface::class);
+        $stub->method('validateCategorization')->willReturnCallback(
+            static fn (string $slug): bool => in_array($slug, ['politics', 'business', 'tech', 'science', 'sports'], true),
+        );
+        $stub->method('validateSummary')->willReturn(true);
+
+        return $stub;
     }
 
     private function makeDeferredResult(string $text): DeferredResult

--- a/tests/Unit/Enrichment/Service/AiQualityGateServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiQualityGateServiceTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Enrichment\Service;
 
 use App\Enrichment\Service\AiQualityGateService;
+use App\Shared\Entity\Category;
+use App\Shared\Repository\CategoryRepositoryInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +17,15 @@ final class AiQualityGateServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->gate = new AiQualityGateService();
+        $categoryRepo = $this->createStub(CategoryRepositoryInterface::class);
+        $categoryRepo->method('findBySlug')->willReturnCallback(
+            static fn (string $slug): ?Category => match ($slug) {
+                'politics', 'business', 'tech', 'science', 'sports' => new Category($slug, $slug, 10, '#000'),
+                default => null,
+            },
+        );
+
+        $this->gate = new AiQualityGateService($categoryRepo);
     }
 
     public function testValidSummaryPasses(): void

--- a/tests/Unit/Enrichment/Service/AiSummarizationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiSummarizationServiceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Enrichment\Service;
 
-use App\Enrichment\Service\AiQualityGateService;
+use App\Enrichment\Service\AiQualityGateServiceInterface;
 use App\Enrichment\Service\AiSummarizationService;
 use App\Enrichment\Service\RuleBasedSummarizationService;
 use App\Shared\AI\Service\ModelQualityTrackerInterface;
@@ -31,7 +31,7 @@ final class AiSummarizationServiceTest extends TestCase
         $service = new AiSummarizationService(
             $platform,
             new RuleBasedSummarizationService(),
-            new AiQualityGateService(),
+            $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
@@ -51,7 +51,7 @@ final class AiSummarizationServiceTest extends TestCase
         $service = new AiSummarizationService(
             $platform,
             new RuleBasedSummarizationService(),
-            new AiQualityGateService(),
+            $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
@@ -71,7 +71,7 @@ final class AiSummarizationServiceTest extends TestCase
         $service = new AiSummarizationService(
             $platform,
             new RuleBasedSummarizationService(),
-            new AiQualityGateService(),
+            $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
@@ -92,7 +92,7 @@ final class AiSummarizationServiceTest extends TestCase
         $service = new AiSummarizationService(
             $platform,
             new RuleBasedSummarizationService(),
-            new AiQualityGateService(),
+            $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
         );
@@ -102,6 +102,24 @@ final class AiSummarizationServiceTest extends TestCase
 
         // Summary that's just the title repeated should be rejected by quality gate
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+    }
+
+    private function createQualityGateStub(): AiQualityGateServiceInterface
+    {
+        $stub = $this->createStub(AiQualityGateServiceInterface::class);
+        $stub->method('validateSummary')->willReturnCallback(
+            static function (string $summary, string $title): bool {
+                $length = mb_strlen($summary);
+                if ($length < 20 || $length > 500) {
+                    return false;
+                }
+                similar_text(mb_strtolower($summary), mb_strtolower($title), $percent);
+
+                return $percent < 90.0;
+            },
+        );
+
+        return $stub;
     }
 
     private function makeDeferredResult(string $text): DeferredResult


### PR DESCRIPTION
## Summary

Closes #49

`AiQualityGateService` had a hardcoded category list `['politics', 'business', 'tech', 'science', 'sports']`. Categories added to the database were incorrectly rejected. Now validates against the actual `Category` entity via `CategoryRepositoryInterface::findBySlug()`.

## Test plan

- [x] All quality checks pass (`make quality`)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)