### PR TITLE
feat: add domain events for cross-module decoupling

### DIFF
--- a/src/Article/Event/ArticleCreated.php
+++ b/src/Article/Event/ArticleCreated.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Article\Event;
+
+use App\Article\Entity\Article;
+
+final readonly class ArticleCreated
+{
+    public function __construct(
+        public Article $article,
+    ) {
+    }
+}

--- a/src/Article/MessageHandler/FetchSourceHandler.php
+++ b/src/Article/MessageHandler/FetchSourceHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Article\MessageHandler;
 
 use App\Article\Entity\Article;
+use App\Article\Event\ArticleCreated;
 use App\Article\Repository\ArticleRepositoryInterface;
 use App\Article\Service\DeduplicationServiceInterface;
 use App\Article\ValueObject\ArticleCollection;
@@ -12,7 +13,6 @@ use App\Article\ValueObject\ArticleFingerprint;
 use App\Article\ValueObject\FetchResult;
 use App\Article\ValueObject\PersistItemResult;
 use App\Enrichment\Service\ArticleEnrichmentServiceInterface;
-use App\Notification\Service\AlertDispatchServiceInterface;
 use App\Source\Entity\Source;
 use App\Source\Exception\FeedFetchException;
 use App\Source\Message\FetchSourceMessage;
@@ -24,6 +24,7 @@ use App\Source\Service\FeedParserServiceInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
@@ -37,7 +38,7 @@ final readonly class FetchSourceHandler
         private FeedParserServiceInterface $feedParser,
         private DeduplicationServiceInterface $deduplication,
         private ArticleEnrichmentServiceInterface $enrichment,
-        private AlertDispatchServiceInterface $alertDispatch,
+        private EventDispatcherInterface $eventDispatcher,
         private ClockInterface $clock,
         private LoggerInterface $logger,
     ) {
@@ -60,7 +61,7 @@ final readonly class FetchSourceHandler
             if ($result->source instanceof Source) {
                 $result->source->recordSuccess($now);
                 $this->articleRepository->flush();
-                $this->alertDispatch->dispatchAlerts($result->newArticles);
+                $this->dispatchArticleEvents($result->newArticles);
                 $this->logger->info('Fetched {source}: {count} new articles from {total} items', [
                     'source' => $result->source->getName(),
                     'count' => $result->persistedCount,
@@ -139,6 +140,13 @@ final readonly class FetchSourceHandler
             $source = $this->sourceRepository->findById($sourceId);
 
             return $source instanceof Source ? new PersistItemResult(null, $source) : null;
+        }
+    }
+
+    private function dispatchArticleEvents(ArticleCollection $articles): void
+    {
+        foreach ($articles as $article) {
+            $this->eventDispatcher->dispatch(new ArticleCreated($article));
         }
     }
 }

--- a/src/Notification/EventSubscriber/ArticleCreatedSubscriber.php
+++ b/src/Notification/EventSubscriber/ArticleCreatedSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\EventSubscriber;
+
+use App\Article\Event\ArticleCreated;
+use App\Notification\Message\SendNotificationMessage;
+use App\Notification\Service\ArticleMatcherServiceInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final readonly class ArticleCreatedSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private ArticleMatcherServiceInterface $articleMatcher,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ArticleCreated::class => 'onArticleCreated',
+        ];
+    }
+
+    public function onArticleCreated(ArticleCreated $event): void
+    {
+        $article = $event->article;
+        $articleId = $article->getId();
+        if ($articleId === null) {
+            return;
+        }
+
+        $matches = $this->articleMatcher->match($article);
+        foreach ($matches as $match) {
+            $ruleId = $match->alertRule->getId();
+            if ($ruleId === null) {
+                continue;
+            }
+
+            $this->messageBus->dispatch(
+                new SendNotificationMessage($ruleId, $articleId, $match->matchedKeywords),
+            );
+        }
+    }
+}

--- a/src/Source/Event/SourceHealthChanged.php
+++ b/src/Source/Event/SourceHealthChanged.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Source\Event;
+
+use App\Source\ValueObject\SourceHealth;
+
+final readonly class SourceHealthChanged
+{
+    public function __construct(
+        public int $sourceId,
+        public string $sourceName,
+        public SourceHealth $previousHealth,
+        public SourceHealth $newHealth,
+    ) {
+    }
+}

--- a/tests/Unit/Article/MessageHandler/FetchSourceHandlerTest.php
+++ b/tests/Unit/Article/MessageHandler/FetchSourceHandlerTest.php
@@ -9,7 +9,6 @@ use App\Article\MessageHandler\FetchSourceHandler;
 use App\Article\Repository\ArticleRepositoryInterface;
 use App\Article\Service\DeduplicationServiceInterface;
 use App\Enrichment\Service\ArticleEnrichmentServiceInterface;
-use App\Notification\Service\AlertDispatchServiceInterface;
 use App\Shared\Entity\Category;
 use App\Source\Entity\Source;
 use App\Source\Exception\FeedFetchException;
@@ -26,6 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 #[CoversClass(FetchSourceHandler::class)]
 final class FetchSourceHandlerTest extends TestCase
@@ -83,7 +83,7 @@ final class FetchSourceHandlerTest extends TestCase
             $this->parser,
             $dedup,
             $this->createStub(ArticleEnrichmentServiceInterface::class),
-            $this->createStub(AlertDispatchServiceInterface::class),
+            $this->createStub(EventDispatcherInterface::class),
             $this->clock,
             new NullLogger(),
         );


### PR DESCRIPTION
## Summary

Closes #50

### New domain events

- **`ArticleCreated`** — dispatched after a new article is persisted
- **`SourceHealthChanged`** — emitted when source health transitions (for future use)

### Architecture change

`FetchSourceHandler` no longer depends on `AlertDispatchServiceInterface`. Instead, it dispatches `ArticleCreated` events via Symfony EventDispatcher. `ArticleCreatedSubscriber` in the Notification module listens and handles alert matching + notification dispatch.

## Test plan

- [x] All quality checks pass (`make quality`)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)