### PR TITLE
fix: enforce mutation testing MSI thresholds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,4 +137,4 @@ jobs:
             php vendor/bin/infection \
               --threads=4 \
               --test-framework-options="--testsuite=unit" \
-              --min-msi=80 --min-covered-msi=90 || true
+              --min-msi=80 --min-covered-msi=90


### PR DESCRIPTION
## Summary

Closes #59

The CI mutation testing step had `|| true` appended, silently swallowing Infection exit codes. MSI could drop to 0% and CI would still pass.

### Change

Remove `|| true` from the Infection step in `.github/workflows/ci.yml`. The `--min-msi=80 --min-covered-msi=90` flags will now correctly fail CI when thresholds are not met.

**Note:** This PR is based on `feat/specialized-agents`. It should be merged after #63.

## Test plan

- [x] CI configuration change only
- [ ] Verify next CI run with low MSI would actually fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)