### PR TITLE
refactor: extract inline DQL from controllers into repositories

### DIFF
--- a/src/Article/Repository/ArticleRepository.php
+++ b/src/Article/Repository/ArticleRepository.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Article\Repository;
 
 use App\Article\Entity\Article;
+use App\User\Entity\User;
+use App\User\Entity\UserArticleRead;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -107,6 +109,70 @@ final class ArticleRepository extends ServiceEntityRepository implements Article
             ->where('a.id IN (:ids)')
             ->setParameter('ids', $ids)
             ->orderBy('a.score', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return list<Article>
+     */
+    public function findPaginated(?string $categorySlug, ?User $unreadForUser, int $page, int $limit): array
+    {
+        $qb = $this->createQueryBuilder('a')
+            ->leftJoin('a.category', 'c')
+            ->leftJoin('a.source', 's')
+            ->orderBy('CASE WHEN a.publishedAt IS NOT NULL THEN a.publishedAt ELSE a.fetchedAt END', 'DESC')
+            ->addOrderBy('a.score', 'DESC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit);
+
+        if ($categorySlug !== null && $categorySlug !== '') {
+            $qb->andWhere('c.slug = :cat')->setParameter('cat', $categorySlug);
+        }
+
+        if ($unreadForUser instanceof User) {
+            $sub = $this->getEntityManager()
+                ->getRepository(UserArticleRead::class)
+                ->createQueryBuilder('r2')
+                ->select('1')
+                ->where('r2.article = a')
+                ->andWhere('r2.user = :currentUser')
+                ->getDQL();
+
+            $qb->andWhere($qb->expr()->not($qb->expr()->exists($sub)))
+                ->setParameter('currentUser', $unreadForUser);
+        }
+
+        /** @var list<Article> */
+        return $qb->getQuery()->getResult();
+    }
+
+    public function countSince(\DateTimeImmutable $since): int
+    {
+        return (int) $this->createQueryBuilder('a')
+            ->select('COUNT(a.id)')
+            ->where('a.fetchedAt >= :since')
+            ->setParameter('since', $since)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * @return list<Article>
+     */
+    public function findUnreadForUser(User $user): array
+    {
+        $subDql = $this->getEntityManager()
+            ->getRepository(UserArticleRead::class)
+            ->createQueryBuilder('r')
+            ->select('IDENTITY(r.article)')
+            ->where('r.user = :user')
+            ->getDQL();
+
+        /** @var list<Article> */
+        return $this->createQueryBuilder('a')
+            ->where("a.id NOT IN ({$subDql})")
+            ->setParameter('user', $user)
             ->getQuery()
             ->getResult();
     }

--- a/src/Article/Repository/ArticleRepositoryInterface.php
+++ b/src/Article/Repository/ArticleRepositoryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Article\Repository;
 
 use App\Article\Entity\Article;
+use App\User\Entity\User;
 
 interface ArticleRepositoryInterface
 {
@@ -37,6 +38,18 @@ interface ArticleRepositoryInterface
      * @return list<Article>
      */
     public function findByIds(array $ids): array;
+
+    /**
+     * @return list<Article>
+     */
+    public function findPaginated(?string $categorySlug, ?User $unreadForUser, int $page, int $limit): array;
+
+    public function countSince(\DateTimeImmutable $since): int;
+
+    /**
+     * @return list<Article>
+     */
+    public function findUnreadForUser(User $user): array;
 
     public function save(Article $article, bool $flush = false): void;
 

--- a/src/Shared/Controller/DashboardController.php
+++ b/src/Shared/Controller/DashboardController.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Shared\Controller;
 
 use App\Article\Entity\Article;
+use App\Article\Repository\ArticleRepositoryInterface;
 use App\Source\Repository\SourceRepositoryInterface;
 use App\User\Entity\User;
-use App\User\Entity\UserArticleRead;
-use Doctrine\ORM\EntityManagerInterface;
+use App\User\Repository\UserArticleReadRepositoryInterface;
 use Psr\Clock\ClockInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\HttpFoundation\Response;
@@ -19,7 +19,8 @@ final class DashboardController
 {
     public function __construct(
         private readonly ControllerHelper $controller,
-        private readonly EntityManagerInterface $entityManager,
+        private readonly ArticleRepositoryInterface $articleRepository,
+        private readonly UserArticleReadRepositoryInterface $userArticleReadRepository,
         private readonly SourceRepositoryInterface $sourceRepository,
         private readonly ClockInterface $clock,
     ) {
@@ -39,52 +40,19 @@ final class DashboardController
         $page = max(1, $page);
         $limit = 20;
 
-        $qb = $this->entityManager
-            ->getRepository(Article::class)
-            ->createQueryBuilder('a')
-            ->leftJoin('a.category', 'c')
-            ->leftJoin('a.source', 's')
-            ->orderBy('CASE WHEN a.publishedAt IS NOT NULL THEN a.publishedAt ELSE a.fetchedAt END', 'DESC')
-            ->addOrderBy('a.score', 'DESC')
-            ->setFirstResult(($page - 1) * $limit)
-            ->setMaxResults($limit);
+        $user = $this->controller->getUser();
 
-        if ($category !== null && $category !== '') {
-            $qb->andWhere('c.slug = :cat')->setParameter('cat', $category);
-        }
-
-        if ($unreadOnly) {
-            $currentUser = $this->controller->getUser();
-            if ($currentUser instanceof User) {
-                $qb->andWhere(
-                    $qb->expr()->not(
-                        $qb->expr()->exists(
-                            $this->entityManager
-                                ->getRepository(UserArticleRead::class)
-                                ->createQueryBuilder('r2')
-                                ->select('1')
-                                ->where('r2.article = a')
-                                ->andWhere('r2.user = :currentUser')
-                                ->getDQL(),
-                        ),
-                    ),
-                )->setParameter('currentUser', $currentUser);
-            }
-        }
-
-        /** @var list<Article> $articles */
-        $articles = $qb->getQuery()->getResult();
+        $articles = $this->articleRepository->findPaginated(
+            $category,
+            $unreadOnly && $user instanceof User ? $user : null,
+            $page,
+            $limit,
+        );
 
         // Stats
         $now = $this->clock->now();
         $todayStart = $now->setTime(0, 0);
-        $articlesToday = $this->entityManager->getRepository(Article::class)
-            ->createQueryBuilder('a')
-            ->select('COUNT(a.id)')
-            ->where('a.fetchedAt >= :today')
-            ->setParameter('today', $todayStart)
-            ->getQuery()
-            ->getSingleScalarResult();
+        $articlesToday = $this->articleRepository->countSince($todayStart);
 
         $activeSources = $this->sourceRepository->countEnabled();
 
@@ -127,22 +95,6 @@ final class DashboardController
             $articles,
         );
 
-        /** @var list<UserArticleRead> $readRecords */
-        $readRecords = $this->entityManager
-            ->getRepository(UserArticleRead::class)
-            ->createQueryBuilder('r')
-            ->where('r.user = :user')
-            ->andWhere('r.article IN (:ids)')
-            ->setParameter('user', $user)
-            ->setParameter('ids', $articleIds)
-            ->getQuery()
-            ->getResult();
-
-        $readIds = [];
-        foreach ($readRecords as $record) {
-            $readIds[(int) $record->getArticle()->getId()] = true;
-        }
-
-        return $readIds;
+        return $this->userArticleReadRepository->findReadArticleIdsForUser($user, $articleIds);
     }
 }

--- a/src/User/Controller/MarkAllReadController.php
+++ b/src/User/Controller/MarkAllReadController.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\User\Controller;
 
-use App\Article\Entity\Article;
+use App\Article\Repository\ArticleRepositoryInterface;
 use App\User\Entity\User;
 use App\User\Entity\UserArticleRead;
-use Doctrine\ORM\EntityManagerInterface;
+use App\User\Repository\UserArticleReadRepositoryInterface;
 use Psr\Clock\ClockInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -19,7 +19,8 @@ final class MarkAllReadController
 {
     public function __construct(
         private readonly ControllerHelper $controller,
-        private readonly EntityManagerInterface $entityManager,
+        private readonly ArticleRepositoryInterface $articleRepository,
+        private readonly UserArticleReadRepositoryInterface $userArticleReadRepository,
         private readonly ClockInterface $clock,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly RequestStack $requestStack,
@@ -47,28 +48,12 @@ final class MarkAllReadController
     private function markUnreadArticles(User $user): void
     {
         $now = $this->clock->now();
-
-        $subDql = $this->entityManager
-            ->getRepository(UserArticleRead::class)
-            ->createQueryBuilder('r')
-            ->select('IDENTITY(r.article)')
-            ->where('r.user = :user')
-            ->getDQL();
-
-        /** @var list<Article> $unreadArticles */
-        $unreadArticles = $this->entityManager
-            ->getRepository(Article::class)
-            ->createQueryBuilder('a')
-            ->where("a.id NOT IN ({$subDql})")
-            ->setParameter('user', $user)
-            ->getQuery()
-            ->getResult();
+        $unreadArticles = $this->articleRepository->findUnreadForUser($user);
 
         foreach ($unreadArticles as $article) {
-            $read = new UserArticleRead($user, $article, $now);
-            $this->entityManager->persist($read);
+            $this->userArticleReadRepository->save(new UserArticleRead($user, $article, $now));
         }
 
-        $this->entityManager->flush();
+        $this->userArticleReadRepository->flush();
     }
 }

--- a/src/User/Repository/UserArticleReadRepository.php
+++ b/src/User/Repository/UserArticleReadRepository.php
@@ -37,6 +37,34 @@ final class UserArticleReadRepository extends ServiceEntityRepository implements
         }
     }
 
+    /**
+     * @param list<int> $articleIds
+     *
+     * @return array<int, true>
+     */
+    public function findReadArticleIdsForUser(User $user, array $articleIds): array
+    {
+        if ($articleIds === []) {
+            return [];
+        }
+
+        /** @var list<UserArticleRead> $readRecords */
+        $readRecords = $this->createQueryBuilder('r')
+            ->where('r.user = :user')
+            ->andWhere('r.article IN (:ids)')
+            ->setParameter('user', $user)
+            ->setParameter('ids', $articleIds)
+            ->getQuery()
+            ->getResult();
+
+        $readIds = [];
+        foreach ($readRecords as $record) {
+            $readIds[(int) $record->getArticle()->getId()] = true;
+        }
+
+        return $readIds;
+    }
+
     public function flush(): void
     {
         $this->getEntityManager()->flush();

--- a/src/User/Repository/UserArticleReadRepositoryInterface.php
+++ b/src/User/Repository/UserArticleReadRepositoryInterface.php
@@ -12,6 +12,13 @@ interface UserArticleReadRepositoryInterface
 {
     public function findByUserAndArticle(User $user, Article $article): ?UserArticleRead;
 
+    /**
+     * @param list<int> $articleIds
+     *
+     * @return array<int, true>
+     */
+    public function findReadArticleIdsForUser(User $user, array $articleIds): array;
+
     public function save(UserArticleRead $read, bool $flush = false): void;
 
     public function flush(): void;


### PR DESCRIPTION
## Summary

Closes #48

Move complex DQL from `DashboardController` (50+ lines) and `MarkAllReadController` into repository methods. Both controllers now have zero inline DQL.

### New repository methods

| Method | Description |
|--------|-------------|
| `ArticleRepository::findPaginated()` | Paginated with category and unread filters |
| `ArticleRepository::countSince()` | Count articles since timestamp |
| `ArticleRepository::findUnreadForUser()` | All unread articles for a user |
| `UserArticleReadRepository::findReadArticleIdsForUser()` | Batch read-state lookup |

`EntityManagerInterface` fully removed from both controllers.

## Test plan

- [x] All quality checks pass (`make quality`)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)