### PR TITLE
refactor: validate URLs using value objects in entities

### DIFF
--- a/src/Article/Entity/Article.php
+++ b/src/Article/Entity/Article.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Article\Entity;
 
+use App\Article\ValueObject\Url;
 use App\Shared\Entity\Category;
 use App\Shared\ValueObject\EnrichmentMethod;
 use App\Source\Entity\Source;
@@ -89,6 +90,7 @@ class Article
         Source $source,
         \DateTimeImmutable $fetchedAt,
     ) {
+        new Url($url); // validate URL format
         $this->title = $title;
         $this->url = $url;
         $this->source = $source;

--- a/src/Source/Entity/Source.php
+++ b/src/Source/Entity/Source.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Source\Entity;
 
 use App\Shared\Entity\Category;
+use App\Source\ValueObject\FeedUrl;
 use App\Source\ValueObject\SourceHealth;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
@@ -58,6 +59,7 @@ class Source
         Category $category,
         \DateTimeImmutable $createdAt,
     ) {
+        new FeedUrl($feedUrl); // validate feed URL format
         $this->name = $name;
         $this->feedUrl = $feedUrl;
         $this->category = $category;


### PR DESCRIPTION
## Summary

Closes #47

Add URL format validation to `Article` and `Source` entity constructors using the existing `Url` and `FeedUrl` value objects. Entities still store raw strings (no Doctrine schema change), but invalid URLs are now rejected at construction time with `InvalidArgumentException`.

## Test plan

- [x] All quality checks pass (`make quality`)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)