### PR TITLE
fix: enforce mutation testing MSI thresholds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,4 +137,4 @@ jobs:
             php vendor/bin/infection \
               --threads=4 \
               --test-framework-options="--testsuite=unit" \
-              --min-msi=80 --min-covered-msi=90 || true
+              --min-msi=80 --min-covered-msi=90

--- a/tests/Unit/Article/MessageHandler/FetchSourceHandlerTest.php
+++ b/tests/Unit/Article/MessageHandler/FetchSourceHandlerTest.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Article\MessageHandler;
 
 use App\Article\Entity\Article;
+use App\Article\Event\ArticleCreated;
 use App\Article\MessageHandler\FetchSourceHandler;
 use App\Article\Repository\ArticleRepositoryInterface;
 use App\Article\Service\DeduplicationServiceInterface;
+use App\Article\ValueObject\ArticleCollection;
+use App\Article\ValueObject\ArticleFingerprint;
+use App\Article\ValueObject\FetchResult;
+use App\Article\ValueObject\PersistItemResult;
 use App\Enrichment\Service\ArticleEnrichmentServiceInterface;
 use App\Shared\Entity\Category;
 use App\Source\Entity\Source;
@@ -21,101 +26,135 @@ use App\Source\Service\FeedParserServiceInterface;
 use App\Source\ValueObject\SourceHealth;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 #[CoversClass(FetchSourceHandler::class)]
+#[UsesClass(FetchSourceMessage::class)]
+#[UsesClass(FeedItem::class)]
+#[UsesClass(FeedItemCollection::class)]
+#[UsesClass(FetchResult::class)]
+#[UsesClass(PersistItemResult::class)]
+#[UsesClass(ArticleCollection::class)]
+#[UsesClass(ArticleFingerprint::class)]
+#[UsesClass(ArticleCreated::class)]
+#[UsesClass(FeedFetchException::class)]
 final class FetchSourceHandlerTest extends TestCase
 {
-    /**
-     * @var ArticleRepositoryInterface&MockObject
-     */
-    private MockObject $articleRepository;
-
-    /**
-     * @var SourceRepositoryInterface&MockObject
-     */
-    private MockObject $sourceRepository;
-
-    /**
-     * @var FeedFetcherServiceInterface&MockObject
-     */
-    private MockObject $fetcher;
-
-    /**
-     * @var FeedParserServiceInterface&MockObject
-     */
-    private MockObject $parser;
-
     private MockClock $clock;
-
-    private FetchSourceHandler $handler;
 
     private Source $source;
 
     protected function setUp(): void
     {
-        $category = new Category('Tech', 'tech', 10, '#3B82F6');
-        $this->source = new Source('Test', 'https://example.com/feed', $category, new \DateTimeImmutable());
-
-        $this->articleRepository = $this->createMock(ArticleRepositoryInterface::class);
-        $this->sourceRepository = $this->createMock(SourceRepositoryInterface::class);
-        $this->sourceRepository->method('findById')->willReturn($this->source);
-
-        $this->fetcher = $this->createMock(FeedFetcherServiceInterface::class);
-        $this->parser = $this->createMock(FeedParserServiceInterface::class);
         $this->clock = new MockClock('2026-04-04 12:00:00');
-
-        $dedup = $this->createStub(DeduplicationServiceInterface::class);
-        $dedup->method('isDuplicate')->willReturn(false);
-
-        $em = $this->createStub(EntityManagerInterface::class);
-        $em->method('isOpen')->willReturn(true);
-
-        $this->handler = new FetchSourceHandler(
-            $this->articleRepository,
-            $this->sourceRepository,
-            $em,
-            $this->fetcher,
-            $this->parser,
-            $dedup,
-            $this->createStub(ArticleEnrichmentServiceInterface::class),
-            $this->createStub(EventDispatcherInterface::class),
-            $this->clock,
-            new NullLogger(),
-        );
+        $this->source = $this->createSource();
     }
 
     public function testHandlesFetchAndPersistsArticles(): void
     {
-        $this->fetcher->method('fetch')->willReturn('<rss>...</rss>');
-        $this->parser->method('parse')->willReturn(new FeedItemCollection([
+        // Put source into degraded state so recordSuccess() is observable
+        $this->source->recordFailure('previous error');
+        self::assertSame(SourceHealth::Degraded, $this->source->getHealthStatus());
+
+        $articleRepository = $this->createMock(ArticleRepositoryInterface::class);
+        $enrichment = $this->createMock(ArticleEnrichmentServiceInterface::class);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $fetcher = $this->createStub(FeedFetcherServiceInterface::class);
+        $fetcher->method('fetch')->willReturn('<rss>...</rss>');
+
+        $parser = $this->createStub(FeedParserServiceInterface::class);
+        $parser->method('parse')->willReturn(new FeedItemCollection([
             new FeedItem('Article 1', 'https://example.com/1', '<p>Content</p>', 'Content text here for summarization', null),
             new FeedItem('Article 2', 'https://example.com/2', null, null, null),
         ]));
 
-        $saved = [];
-        $this->articleRepository->method('save')->willReturnCallback(function (Article $article) use (&$saved): void {
-            $saved[] = $article;
-        });
+        $enrichment->expects(self::exactly(2))->method('enrich');
 
-        ($this->handler)(new FetchSourceMessage(1));
+        $saved = [];
+        $articleRepository->expects(self::exactly(2))
+            ->method('save')
+            ->willReturnCallback(function (Article $article, bool $flush) use (&$saved): void {
+                self::assertTrue($flush, 'save() must be called with flush: true');
+                $saved[] = $article;
+            });
+
+        $articleRepository->expects(self::once())->method('flush');
+
+        $eventDispatcher->expects(self::exactly(2))
+            ->method('dispatch')
+            ->with(self::callback(static fn (mixed $event): bool => $event instanceof ArticleCreated));
+
+        $logger->expects(self::once())
+            ->method('info')
+            ->with(
+                self::stringContains('new articles'),
+                self::callback(static function (array $context): bool {
+                    return $context['source'] === 'Test'
+                        && $context['count'] === 2
+                        && $context['total'] === 2;
+                }),
+            );
+
+        $handler = $this->createHandler(
+            articleRepository: $articleRepository,
+            fetcher: $fetcher,
+            parser: $parser,
+            enrichment: $enrichment,
+            eventDispatcher: $eventDispatcher,
+            logger: $logger,
+        );
+
+        ($handler)(new FetchSourceMessage(1));
 
         self::assertCount(2, $saved);
         self::assertSame('Article 1', $saved[0]->getTitle());
+        self::assertSame('<p>Content</p>', $saved[0]->getContentRaw());
+        self::assertSame('Content text here for summarization', $saved[0]->getContentText());
+        self::assertNotNull($saved[0]->getFingerprint());
+        self::assertNull($saved[1]->getContentRaw());
+        self::assertNull($saved[1]->getFingerprint());
         self::assertSame(SourceHealth::Healthy, $this->source->getHealthStatus());
+        self::assertSame(0, $this->source->getErrorCount());
     }
 
     public function testRecordsFailureOnFetchError(): void
     {
-        $this->fetcher->method('fetch')->willThrowException(
+        $sourceRepository = $this->createMock(SourceRepositoryInterface::class);
+        $sourceRepository->method('findById')->willReturn($this->source);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $fetcher = $this->createStub(FeedFetcherServiceInterface::class);
+        $fetcher->method('fetch')->willThrowException(
             FeedFetchException::fromUrl('https://example.com/feed', 'timeout'),
         );
 
-        ($this->handler)(new FetchSourceMessage(1));
+        $sourceRepository->expects(self::once())->method('flush');
+
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('fetch failed'),
+                self::callback(static function (array $context): bool {
+                    return $context['source'] === 'Test'
+                        && \is_string($context['error'])
+                        && $context['error'] !== '';
+                }),
+            );
+
+        $handler = $this->createHandler(
+            sourceRepository: $sourceRepository,
+            fetcher: $fetcher,
+            logger: $logger,
+        );
+
+        ($handler)(new FetchSourceMessage(1));
 
         self::assertSame(SourceHealth::Degraded, $this->source->getHealthStatus());
         self::assertSame(1, $this->source->getErrorCount());
@@ -123,12 +162,181 @@ final class FetchSourceHandlerTest extends TestCase
 
     public function testSkipsDisabledSource(): void
     {
+        $fetcher = $this->createMock(FeedFetcherServiceInterface::class);
+        $fetcher->expects(self::never())->method('fetch');
+
         $this->source->setEnabled(false);
 
-        $this->fetcher->expects(self::never())->method('fetch');
+        $handler = $this->createHandler(fetcher: $fetcher);
 
-        ($this->handler)(new FetchSourceMessage(1));
+        ($handler)(new FetchSourceMessage(1));
 
         self::assertFalse($this->source->isEnabled());
+    }
+
+    public function testSkipsDuplicateArticles(): void
+    {
+        $articleRepository = $this->createMock(ArticleRepositoryInterface::class);
+        $enrichment = $this->createMock(ArticleEnrichmentServiceInterface::class);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $fetcher = $this->createStub(FeedFetcherServiceInterface::class);
+        $fetcher->method('fetch')->willReturn('<rss>...</rss>');
+
+        $parser = $this->createStub(FeedParserServiceInterface::class);
+        $parser->method('parse')->willReturn(new FeedItemCollection([
+            new FeedItem('Duplicate', 'https://example.com/dup', null, null, null),
+            new FeedItem('Unique', 'https://example.com/new', null, null, null),
+        ]));
+
+        $dedup = $this->createStub(DeduplicationServiceInterface::class);
+        $callCount = 0;
+        $dedup->method('isDuplicate')->willReturnCallback(function () use (&$callCount): bool {
+            return ++$callCount === 1;
+        });
+
+        $articleRepository->expects(self::once())->method('save');
+        $enrichment->expects(self::once())->method('enrich');
+        $articleRepository->expects(self::once())->method('flush');
+
+        $eventDispatcher->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(static fn (mixed $event): bool => $event instanceof ArticleCreated));
+
+        $logger->expects(self::once())
+            ->method('info')
+            ->with(
+                self::stringContains('new articles'),
+                self::callback(static function (array $context): bool {
+                    return $context['count'] === 1 && $context['total'] === 2;
+                }),
+            );
+
+        $handler = $this->createHandler(
+            articleRepository: $articleRepository,
+            fetcher: $fetcher,
+            parser: $parser,
+            dedup: $dedup,
+            enrichment: $enrichment,
+            eventDispatcher: $eventDispatcher,
+            logger: $logger,
+        );
+
+        ($handler)(new FetchSourceMessage(1));
+    }
+
+    public function testDispatchesArticleCreatedEventsForEachNewArticle(): void
+    {
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $fetcher = $this->createStub(FeedFetcherServiceInterface::class);
+        $fetcher->method('fetch')->willReturn('<rss>...</rss>');
+
+        $parser = $this->createStub(FeedParserServiceInterface::class);
+        $parser->method('parse')->willReturn(new FeedItemCollection([
+            new FeedItem('First', 'https://example.com/1', null, null, null),
+            new FeedItem('Second', 'https://example.com/2', null, null, null),
+            new FeedItem('Third', 'https://example.com/3', null, null, null),
+        ]));
+
+        $dispatched = [];
+        $eventDispatcher->expects(self::exactly(3))
+            ->method('dispatch')
+            ->willReturnCallback(function (ArticleCreated $event) use (&$dispatched): ArticleCreated {
+                $dispatched[] = $event->article->getTitle();
+
+                return $event;
+            });
+
+        $handler = $this->createHandler(
+            fetcher: $fetcher,
+            parser: $parser,
+            eventDispatcher: $eventDispatcher,
+        );
+
+        ($handler)(new FetchSourceMessage(1));
+
+        self::assertSame(['First', 'Second', 'Third'], $dispatched);
+    }
+
+    public function testSetsArticlePropertiesFromFeedItem(): void
+    {
+        $articleRepository = $this->createMock(ArticleRepositoryInterface::class);
+        $publishedAt = new \DateTimeImmutable('2026-04-01 10:00:00');
+
+        $fetcher = $this->createStub(FeedFetcherServiceInterface::class);
+        $fetcher->method('fetch')->willReturn('<rss>...</rss>');
+
+        $parser = $this->createStub(FeedParserServiceInterface::class);
+        $parser->method('parse')->willReturn(new FeedItemCollection([
+            new FeedItem('Title', 'https://example.com/1', '<p>Raw</p>', 'Plain text', $publishedAt),
+        ]));
+
+        $saved = [];
+        $articleRepository->expects(self::once())
+            ->method('save')
+            ->willReturnCallback(function (Article $article) use (&$saved): void {
+                $saved[] = $article;
+            });
+
+        $handler = $this->createHandler(
+            articleRepository: $articleRepository,
+            fetcher: $fetcher,
+            parser: $parser,
+        );
+
+        ($handler)(new FetchSourceMessage(1));
+
+        self::assertCount(1, $saved);
+        $article = $saved[0];
+        self::assertSame('<p>Raw</p>', $article->getContentRaw());
+        self::assertSame('Plain text', $article->getContentText());
+        self::assertSame($publishedAt, $article->getPublishedAt());
+        self::assertNotNull($article->getFingerprint());
+    }
+
+    private function createSource(): Source
+    {
+        $category = new Category('Tech', 'tech', 10, '#3B82F6');
+
+        return new Source('Test', 'https://example.com/feed', $category, new \DateTimeImmutable());
+    }
+
+    private function createHandler(
+        ?ArticleRepositoryInterface $articleRepository = null,
+        ?SourceRepositoryInterface $sourceRepository = null,
+        ?FeedFetcherServiceInterface $fetcher = null,
+        ?FeedParserServiceInterface $parser = null,
+        ?DeduplicationServiceInterface $dedup = null,
+        ?ArticleEnrichmentServiceInterface $enrichment = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+        ?LoggerInterface $logger = null,
+    ): FetchSourceHandler {
+        if (! $sourceRepository instanceof SourceRepositoryInterface) {
+            $sourceRepository = $this->createStub(SourceRepositoryInterface::class);
+            $sourceRepository->method('findById')->willReturn($this->source);
+        }
+
+        if (! $dedup instanceof DeduplicationServiceInterface) {
+            $dedup = $this->createStub(DeduplicationServiceInterface::class);
+            $dedup->method('isDuplicate')->willReturn(false);
+        }
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('isOpen')->willReturn(true);
+
+        return new FetchSourceHandler(
+            $articleRepository ?? $this->createStub(ArticleRepositoryInterface::class),
+            $sourceRepository,
+            $em,
+            $fetcher ?? $this->createStub(FeedFetcherServiceInterface::class),
+            $parser ?? $this->createStub(FeedParserServiceInterface::class),
+            $dedup,
+            $enrichment ?? $this->createStub(ArticleEnrichmentServiceInterface::class),
+            $eventDispatcher ?? $this->createStub(EventDispatcherInterface::class),
+            $this->clock,
+            $logger ?? new NullLogger(),
+        );
     }
 }

--- a/tests/Unit/Article/Service/DeduplicationServiceTest.php
+++ b/tests/Unit/Article/Service/DeduplicationServiceTest.php
@@ -25,6 +25,19 @@ final class DeduplicationServiceTest extends TestCase
         self::assertTrue($service->isDuplicate('https://example.com/existing', 'Any Title', null));
     }
 
+    public function testUrlCheckShortCircuits(): void
+    {
+        $repo = $this->createMock(ArticleRepositoryInterface::class);
+        $repo->method('findByUrl')->willReturn($this->createStub(Article::class));
+        // Fingerprint and title checks should NOT be called if URL matches
+        $repo->expects(self::never())->method('findByFingerprint');
+        $repo->expects(self::never())->method('findRecentTitles');
+
+        $service = new DeduplicationService($repo);
+
+        self::assertTrue($service->isDuplicate('https://example.com/existing', 'Title', 'fp123'));
+    }
+
     public function testIsNotDuplicateForNewUrl(): void
     {
         $service = new DeduplicationService($this->buildRepoWithTitles([]));
@@ -44,6 +57,32 @@ final class DeduplicationServiceTest extends TestCase
         self::assertTrue($service->isDuplicate('https://example.com/new', 'Title', 'abc123'));
     }
 
+    public function testFingerprintCheckShortCircuits(): void
+    {
+        $repo = $this->createMock(ArticleRepositoryInterface::class);
+        $repo->method('findByUrl')->willReturn(null);
+        $repo->method('findByFingerprint')->willReturn($this->createStub(Article::class));
+        // Title check should NOT be called if fingerprint matches
+        $repo->expects(self::never())->method('findRecentTitles');
+
+        $service = new DeduplicationService($repo);
+
+        self::assertTrue($service->isDuplicate('https://example.com/new', 'Title', 'abc123'));
+    }
+
+    public function testNullFingerprintSkipsFingerprintCheck(): void
+    {
+        $repo = $this->createMock(ArticleRepositoryInterface::class);
+        $repo->method('findByUrl')->willReturn(null);
+        // Should NOT check fingerprint when it's null
+        $repo->expects(self::never())->method('findByFingerprint');
+        $repo->method('findRecentTitles')->willReturn([]);
+
+        $service = new DeduplicationService($repo);
+
+        self::assertFalse($service->isDuplicate('https://example.com/new', 'Unique Title', null));
+    }
+
     public function testIsDuplicateBySimilarTitle(): void
     {
         $service = new DeduplicationService(
@@ -57,6 +96,73 @@ final class DeduplicationServiceTest extends TestCase
             'Breaking: Major Event Happens Today!',
             null,
         ));
+    }
+
+    public function testIsNotDuplicateByDifferentTitle(): void
+    {
+        $service = new DeduplicationService(
+            $this->buildRepoWithTitles([[
+                'title' => 'Completely different article about sports',
+            ]]),
+        );
+
+        self::assertFalse($service->isDuplicate(
+            'https://example.com/new',
+            'Technology news about quantum computing',
+            null,
+        ));
+    }
+
+    public function testEmptyTitleIsNotDuplicate(): void
+    {
+        $service = new DeduplicationService(
+            $this->buildRepoWithTitles([[
+                'title' => 'Some existing article',
+            ]]),
+        );
+
+        self::assertFalse($service->isDuplicate('https://example.com/new', '', null));
+    }
+
+    public function testWhitespaceOnlyTitleIsNotDuplicate(): void
+    {
+        $service = new DeduplicationService(
+            $this->buildRepoWithTitles([[
+                'title' => 'Some existing article',
+            ]]),
+        );
+
+        self::assertFalse($service->isDuplicate('https://example.com/new', '   ', null));
+    }
+
+    public function testTitleComparisonIsCaseInsensitive(): void
+    {
+        $service = new DeduplicationService(
+            $this->buildRepoWithTitles([[
+                'title' => 'BREAKING NEWS: Major Event',
+            ]]),
+        );
+
+        self::assertTrue($service->isDuplicate(
+            'https://example.com/new',
+            'breaking news: major event',
+            null,
+        ));
+    }
+
+    public function testChecksUpTo1000RecentTitles(): void
+    {
+        $repo = $this->createMock(ArticleRepositoryInterface::class);
+        $repo->method('findByUrl')->willReturn(null);
+        $repo->method('findByFingerprint')->willReturn(null);
+        $repo->expects(self::once())
+            ->method('findRecentTitles')
+            ->with(1000)
+            ->willReturn([]);
+
+        $service = new DeduplicationService($repo);
+
+        $service->isDuplicate('https://example.com/new', 'Title', null);
     }
 
     /**

--- a/tests/Unit/Article/Service/ScoringServiceTest.php
+++ b/tests/Unit/Article/Service/ScoringServiceTest.php
@@ -9,6 +9,7 @@ use App\Article\Service\ScoringService;
 use App\Shared\Entity\Category;
 use App\Shared\ValueObject\EnrichmentMethod;
 use App\Source\Entity\Source;
+use App\Source\ValueObject\SourceHealth;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
@@ -33,6 +34,15 @@ final class ScoringServiceTest extends TestCase
 
         self::assertGreaterThanOrEqual(0.0, $score);
         self::assertLessThanOrEqual(1.0, $score);
+    }
+
+    public function testScoreIsRoundedToFourDecimals(): void
+    {
+        $article = $this->createArticle();
+        $score = $this->service->score($article);
+
+        // Verify it's rounded to 4 decimal places
+        self::assertSame($score, round($score, 4));
     }
 
     public function testRecentArticleScoresHigherThanOld(): void
@@ -68,16 +78,51 @@ final class ScoringServiceTest extends TestCase
         );
     }
 
+    public function testNullEnrichmentScoresLowest(): void
+    {
+        $none = $this->createArticle(enrichment: null);
+        $ruleBased = $this->createArticle(enrichment: EnrichmentMethod::RuleBased);
+
+        self::assertGreaterThan(
+            $this->service->score($none),
+            $this->service->score($ruleBased),
+        );
+    }
+
     public function testVeryOldArticleGetsLowScore(): void
     {
         $article = $this->createArticle(publishedAt: '2026-03-20 12:00:00');
         $score = $this->service->score($article);
 
-        // 15 days old, should have very low recency contribution
         self::assertLessThan(0.6, $score);
     }
 
-    public function testUncategorizedArticleGetsMidScore(): void
+    public function testArticleExactlyMaxAgeGetsZeroRecency(): void
+    {
+        // 168 hours = 7 days old -> recency = 0.0
+        $article = $this->createArticle(publishedAt: '2026-03-28 12:00:00');
+        $score = $this->service->score($article);
+
+        // With zero recency, score should be notably lower
+        $freshArticle = $this->createArticle(publishedAt: '2026-04-04 12:00:00');
+        self::assertGreaterThan($score, $this->service->score($freshArticle));
+    }
+
+    public function testFutureArticleGetsMaxRecency(): void
+    {
+        // Published in the future (ageHours <= 0)
+        $article = $this->createArticle(publishedAt: '2026-04-04 13:00:00');
+        $freshScore = $this->service->score($article);
+
+        // Published just now
+        $nowArticle = $this->createArticle(publishedAt: '2026-04-04 12:00:00');
+        $nowScore = $this->service->score($nowArticle);
+
+        // Future should equal or exceed now
+        self::assertGreaterThanOrEqual($nowScore, $freshScore);
+    }
+
+    public function testUncategorizedArticleGetsMidCategoryScore(): void
     {
         $category = new Category('Tech', 'tech', 10, '#3B82F6');
         $source = new Source('Test', 'https://example.com/feed', $category, new \DateTimeImmutable());
@@ -88,20 +133,220 @@ final class ScoringServiceTest extends TestCase
             new \DateTimeImmutable('2026-04-04 11:00:00'),
         );
         $article->setPublishedAt(new \DateTimeImmutable('2026-04-04 11:00:00'));
-        // No category set, no enrichment
+        // No category set -> returns 0.5 for category score
 
         $score = $this->service->score($article);
         self::assertGreaterThan(0.0, $score);
         self::assertLessThan(1.0, $score);
     }
 
+    public function testCategoryWeightAboveMaxCapsAtOne(): void
+    {
+        // Category weight 20 / MAX_CATEGORY_WEIGHT 10 = 2.0, but min(1.0, 2.0) = 1.0
+        $highWeight = $this->createArticle(categoryWeight: 20);
+        $maxWeight = $this->createArticle(categoryWeight: 10);
+
+        // Both should produce same category score (both cap at 1.0)
+        self::assertSame(
+            $this->service->score($maxWeight),
+            $this->service->score($highWeight),
+        );
+    }
+
+    public function testHealthySourceScoresHigherThanDegraded(): void
+    {
+        $healthy = $this->createArticle(health: SourceHealth::Healthy);
+        $degraded = $this->createArticle(health: SourceHealth::Degraded);
+
+        self::assertGreaterThan(
+            $this->service->score($degraded),
+            $this->service->score($healthy),
+        );
+    }
+
+    public function testDegradedSourceScoresHigherThanFailing(): void
+    {
+        $degraded = $this->createArticle(health: SourceHealth::Degraded);
+        $failing = $this->createArticle(health: SourceHealth::Failing);
+
+        self::assertGreaterThan(
+            $this->service->score($failing),
+            $this->service->score($degraded),
+        );
+    }
+
+    public function testFailingSourceScoresHigherThanDisabled(): void
+    {
+        $failing = $this->createArticle(health: SourceHealth::Failing);
+        $disabled = $this->createArticle(health: SourceHealth::Disabled);
+
+        self::assertGreaterThan(
+            $this->service->score($disabled),
+            $this->service->score($failing),
+        );
+    }
+
+    public function testArticleWithoutPublishedAtUsesFetchedAt(): void
+    {
+        $category = new Category('Tech', 'tech', 10, '#3B82F6');
+        $source = new Source('Test', 'https://example.com/feed', $category, new \DateTimeImmutable());
+        $article = new Article(
+            'Test',
+            'https://example.com/no-published',
+            $source,
+            new \DateTimeImmutable('2026-04-04 11:00:00'),
+        );
+        // No publishedAt set -> falls back to fetchedAt
+        $article->setCategory($category);
+        $article->setEnrichmentMethod(EnrichmentMethod::RuleBased);
+
+        $score = $this->service->score($article);
+        self::assertGreaterThan(0.0, $score);
+        self::assertLessThan(1.0, $score);
+    }
+
+    public function testScoreComponentWeightsAddUpCorrectly(): void
+    {
+        // Perfect article: recent, high category, healthy source, AI enriched
+        $perfect = $this->createArticle(
+            categoryWeight: 10,
+            publishedAt: '2026-04-04 12:00:00', // now
+            enrichment: EnrichmentMethod::Ai,
+            health: SourceHealth::Healthy,
+        );
+        $perfectScore = $this->service->score($perfect);
+
+        // Should be very close to 1.0 (all components at max)
+        // 0.3*1.0 + 0.4*1.0 + 0.2*1.0 + 0.1*1.0 = 1.0
+        self::assertEqualsWithDelta(1.0, $perfectScore, 0.01);
+    }
+
+    public function testExactScoreForKnownInputs(): void
+    {
+        // Published exactly at "now" -> recency = 1.0
+        // Category weight 10 / MAX 10 = 1.0
+        // Healthy source = 1.0
+        // AI enrichment = 1.0
+        // combined = 0.3*1.0 + 0.4*1.0 + 0.2*1.0 + 0.1*1.0 = 1.0
+        $article = $this->createArticle(
+            categoryWeight: 10,
+            publishedAt: '2026-04-04 12:00:00',
+            enrichment: EnrichmentMethod::Ai,
+            health: SourceHealth::Healthy,
+        );
+
+        self::assertSame(1.0, $this->service->score($article));
+    }
+
+    public function testExactScoreForHalfLifeAge(): void
+    {
+        // Published exactly 12 hours ago -> recency = 2^(-12/12) = 0.5
+        // Category weight 5 / MAX 10 = 0.5
+        // Degraded source = 0.7
+        // RuleBased enrichment = 0.6
+        // combined = 0.3*0.5 + 0.4*0.5 + 0.2*0.7 + 0.1*0.6 = 0.15+0.20+0.14+0.06 = 0.55
+        $article = $this->createArticle(
+            categoryWeight: 5,
+            publishedAt: '2026-04-04 00:00:00', // 12h ago
+            enrichment: EnrichmentMethod::RuleBased,
+            health: SourceHealth::Degraded,
+        );
+
+        self::assertSame(0.55, $this->service->score($article));
+    }
+
+    public function testUncategorizedReturnsHalf(): void
+    {
+        // Uncategorized article -> category score = 0.5
+        // Published now -> recency = 1.0
+        // Healthy -> source = 1.0
+        // Null enrichment -> 0.3
+        // combined = 0.3*0.5 + 0.4*1.0 + 0.2*1.0 + 0.1*0.3 = 0.15+0.40+0.20+0.03 = 0.78
+        $category = new Category('Tech', 'tech', 10, '#3B82F6');
+        $source = new Source('Test', 'https://example.com/feed', $category, new \DateTimeImmutable());
+        $article = new Article(
+            'Test',
+            'https://example.com/uncategorized-2',
+            $source,
+            new \DateTimeImmutable('2026-04-04 12:00:00'),
+        );
+        $article->setPublishedAt(new \DateTimeImmutable('2026-04-04 12:00:00'));
+        // No category set -> 0.5
+
+        self::assertSame(0.78, $this->service->score($article));
+    }
+
+    public function testExactlyZeroAgeHoursReturnsMaxRecency(): void
+    {
+        // Published at exact same timestamp as clock -> ageHours = 0 -> returns 1.0
+        $article = $this->createArticle(publishedAt: '2026-04-04 12:00:00');
+        $this->service->score($article);
+
+        // This kills the LessThanOrEqualTo mutant (ageHours <= 0 -> ageHours < 0)
+        // If changed to <0, ageHours=0 would not trigger, falling through to exponential decay
+        // 2^(0) = 1.0 which is same, so we need a different approach
+
+        // Use 7 days exactly -> ageHours = 168 = RECENCY_MAX_AGE_HOURS -> returns 0.0
+        $article7days = $this->createArticle(publishedAt: '2026-03-28 12:00:00');
+        $score7days = $this->service->score($article7days);
+
+        // 7 days + 1 hour -> ageHours > 168 -> still 0.0
+        $articleOlder = $this->createArticle(publishedAt: '2026-03-28 11:00:00');
+        $scoreOlder = $this->service->score($articleOlder);
+
+        // Both should have same score (both hit the >= boundary vs >)
+        self::assertSame($score7days, $scoreOlder);
+    }
+
+    public function testPublishedAtTakesPriorityOverFetchedAt(): void
+    {
+        // If publishedAt is set, it should be used over fetchedAt
+        // This kills the Coalesce mutant
+        $category = new Category('Tech', 'tech', 10, '#3B82F6');
+        $source = new Source('Test', 'https://example.com/feed', $category, new \DateTimeImmutable());
+
+        $article = new Article(
+            'Test',
+            'https://example.com/coalesce-test',
+            $source,
+            new \DateTimeImmutable('2026-03-28 12:00:00'), // fetchedAt = 7 days ago
+        );
+        $article->setPublishedAt(new \DateTimeImmutable('2026-04-04 12:00:00')); // publishedAt = now
+        $article->setCategory($category);
+        $article->setEnrichmentMethod(EnrichmentMethod::RuleBased);
+
+        $scoreWithPublished = $this->service->score($article);
+
+        // Without publishedAt, fetchedAt would be 7 days ago -> low score
+        $article2 = new Article(
+            'Test2',
+            'https://example.com/coalesce-test-2',
+            $source,
+            new \DateTimeImmutable('2026-03-28 12:00:00'), // fetchedAt = 7 days ago
+        );
+        // No publishedAt set -> falls back to fetchedAt
+        $article2->setCategory($category);
+        $article2->setEnrichmentMethod(EnrichmentMethod::RuleBased);
+
+        $scoreWithoutPublished = $this->service->score($article2);
+
+        // The article with recent publishedAt should score much higher
+        self::assertGreaterThan($scoreWithoutPublished, $scoreWithPublished);
+    }
+
     private function createArticle(
         int $categoryWeight = 10,
         string $publishedAt = '2026-04-04 11:00:00',
         ?EnrichmentMethod $enrichment = EnrichmentMethod::RuleBased,
+        SourceHealth $health = SourceHealth::Healthy,
     ): Article {
         $category = new Category('Tech', 'tech', $categoryWeight, '#3B82F6');
         $source = new Source('Test', 'https://example.com/feed', $category, new \DateTimeImmutable());
+
+        // Use reflection to set health status since there's no public setter
+        $healthProp = new \ReflectionProperty(Source::class, 'healthStatus');
+        $healthProp->setValue($source, $health);
+
         $article = new Article(
             'Test Article',
             'https://example.com/article/' . random_int(1, 99999),

--- a/tests/Unit/Enrichment/Service/AiCategorizationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiCategorizationServiceTest.php
@@ -6,31 +6,35 @@ namespace App\Tests\Unit\Enrichment\Service;
 
 use App\Enrichment\Service\AiCategorizationService;
 use App\Enrichment\Service\AiQualityGateServiceInterface;
+use App\Enrichment\Service\CategorizationServiceInterface;
 use App\Enrichment\Service\RuleBasedCategorizationService;
+use App\Enrichment\ValueObject\EnrichmentResult;
 use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\ValueObject\EnrichmentMethod;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Platform\PlatformInterface;
-use Symfony\AI\Platform\Result\DeferredResult;
-use Symfony\AI\Platform\Result\RawResultInterface;
-use Symfony\AI\Platform\Result\TextResult;
-use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\Test\InMemoryPlatform;
 
 #[CoversClass(AiCategorizationService::class)]
+#[UsesClass(EnrichmentResult::class)]
 final class AiCategorizationServiceTest extends TestCase
 {
     public function testUsesAiWhenSuccessful(): void
     {
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn($this->makeDeferredResult('tech'));
+        $platform = new InMemoryPlatform('tech');
+
+        $qualityTracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $qualityTracker->expects(self::once())->method('recordAcceptance')->with('openrouter/free');
 
         $service = new AiCategorizationService(
             $platform,
             new RuleBasedCategorizationService(),
             $this->createQualityGateStub(),
-            $this->createStub(ModelQualityTrackerInterface::class),
+            $qualityTracker,
             new NullLogger(),
         );
 
@@ -46,15 +50,30 @@ final class AiCategorizationServiceTest extends TestCase
         $platform = $this->createStub(PlatformInterface::class);
         $platform->method('invoke')->willThrowException(new \RuntimeException('API down'));
 
+        $qualityTracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $qualityTracker->expects(self::never())->method('recordAcceptance');
+        $qualityTracker->expects(self::never())->method('recordRejection');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')
+            ->with(
+                self::stringContains('AI categorization failed'),
+                self::callback(static function (array $context): bool {
+                    return isset($context['error'])
+                        && isset($context['model'])
+                        && $context['error'] === 'API down'
+                        && $context['model'] === 'openrouter/free';
+                }),
+            );
+
         $service = new AiCategorizationService(
             $platform,
             new RuleBasedCategorizationService(),
             $this->createQualityGateStub(),
-            $this->createStub(ModelQualityTrackerInterface::class),
-            new NullLogger(),
+            $qualityTracker,
+            $logger,
         );
 
-        // Rule-based should still categorize based on keywords
         $result = $service->categorize(
             'Parliament votes on new election law',
             'The government coalition passed the new policy with opposition support.',
@@ -62,12 +81,51 @@ final class AiCategorizationServiceTest extends TestCase
 
         self::assertSame('politics', $result->value);
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+        self::assertNull($result->modelUsed);
     }
 
     public function testFallsBackOnInvalidAiResponse(): void
     {
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn($this->makeDeferredResult('invalid_category'));
+        $platform = new InMemoryPlatform('invalid_category');
+
+        $qualityTracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $qualityTracker->expects(self::never())->method('recordAcceptance');
+        $qualityTracker->expects(self::once())->method('recordRejection')->with('openrouter/free');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info')
+            ->with(
+                self::stringContains('rejected by quality gate'),
+                self::callback(static function (array $context): bool {
+                    return isset($context['slug'])
+                        && isset($context['model'])
+                        && $context['slug'] === 'invalid_category'
+                        && $context['model'] === 'openrouter/free';
+                }),
+            );
+
+        $service = new AiCategorizationService(
+            $platform,
+            new RuleBasedCategorizationService(),
+            $this->createQualityGateStub(),
+            $qualityTracker,
+            $logger,
+        );
+
+        $result = $service->categorize(
+            'Scientists discover new quantum physics breakthrough',
+            'The research team published their experiment results.',
+        );
+
+        self::assertSame('science', $result->value);
+        self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+    }
+
+    public function testTruncatesContentTo1000Chars(): void
+    {
+        // Verify it uses mb_substr to limit content - test by sending long content that still categorizes
+        $longContent = str_repeat('The government passed a new policy. ', 100);
+        $platform = new InMemoryPlatform('politics');
 
         $service = new AiCategorizationService(
             $platform,
@@ -77,14 +135,69 @@ final class AiCategorizationServiceTest extends TestCase
             new NullLogger(),
         );
 
-        // AI returns invalid slug, should fall back to rule-based
-        $result = $service->categorize(
-            'Scientists discover new quantum physics breakthrough',
-            'The research team published their experiment results.',
+        $result = $service->categorize('Policy Update', $longContent);
+
+        self::assertSame('politics', $result->value);
+        self::assertSame(EnrichmentMethod::Ai, $result->method);
+    }
+
+    public function testHandlesNullContent(): void
+    {
+        $platform = new InMemoryPlatform('tech');
+
+        $service = new AiCategorizationService(
+            $platform,
+            new RuleBasedCategorizationService(),
+            $this->createQualityGateStub(),
+            $this->createStub(ModelQualityTrackerInterface::class),
+            new NullLogger(),
         );
 
-        self::assertSame('science', $result->value);
+        $result = $service->categorize('Tech News Title', null);
+
+        self::assertSame('tech', $result->value);
+        self::assertSame(EnrichmentMethod::Ai, $result->method);
+    }
+
+    public function testFallbackServiceCalledOnRejection(): void
+    {
+        $platform = new InMemoryPlatform('invalid_slug');
+
+        $fallback = $this->createMock(CategorizationServiceInterface::class);
+        $fallback->expects(self::once())->method('categorize')
+            ->with('Title', 'Content')
+            ->willReturn(new EnrichmentResult('tech', EnrichmentMethod::RuleBased));
+
+        $service = new AiCategorizationService(
+            $platform,
+            $fallback,
+            $this->createQualityGateStub(),
+            $this->createStub(ModelQualityTrackerInterface::class),
+            new NullLogger(),
+        );
+
+        $result = $service->categorize('Title', 'Content');
+
+        self::assertSame('tech', $result->value);
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+    }
+
+    public function testTrimsAndLowercasesAiResponse(): void
+    {
+        $platform = new InMemoryPlatform('  TECH  ');
+
+        $service = new AiCategorizationService(
+            $platform,
+            new RuleBasedCategorizationService(),
+            $this->createQualityGateStub(),
+            $this->createStub(ModelQualityTrackerInterface::class),
+            new NullLogger(),
+        );
+
+        $result = $service->categorize('Test', 'Content');
+
+        self::assertSame('tech', $result->value);
+        self::assertSame(EnrichmentMethod::Ai, $result->method);
     }
 
     private function createQualityGateStub(): AiQualityGateServiceInterface
@@ -96,18 +209,5 @@ final class AiCategorizationServiceTest extends TestCase
         $stub->method('validateSummary')->willReturn(true);
 
         return $stub;
-    }
-
-    private function makeDeferredResult(string $text): DeferredResult
-    {
-        $textResult = new TextResult($text);
-
-        $rawResult = $this->createStub(RawResultInterface::class);
-
-        $converter = $this->createStub(ResultConverterInterface::class);
-        $converter->method('convert')->willReturn($textResult);
-        $converter->method('getTokenUsageExtractor')->willReturn(null);
-
-        return new DeferredResult($converter, $rawResult);
     }
 }

--- a/tests/Unit/Enrichment/Service/AiKeywordExtractionServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiKeywordExtractionServiceTest.php
@@ -5,25 +5,21 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Enrichment\Service;
 
 use App\Enrichment\Service\AiKeywordExtractionService;
+use App\Enrichment\Service\KeywordExtractionServiceInterface;
 use App\Enrichment\Service\RuleBasedKeywordExtractionService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Platform\PlatformInterface;
-use Symfony\AI\Platform\Result\DeferredResult;
-use Symfony\AI\Platform\Result\RawResultInterface;
-use Symfony\AI\Platform\Result\TextResult;
-use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\Test\InMemoryPlatform;
 
 #[CoversClass(AiKeywordExtractionService::class)]
 final class AiKeywordExtractionServiceTest extends TestCase
 {
     public function testUsesAiWhenSuccessful(): void
     {
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn(
-            $this->makeDeferredResult('Google, Artificial Intelligence, Developers'),
-        );
+        $platform = new InMemoryPlatform('Google, Artificial Intelligence, Developers');
 
         $service = new AiKeywordExtractionService(
             $platform,
@@ -44,10 +40,21 @@ final class AiKeywordExtractionServiceTest extends TestCase
         $platform = $this->createStub(PlatformInterface::class);
         $platform->method('invoke')->willThrowException(new \RuntimeException('API down'));
 
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')
+            ->with(
+                self::stringContains('AI keyword extraction failed'),
+                self::callback(static function (array $context): bool {
+                    return isset($context['error'])
+                        && isset($context['model'])
+                        && $context['model'] === 'openrouter/free';
+                }),
+            );
+
         $service = new AiKeywordExtractionService(
             $platform,
             new RuleBasedKeywordExtractionService(),
-            new NullLogger(),
+            $logger,
         );
 
         $keywords = $service->extract(
@@ -55,20 +62,29 @@ final class AiKeywordExtractionServiceTest extends TestCase
             'Microsoft released a major Azure cloud platform update.',
         );
 
-        // Rule-based should extract proper nouns
         self::assertNotSame([], $keywords);
         self::assertContains('Microsoft', $keywords);
     }
 
     public function testFallsBackOnEmptyAiResponse(): void
     {
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn($this->makeDeferredResult(''));
+        $platform = new InMemoryPlatform('');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info')
+            ->with(
+                self::stringContains('no valid keywords'),
+                self::callback(static function (array $context): bool {
+                    return isset($context['response'])
+                        && isset($context['model'])
+                        && $context['model'] === 'openrouter/free';
+                }),
+            );
 
         $service = new AiKeywordExtractionService(
             $platform,
             new RuleBasedKeywordExtractionService(),
-            new NullLogger(),
+            $logger,
         );
 
         $keywords = $service->extract(
@@ -76,16 +92,12 @@ final class AiKeywordExtractionServiceTest extends TestCase
             'Apple announced a new product at their Cupertino headquarters.',
         );
 
-        // Empty AI response should fall back to rule-based
         self::assertContains('Apple', $keywords);
     }
 
     public function testTrimsKeywords(): void
     {
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn(
-            $this->makeDeferredResult(' Google ,  AI , Cloud '),
-        );
+        $platform = new InMemoryPlatform(' Google ,  AI , Cloud ');
 
         $service = new AiKeywordExtractionService(
             $platform,
@@ -100,10 +112,7 @@ final class AiKeywordExtractionServiceTest extends TestCase
 
     public function testLimitsToMaxKeywords(): void
     {
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn(
-            $this->makeDeferredResult('A, B, C, D, E, F, G, H, I, J'),
-        );
+        $platform = new InMemoryPlatform('A, B, C, D, E, F, G, H, I, J');
 
         $service = new AiKeywordExtractionService(
             $platform,
@@ -113,19 +122,108 @@ final class AiKeywordExtractionServiceTest extends TestCase
 
         $keywords = $service->extract('Test', 'Content');
 
-        self::assertLessThanOrEqual(8, \count($keywords));
+        self::assertCount(8, $keywords);
+        self::assertSame(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'], $keywords);
     }
 
-    private function makeDeferredResult(string $text): DeferredResult
+    public function testFiltersEmptyKeywordsAfterTrim(): void
     {
-        $textResult = new TextResult($text);
+        $platform = new InMemoryPlatform('Google, , , AI');
 
-        $rawResult = $this->createStub(RawResultInterface::class);
+        $service = new AiKeywordExtractionService(
+            $platform,
+            new RuleBasedKeywordExtractionService(),
+            new NullLogger(),
+        );
 
-        $converter = $this->createStub(ResultConverterInterface::class);
-        $converter->method('convert')->willReturn($textResult);
-        $converter->method('getTokenUsageExtractor')->willReturn(null);
+        $keywords = $service->extract('Test', 'Content');
 
-        return new DeferredResult($converter, $rawResult);
+        self::assertSame(['Google', 'AI'], $keywords);
+    }
+
+    public function testFiltersKeywordsOver100Chars(): void
+    {
+        $longKeyword = str_repeat('x', 101);
+        $platform = new InMemoryPlatform("Google, {$longKeyword}, AI");
+
+        $service = new AiKeywordExtractionService(
+            $platform,
+            new RuleBasedKeywordExtractionService(),
+            new NullLogger(),
+        );
+
+        $keywords = $service->extract('Test', 'Content');
+
+        self::assertSame(['Google', 'AI'], $keywords);
+    }
+
+    public function testKeywordExactly100CharsIsAccepted(): void
+    {
+        $keyword100 = str_repeat('x', 100);
+        $platform = new InMemoryPlatform("Google, {$keyword100}");
+
+        $service = new AiKeywordExtractionService(
+            $platform,
+            new RuleBasedKeywordExtractionService(),
+            new NullLogger(),
+        );
+
+        $keywords = $service->extract('Test', 'Content');
+
+        self::assertCount(2, $keywords);
+        self::assertSame($keyword100, $keywords[1]);
+    }
+
+    public function testFallbackCalledOnEmptyResult(): void
+    {
+        $platform = new InMemoryPlatform(',,,'); // All empty after trim
+
+        $fallback = $this->createMock(KeywordExtractionServiceInterface::class);
+        $fallback->expects(self::once())->method('extract')
+            ->with('My Title', 'My Content')
+            ->willReturn(['Fallback']);
+
+        $service = new AiKeywordExtractionService(
+            $platform,
+            $fallback,
+            new NullLogger(),
+        );
+
+        $keywords = $service->extract('My Title', 'My Content');
+
+        self::assertSame(['Fallback'], $keywords);
+    }
+
+    public function testKeywordsWithMbChars(): void
+    {
+        $platform = new InMemoryPlatform('München, São Paulo, Café');
+
+        $service = new AiKeywordExtractionService(
+            $platform,
+            new RuleBasedKeywordExtractionService(),
+            new NullLogger(),
+        );
+
+        $keywords = $service->extract('Test', 'Content');
+
+        self::assertCount(3, $keywords);
+        self::assertSame('München', $keywords[0]);
+        self::assertSame('São Paulo', $keywords[1]);
+        self::assertSame('Café', $keywords[2]);
+    }
+
+    public function testHandlesNullContent(): void
+    {
+        $platform = new InMemoryPlatform('Keyword1, Keyword2');
+
+        $service = new AiKeywordExtractionService(
+            $platform,
+            new RuleBasedKeywordExtractionService(),
+            new NullLogger(),
+        );
+
+        $keywords = $service->extract('Test Title', null);
+
+        self::assertSame(['Keyword1', 'Keyword2'], $keywords);
     }
 }

--- a/tests/Unit/Enrichment/Service/AiQualityGateServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiQualityGateServiceTest.php
@@ -66,4 +66,38 @@ final class AiQualityGateServiceTest extends TestCase
         self::assertFalse($this->gate->validateCategorization('unknown'));
         self::assertFalse($this->gate->validateCategorization(''));
     }
+
+    public function testSummaryExactly20CharsPassesLowerBound(): void
+    {
+        // 20 chars exactly should pass length check
+        $summary = str_repeat('a', 20);
+        self::assertTrue($this->gate->validateSummary($summary, 'Different Title'));
+    }
+
+    public function testSummaryExactly19CharsFailsLowerBound(): void
+    {
+        $summary = str_repeat('a', 19);
+        self::assertFalse($this->gate->validateSummary($summary, 'Different Title'));
+    }
+
+    public function testSummaryExactly500CharsPassesUpperBound(): void
+    {
+        $summary = str_repeat('a', 500);
+        self::assertTrue($this->gate->validateSummary($summary, 'Different Title'));
+    }
+
+    public function testSummaryExactly501CharsFailsUpperBound(): void
+    {
+        $summary = str_repeat('a', 501);
+        self::assertFalse($this->gate->validateSummary($summary, 'Different Title'));
+    }
+
+    public function testSimilarButNotIdenticalTitlePasses(): void
+    {
+        // Just below 90% similarity should pass
+        self::assertTrue($this->gate->validateSummary(
+            'The quick brown fox jumps over the lazy dog near the park and the lake area.',
+            'A completely different title that has nothing to do with foxes',
+        ));
+    }
 }

--- a/tests/Unit/Enrichment/Service/AiSummarizationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiSummarizationServiceTest.php
@@ -7,32 +7,35 @@ namespace App\Tests\Unit\Enrichment\Service;
 use App\Enrichment\Service\AiQualityGateServiceInterface;
 use App\Enrichment\Service\AiSummarizationService;
 use App\Enrichment\Service\RuleBasedSummarizationService;
+use App\Enrichment\Service\SummarizationServiceInterface;
+use App\Enrichment\ValueObject\EnrichmentResult;
 use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\ValueObject\EnrichmentMethod;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Platform\PlatformInterface;
-use Symfony\AI\Platform\Result\DeferredResult;
-use Symfony\AI\Platform\Result\RawResultInterface;
-use Symfony\AI\Platform\Result\TextResult;
-use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\Test\InMemoryPlatform;
 
 #[CoversClass(AiSummarizationService::class)]
+#[UsesClass(EnrichmentResult::class)]
 final class AiSummarizationServiceTest extends TestCase
 {
     public function testUsesAiWhenSuccessful(): void
     {
         $aiSummary = 'The government announced new measures to combat rising inflation rates.';
+        $platform = new InMemoryPlatform($aiSummary);
 
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn($this->makeDeferredResult($aiSummary));
+        $qualityTracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $qualityTracker->expects(self::once())->method('recordAcceptance')->with('openrouter/free');
 
         $service = new AiSummarizationService(
             $platform,
             new RuleBasedSummarizationService(),
             $this->createQualityGateStub(),
-            $this->createStub(ModelQualityTrackerInterface::class),
+            $qualityTracker,
             new NullLogger(),
         );
 
@@ -48,12 +51,27 @@ final class AiSummarizationServiceTest extends TestCase
         $platform = $this->createStub(PlatformInterface::class);
         $platform->method('invoke')->willThrowException(new \RuntimeException('API timeout'));
 
+        $qualityTracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $qualityTracker->expects(self::never())->method('recordAcceptance');
+        $qualityTracker->expects(self::never())->method('recordRejection');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')
+            ->with(
+                self::stringContains('AI summarization failed'),
+                self::callback(static function (array $context): bool {
+                    return isset($context['error'])
+                        && isset($context['model'])
+                        && $context['model'] === 'openrouter/free';
+                }),
+            );
+
         $service = new AiSummarizationService(
             $platform,
             new RuleBasedSummarizationService(),
             $this->createQualityGateStub(),
-            $this->createStub(ModelQualityTrackerInterface::class),
-            new NullLogger(),
+            $qualityTracker,
+            $logger,
         );
 
         $content = 'This is the first sentence of a long article. This is the second sentence with more detail. And a third one.';
@@ -61,19 +79,34 @@ final class AiSummarizationServiceTest extends TestCase
 
         self::assertStringContainsString('first sentence', $result->value ?? '');
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+        self::assertNull($result->modelUsed);
     }
 
     public function testFallsBackOnTooShortAiResponse(): void
     {
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn($this->makeDeferredResult('Short.'));
+        $platform = new InMemoryPlatform('Short.');
+
+        $qualityTracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $qualityTracker->expects(self::never())->method('recordAcceptance');
+        $qualityTracker->expects(self::once())->method('recordRejection')->with('openrouter/free');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info')
+            ->with(
+                self::stringContains('rejected by quality gate'),
+                self::callback(static function (array $context): bool {
+                    return isset($context['length'])
+                        && isset($context['model'])
+                        && $context['model'] === 'openrouter/free';
+                }),
+            );
 
         $service = new AiSummarizationService(
             $platform,
             new RuleBasedSummarizationService(),
             $this->createQualityGateStub(),
-            $this->createStub(ModelQualityTrackerInterface::class),
-            new NullLogger(),
+            $qualityTracker,
+            $logger,
         );
 
         $content = 'This is a sufficiently long article content for testing purposes. It should trigger the rule-based fallback.';
@@ -86,8 +119,7 @@ final class AiSummarizationServiceTest extends TestCase
     public function testRejectsSummaryThatMatchesTitle(): void
     {
         $title = 'Breaking News: Major Economic Policy Change';
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn($this->makeDeferredResult($title));
+        $platform = new InMemoryPlatform($title);
 
         $service = new AiSummarizationService(
             $platform,
@@ -100,8 +132,49 @@ final class AiSummarizationServiceTest extends TestCase
         $content = 'This is a sufficiently long article content for testing purposes. It should trigger the rule-based fallback.';
         $result = $service->summarize($content, $title);
 
-        // Summary that's just the title repeated should be rejected by quality gate
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+    }
+
+    public function testFallbackCalledWithOriginalArgs(): void
+    {
+        $platform = $this->createStub(PlatformInterface::class);
+        $platform->method('invoke')->willThrowException(new \RuntimeException('Fail'));
+
+        $fallback = $this->createMock(SummarizationServiceInterface::class);
+        $fallback->expects(self::once())->method('summarize')
+            ->with('Content text', 'My Title')
+            ->willReturn(new EnrichmentResult('Fallback summary', EnrichmentMethod::RuleBased));
+
+        $service = new AiSummarizationService(
+            $platform,
+            $fallback,
+            $this->createQualityGateStub(),
+            $this->createStub(ModelQualityTrackerInterface::class),
+            new NullLogger(),
+        );
+
+        $result = $service->summarize('Content text', 'My Title');
+
+        self::assertSame('Fallback summary', $result->value);
+    }
+
+    public function testTruncatesContentTo2000Chars(): void
+    {
+        // Extremely long content should still work
+        $longContent = str_repeat('This is a sentence. ', 500);
+        $platform = new InMemoryPlatform('A valid AI summary of sufficient length for the quality gate.');
+
+        $service = new AiSummarizationService(
+            $platform,
+            new RuleBasedSummarizationService(),
+            $this->createQualityGateStub(),
+            $this->createStub(ModelQualityTrackerInterface::class),
+            new NullLogger(),
+        );
+
+        $result = $service->summarize($longContent, 'Title');
+
+        self::assertSame(EnrichmentMethod::Ai, $result->method);
     }
 
     private function createQualityGateStub(): AiQualityGateServiceInterface
@@ -120,18 +193,5 @@ final class AiSummarizationServiceTest extends TestCase
         );
 
         return $stub;
-    }
-
-    private function makeDeferredResult(string $text): DeferredResult
-    {
-        $textResult = new TextResult($text);
-
-        $rawResult = $this->createStub(RawResultInterface::class);
-
-        $converter = $this->createStub(ResultConverterInterface::class);
-        $converter->method('convert')->willReturn($textResult);
-        $converter->method('getTokenUsageExtractor')->willReturn(null);
-
-        return new DeferredResult($converter, $rawResult);
     }
 }

--- a/tests/Unit/Enrichment/Service/AiTranslationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiTranslationServiceTest.php
@@ -6,14 +6,13 @@ namespace App\Tests\Unit\Enrichment\Service;
 
 use App\Enrichment\Service\AiTranslationService;
 use App\Enrichment\Service\RuleBasedTranslationService;
+use App\Enrichment\Service\TranslationServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Platform\PlatformInterface;
-use Symfony\AI\Platform\Result\DeferredResult;
-use Symfony\AI\Platform\Result\RawResultInterface;
-use Symfony\AI\Platform\Result\TextResult;
-use Symfony\AI\Platform\ResultConverterInterface;
+use Symfony\AI\Platform\Test\InMemoryPlatform;
 
 #[CoversClass(AiTranslationService::class)]
 final class AiTranslationServiceTest extends TestCase
@@ -21,9 +20,7 @@ final class AiTranslationServiceTest extends TestCase
     public function testTranslatesSuccessfully(): void
     {
         $translated = 'Federal government announces new measures';
-
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn($this->makeDeferredResult($translated));
+        $platform = new InMemoryPlatform($translated);
 
         $service = new AiTranslationService(
             $platform,
@@ -43,10 +40,26 @@ final class AiTranslationServiceTest extends TestCase
         $platform = $this->createStub(PlatformInterface::class);
         $platform->method('invoke')->willThrowException(new \RuntimeException('API timeout'));
 
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')
+            ->with(
+                self::stringContains('AI translation failed'),
+                self::callback(static function (array $context): bool {
+                    return isset($context['error'])
+                        && isset($context['model'])
+                        && $context['model'] === 'openrouter/free';
+                }),
+            );
+
+        $fallback = $this->createMock(TranslationServiceInterface::class);
+        $fallback->expects(self::once())->method('translate')
+            ->with($original, 'de', 'en')
+            ->willReturn($original);
+
         $service = new AiTranslationService(
             $platform,
-            new RuleBasedTranslationService(),
-            new NullLogger(),
+            $fallback,
+            $logger,
         );
 
         $result = $service->translate($original, 'de', 'en');
@@ -57,14 +70,28 @@ final class AiTranslationServiceTest extends TestCase
     public function testFallsBackOnEmptyResponse(): void
     {
         $original = 'Bundesregierung beschließt neue Maßnahmen';
+        $platform = new InMemoryPlatform('');
 
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn($this->makeDeferredResult(''));
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info')
+            ->with(
+                self::stringContains('rejected'),
+                self::callback(static function (array $context): bool {
+                    return isset($context['original_length'])
+                        && isset($context['translated_length'])
+                        && isset($context['model'])
+                        && $context['model'] === 'openrouter/free';
+                }),
+            );
+
+        $fallback = $this->createMock(TranslationServiceInterface::class);
+        $fallback->expects(self::once())->method('translate')
+            ->willReturn($original);
 
         $service = new AiTranslationService(
             $platform,
-            new RuleBasedTranslationService(),
-            new NullLogger(),
+            $fallback,
+            $logger,
         );
 
         $result = $service->translate($original, 'de', 'en');
@@ -75,14 +102,28 @@ final class AiTranslationServiceTest extends TestCase
     public function testFallsBackOnTooSimilarResponse(): void
     {
         $original = 'Some text that stays the same';
+        $platform = new InMemoryPlatform($original);
 
-        $platform = $this->createStub(PlatformInterface::class);
-        $platform->method('invoke')->willReturn($this->makeDeferredResult($original));
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info')
+            ->with(
+                self::stringContains('rejected'),
+                self::callback(static function (array $context): bool {
+                    return isset($context['original_length'])
+                        && isset($context['translated_length'])
+                        && isset($context['model'])
+                        && $context['model'] === 'openrouter/free';
+                }),
+            );
+
+        $fallback = $this->createMock(TranslationServiceInterface::class);
+        $fallback->expects(self::once())->method('translate')
+            ->willReturn($original);
 
         $service = new AiTranslationService(
             $platform,
-            new RuleBasedTranslationService(),
-            new NullLogger(),
+            $fallback,
+            $logger,
         );
 
         $result = $service->translate($original, 'de', 'en');
@@ -98,9 +139,12 @@ final class AiTranslationServiceTest extends TestCase
         // Platform should NOT be called when languages match
         $platform->method('invoke')->willThrowException(new \RuntimeException('Should not be called'));
 
+        $fallback = $this->createMock(TranslationServiceInterface::class);
+        $fallback->expects(self::never())->method('translate');
+
         $service = new AiTranslationService(
             $platform,
-            new RuleBasedTranslationService(),
+            $fallback,
             new NullLogger(),
         );
 
@@ -109,16 +153,39 @@ final class AiTranslationServiceTest extends TestCase
         self::assertSame($original, $result);
     }
 
-    private function makeDeferredResult(string $text): DeferredResult
+    public function testAcceptsSufficientlyDifferentTranslation(): void
     {
-        $textResult = new TextResult($text);
+        // German text -> very different English translation
+        $original = 'Dies ist ein deutscher Text';
+        $translated = 'This is a German text completely different';
+        $platform = new InMemoryPlatform($translated);
 
-        $rawResult = $this->createStub(RawResultInterface::class);
+        $fallback = $this->createMock(TranslationServiceInterface::class);
+        $fallback->expects(self::never())->method('translate');
 
-        $converter = $this->createStub(ResultConverterInterface::class);
-        $converter->method('convert')->willReturn($textResult);
-        $converter->method('getTokenUsageExtractor')->willReturn(null);
+        $service = new AiTranslationService(
+            $platform,
+            $fallback,
+            new NullLogger(),
+        );
 
-        return new DeferredResult($converter, $rawResult);
+        $result = $service->translate($original, 'de', 'en');
+
+        self::assertSame($translated, $result);
+    }
+
+    public function testTrimsWhitespaceFromTranslation(): void
+    {
+        $platform = new InMemoryPlatform('  Translated text with whitespace  ');
+
+        $service = new AiTranslationService(
+            $platform,
+            new RuleBasedTranslationService(),
+            new NullLogger(),
+        );
+
+        $result = $service->translate('Original text that is different enough', 'de', 'en');
+
+        self::assertSame('Translated text with whitespace', $result);
     }
 }

--- a/tests/Unit/Enrichment/Service/RuleBasedCategorizationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/RuleBasedCategorizationServiceTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Enrichment\Service;
 
 use App\Enrichment\Service\RuleBasedCategorizationService;
+use App\Enrichment\ValueObject\EnrichmentResult;
 use App\Shared\ValueObject\EnrichmentMethod;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(RuleBasedCategorizationService::class)]
+#[UsesClass(EnrichmentResult::class)]
 final class RuleBasedCategorizationServiceTest extends TestCase
 {
     private RuleBasedCategorizationService $service;
@@ -28,6 +31,7 @@ final class RuleBasedCategorizationServiceTest extends TestCase
 
         self::assertSame('tech', $result->value);
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+        self::assertNull($result->modelUsed);
     }
 
     public function testCategorizePoliticsArticle(): void
@@ -38,6 +42,28 @@ final class RuleBasedCategorizationServiceTest extends TestCase
         );
 
         self::assertSame('politics', $result->value);
+        self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+    }
+
+    public function testCategorizeBusinessArticle(): void
+    {
+        $result = $this->service->categorize(
+            'Stock market reaches new high',
+            'The economy showed strong growth with rising revenue and profit across the finance sector.',
+        );
+
+        self::assertSame('business', $result->value);
+        self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+    }
+
+    public function testCategorizeScienceArticle(): void
+    {
+        $result = $this->service->categorize(
+            'Scientists make quantum physics breakthrough',
+            'The research team published their discovery from a new experiment in the lab.',
+        );
+
+        self::assertSame('science', $result->value);
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
     }
 
@@ -63,6 +89,17 @@ final class RuleBasedCategorizationServiceTest extends TestCase
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
     }
 
+    public function testRequiresAtLeastTwoKeywordMatches(): void
+    {
+        // Only one keyword match ("government") -> should return null
+        $result = $this->service->categorize(
+            'Random topic',
+            'The government did something.',
+        );
+
+        self::assertNull($result->value);
+    }
+
     public function testUsesContentForCategorization(): void
     {
         // Title alone has no keywords, but content does
@@ -73,5 +110,57 @@ final class RuleBasedCategorizationServiceTest extends TestCase
 
         self::assertSame('science', $result->value);
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+    }
+
+    public function testIsCaseInsensitive(): void
+    {
+        $result = $this->service->categorize(
+            'PARLIAMENT VOTES ON ELECTION',
+            'THE GOVERNMENT PASSED A NEW LAW WITH MINISTER SUPPORT.',
+        );
+
+        self::assertSame('politics', $result->value);
+    }
+
+    public function testHandlesNullContent(): void
+    {
+        $result = $this->service->categorize(
+            'Parliament votes on new election law with government coalition',
+            null,
+        );
+
+        self::assertSame('politics', $result->value);
+    }
+
+    public function testBestCategoryWins(): void
+    {
+        // Mix of tech and politics keywords - tech should win with more matches
+        $result = $this->service->categorize(
+            'Google AI developer API cloud software announcement',
+            'The new artificial intelligence programming platform.',
+        );
+
+        self::assertSame('tech', $result->value);
+    }
+
+    public function testCategorizeWithGermanUmlautContent(): void
+    {
+        // German text with umlauts - tests mb_strtolower vs strtolower
+        $result = $this->service->categorize(
+            'Bundesliga: MÜNCHEN gewinnt Meisterschaft',
+            'Das team feiert den league sieg am stadium nach dem match gegen den trainer.',
+        );
+
+        self::assertSame('sports', $result->value);
+    }
+
+    public function testCategorizeWithAccentedChars(): void
+    {
+        $result = $this->service->categorize(
+            'Élection présidentielle: résultats du vote',
+            'Le government a annoncé une nouvelle policy après election.',
+        );
+
+        self::assertSame('politics', $result->value);
     }
 }

--- a/tests/Unit/Enrichment/Service/RuleBasedKeywordExtractionServiceTest.php
+++ b/tests/Unit/Enrichment/Service/RuleBasedKeywordExtractionServiceTest.php
@@ -92,4 +92,43 @@ final class RuleBasedKeywordExtractionServiceTest extends TestCase
         $berlinCount = \count(array_filter($keywords, static fn (string $k): bool => $k === 'Berlin'));
         self::assertSame(1, $berlinCount);
     }
+
+    public function testContentKeywordsAreIncluded(): void
+    {
+        // Keywords only in content (not title) should appear
+        $keywords = $this->service->extract(
+            'a lowercase title only',
+            'Microsoft announced a partnership with Amazon in Seattle.',
+        );
+
+        self::assertContains('Microsoft', $keywords);
+        self::assertContains('Amazon', $keywords);
+        self::assertContains('Seattle', $keywords);
+    }
+
+    public function testExactlyMaxKeywordsReturned(): void
+    {
+        // 9 unique proper nouns -> should return exactly 8
+        $keywords = $this->service->extract(
+            'Apple Google Microsoft Amazon Meta Tesla Nvidia Intel Samsung',
+            '',
+        );
+
+        self::assertSame(8, \count($keywords));
+    }
+
+    public function testFilterMultiWordStartingWithStopWord(): void
+    {
+        // "The Company" should be filtered because "The" is a stop word
+        $keywords = $this->service->extract(
+            'Regular Title',
+            'Something about Apple Inc and not about stop word phrases.',
+        );
+
+        foreach ($keywords as $keyword) {
+            $firstWord = explode(' ', $keyword)[0];
+            self::assertNotSame('The', $firstWord);
+            self::assertNotSame('This', $firstWord);
+        }
+    }
 }

--- a/tests/Unit/Enrichment/Service/RuleBasedSummarizationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/RuleBasedSummarizationServiceTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Enrichment\Service;
 
 use App\Enrichment\Service\RuleBasedSummarizationService;
+use App\Enrichment\ValueObject\EnrichmentResult;
 use App\Shared\ValueObject\EnrichmentMethod;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(RuleBasedSummarizationService::class)]
+#[UsesClass(EnrichmentResult::class)]
 final class RuleBasedSummarizationServiceTest extends TestCase
 {
     private RuleBasedSummarizationService $service;
@@ -27,6 +30,7 @@ final class RuleBasedSummarizationServiceTest extends TestCase
 
         self::assertSame('This is the first sentence of the article. This is the second sentence with more detail.', $result->value);
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+        self::assertNull($result->modelUsed);
     }
 
     public function testReturnsNullValueForShortContent(): void
@@ -34,6 +38,25 @@ final class RuleBasedSummarizationServiceTest extends TestCase
         $result = $this->service->summarize('Too short.');
 
         self::assertNull($result->value);
+        self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+    }
+
+    public function testReturnsNullForContentExactlyAtMinLength(): void
+    {
+        // MIN_CONTENT_LENGTH = 50; create content of exactly 49 chars
+        $content = str_repeat('x', 49);
+        $result = $this->service->summarize($content);
+
+        self::assertNull($result->value);
+    }
+
+    public function testAcceptsContentAtMinLength(): void
+    {
+        // 50 chars + sentence structure
+        $content = 'This is a sentence long enough to be over fifty characters for valid content.';
+        $result = $this->service->summarize($content);
+
+        self::assertNotNull($result->value);
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
     }
 
@@ -60,6 +83,18 @@ final class RuleBasedSummarizationServiceTest extends TestCase
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
     }
 
+    public function testTruncatedSummaryExactly500Chars(): void
+    {
+        $longSentence = str_repeat('word ', 100) . 'end.';
+        $content = $longSentence . ' Second sentence here with more words to ensure truncation happens.';
+
+        $result = $this->service->summarize($content);
+
+        self::assertNotNull($result->value);
+        // MAX_SUMMARY_LENGTH = 500, truncated to 497 + "..." = 500
+        self::assertSame(500, mb_strlen($result->value));
+    }
+
     public function testHandlesEmptyContent(): void
     {
         $result = $this->service->summarize('');
@@ -68,13 +103,54 @@ final class RuleBasedSummarizationServiceTest extends TestCase
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
     }
 
+    public function testHandlesWhitespaceOnlyContent(): void
+    {
+        $result = $this->service->summarize('   ');
+
+        self::assertNull($result->value);
+    }
+
     public function testFiltersShortFragments(): void
     {
         $content = 'Dr. Smith announced a breakthrough in quantum computing research. The discovery could revolutionize modern technology.';
 
         $result = $this->service->summarize($content);
 
-        // "Dr." alone is too short, so it should be filtered and the real sentences used
+        self::assertNotNull($result->value);
+        self::assertSame(EnrichmentMethod::RuleBased, $result->method);
+        // "Dr." alone (<10 chars) should be filtered; real sentences should be used
+        self::assertStringContainsString('announced a breakthrough', $result->value);
+    }
+
+    public function testReturnsNullWhenAllSentencesAreTooShort(): void
+    {
+        // All fragments < 10 chars after split, but total content >= 50
+        $content = str_repeat('Ok. Ab. ', 10);
+
+        $result = $this->service->summarize($content);
+
+        // All split parts are too short -> filtered to empty -> return null
+        self::assertNull($result->value);
+    }
+
+    public function testHandlesExclamationAndQuestionMarks(): void
+    {
+        $content = 'What an amazing discovery! The scientists were ecstatic about the results. How will this change everything?';
+
+        $result = $this->service->summarize($content);
+
+        self::assertNotNull($result->value);
+        // Should take first two valid sentences
+        self::assertStringContainsString('What an amazing discovery!', $result->value);
+        self::assertStringContainsString('The scientists were ecstatic', $result->value);
+    }
+
+    public function testTitleParameterAccepted(): void
+    {
+        $content = 'This is a sufficiently long article content for testing the title parameter functionality.';
+
+        $result = $this->service->summarize($content, 'My Title');
+
         self::assertNotNull($result->value);
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
     }

--- a/tests/Unit/Notification/Command/LoadAlertRulesCommandTest.php
+++ b/tests/Unit/Notification/Command/LoadAlertRulesCommandTest.php
@@ -31,6 +31,8 @@ final class LoadAlertRulesCommandTest extends TestCase
 
     private MockObject&AlertRuleFixtureLoaderInterface $loader;
 
+    private MockClock $clock;
+
     private CommandTester $tester;
 
     protected function setUp(): void
@@ -38,11 +40,12 @@ final class LoadAlertRulesCommandTest extends TestCase
         $this->userRepository = $this->createMock(UserRepositoryInterface::class);
         $this->alertRuleRepository = $this->createMock(AlertRuleRepositoryInterface::class);
         $this->loader = $this->createMock(AlertRuleFixtureLoaderInterface::class);
+        $this->clock = new MockClock('2026-04-05 10:00:00');
 
         $command = new LoadAlertRulesCommand(
             $this->userRepository,
             $this->alertRuleRepository,
-            new MockClock('2026-04-05 10:00:00'),
+            $this->clock,
             $this->loader,
             'admin@test.com',
         );
@@ -67,6 +70,30 @@ final class LoadAlertRulesCommandTest extends TestCase
         self::assertSame(0, $this->tester->getStatusCode());
         self::assertStringContainsString('Created: Rule A', $this->tester->getDisplay());
         self::assertStringContainsString('1 created', $this->tester->getDisplay());
+        self::assertStringContainsString('0 updated', $this->tester->getDisplay());
+        self::assertStringContainsString('0 purged', $this->tester->getDisplay());
+    }
+
+    public function testCreatesMultipleNewRules(): void
+    {
+        $this->userRepository->method('findByEmail')->willReturn(new User('admin@test.com', 'hashed'));
+        $this->alertRuleRepository->method('findByNameAndUser')->willReturn(null);
+        $this->alertRuleRepository->method('findByUser')->willReturn([]);
+        $this->loader->method('loadFromPath')->willReturn([
+            $this->fixture('Rule A'),
+            $this->fixture('Rule B'),
+        ]);
+
+        $this->alertRuleRepository->expects(self::exactly(2))->method('save');
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+        ]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertStringContainsString('Created: Rule A', $this->tester->getDisplay());
+        self::assertStringContainsString('Created: Rule B', $this->tester->getDisplay());
+        self::assertStringContainsString('2 created', $this->tester->getDisplay());
     }
 
     public function testUpdatesExistingRules(): void
@@ -89,6 +116,88 @@ final class LoadAlertRulesCommandTest extends TestCase
         self::assertSame(0, $this->tester->getStatusCode());
         self::assertStringContainsString('Updated: Rule A', $this->tester->getDisplay());
         self::assertStringContainsString('1 updated', $this->tester->getDisplay());
+        self::assertStringContainsString('0 created', $this->tester->getDisplay());
+    }
+
+    public function testUpdateSetsAllFields(): void
+    {
+        $user = new User('admin@test.com', 'hashed');
+        $existingRule = new AlertRule('Rule A', AlertRuleType::Keyword, $user, new \DateTimeImmutable('2026-01-01'));
+
+        $this->userRepository->method('findByEmail')->willReturn($user);
+        $this->alertRuleRepository->method('findByNameAndUser')->willReturn($existingRule);
+        $this->alertRuleRepository->method('findByUser')->willReturn([$existingRule]);
+
+        $fixture = new AlertRuleFixture(
+            name: 'Rule A',
+            type: AlertRuleType::Ai,
+            keywords: ['updated-keyword'],
+            contextPrompt: 'Updated context',
+            urgency: AlertUrgency::High,
+            severityThreshold: 8,
+            cooldownMinutes: 120,
+            categories: ['tech', 'science'],
+            enabled: false,
+        );
+        $this->loader->method('loadFromPath')->willReturn([$fixture]);
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+        ]);
+
+        self::assertSame(['updated-keyword'], $existingRule->getKeywords());
+        self::assertSame('Updated context', $existingRule->getContextPrompt());
+        self::assertSame(AlertUrgency::High, $existingRule->getUrgency());
+        self::assertSame(8, $existingRule->getSeverityThreshold());
+        self::assertSame(120, $existingRule->getCooldownMinutes());
+        self::assertSame(['tech', 'science'], $existingRule->getCategories());
+        self::assertFalse($existingRule->isEnabled());
+        self::assertSame($this->clock->now()->getTimestamp(), $existingRule->getUpdatedAt()->getTimestamp());
+    }
+
+    public function testCreateSetsAllFields(): void
+    {
+        $user = new User('admin@test.com', 'hashed');
+        $this->userRepository->method('findByEmail')->willReturn($user);
+        $this->alertRuleRepository->method('findByNameAndUser')->willReturn(null);
+        $this->alertRuleRepository->method('findByUser')->willReturn([]);
+
+        $fixture = new AlertRuleFixture(
+            name: 'New Rule',
+            type: AlertRuleType::Both,
+            keywords: ['keyword1', 'keyword2'],
+            contextPrompt: 'Test context prompt',
+            urgency: AlertUrgency::Low,
+            severityThreshold: 3,
+            cooldownMinutes: 30,
+            categories: ['politics'],
+            enabled: true,
+        );
+        $this->loader->method('loadFromPath')->willReturn([$fixture]);
+
+        $savedRule = null;
+        $this->alertRuleRepository->expects(self::once())
+            ->method('save')
+            ->with(self::callback(static function (AlertRule $rule) use (&$savedRule): bool {
+                $savedRule = $rule;
+
+                return true;
+            }));
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+        ]);
+
+        self::assertInstanceOf(AlertRule::class, $savedRule);
+        self::assertSame('New Rule', $savedRule->getName());
+        self::assertSame(AlertRuleType::Both, $savedRule->getType());
+        self::assertSame(['keyword1', 'keyword2'], $savedRule->getKeywords());
+        self::assertSame('Test context prompt', $savedRule->getContextPrompt());
+        self::assertSame(AlertUrgency::Low, $savedRule->getUrgency());
+        self::assertSame(3, $savedRule->getSeverityThreshold());
+        self::assertSame(30, $savedRule->getCooldownMinutes());
+        self::assertSame(['politics'], $savedRule->getCategories());
+        self::assertTrue($savedRule->isEnabled());
     }
 
     public function testDryRunDoesNotFlush(): void
@@ -107,6 +216,28 @@ final class LoadAlertRulesCommandTest extends TestCase
 
         self::assertSame(0, $this->tester->getStatusCode());
         self::assertStringContainsString('Dry run', $this->tester->getDisplay());
+        self::assertStringContainsString('1 to create', $this->tester->getDisplay());
+        self::assertStringContainsString('No changes persisted', $this->tester->getDisplay());
+    }
+
+    public function testDryRunWithUpdatesShowsCorrectStats(): void
+    {
+        $user = new User('admin@test.com', 'hashed');
+        $existingRule = new AlertRule('Rule A', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
+
+        $this->userRepository->method('findByEmail')->willReturn($user);
+        $this->alertRuleRepository->method('findByNameAndUser')->willReturn($existingRule);
+        $this->alertRuleRepository->method('findByUser')->willReturn([$existingRule]);
+        $this->loader->method('loadFromPath')->willReturn([$this->fixture('Rule A')]);
+
+        $this->alertRuleRepository->expects(self::never())->method('flush');
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+            '--dry-run' => true,
+        ]);
+
+        self::assertStringContainsString('1 to update', $this->tester->getDisplay());
     }
 
     public function testPurgeRemovesAbsentRules(): void
@@ -128,6 +259,46 @@ final class LoadAlertRulesCommandTest extends TestCase
 
         self::assertSame(0, $this->tester->getStatusCode());
         self::assertStringContainsString('Purged: Orphan', $this->tester->getDisplay());
+        self::assertStringContainsString('1 purged', $this->tester->getDisplay());
+    }
+
+    public function testPurgeKeepsRulesPresentInFixtures(): void
+    {
+        $user = new User('admin@test.com', 'hashed');
+        $ruleA = new AlertRule('Rule A', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
+
+        $this->userRepository->method('findByEmail')->willReturn($user);
+        $this->alertRuleRepository->method('findByNameAndUser')->willReturn($ruleA);
+        $this->alertRuleRepository->method('findByUser')->willReturn([$ruleA]);
+        $this->loader->method('loadFromPath')->willReturn([$this->fixture('Rule A')]);
+
+        $this->alertRuleRepository->expects(self::never())->method('remove');
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+            '--purge' => true,
+        ]);
+
+        self::assertStringNotContainsString('Purged', $this->tester->getDisplay());
+    }
+
+    public function testWithoutPurgeFlagDoesNotRemoveRules(): void
+    {
+        $user = new User('admin@test.com', 'hashed');
+        $orphan = new AlertRule('Orphan', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
+
+        $this->userRepository->method('findByEmail')->willReturn($user);
+        $this->alertRuleRepository->method('findByNameAndUser')->willReturn(null);
+        $this->alertRuleRepository->method('findByUser')->willReturn([$orphan]);
+        $this->loader->method('loadFromPath')->willReturn([$this->fixture('Rule A')]);
+
+        $this->alertRuleRepository->expects(self::never())->method('remove');
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+        ]);
+
+        self::assertStringNotContainsString('Purged', $this->tester->getDisplay());
     }
 
     public function testFailsWhenAdminNotFound(): void
@@ -135,12 +306,52 @@ final class LoadAlertRulesCommandTest extends TestCase
         $this->userRepository->method('findByEmail')->willReturn(null);
         $this->loader->method('loadFromPath')->willReturn([]);
 
+        $this->alertRuleRepository->expects(self::never())->method('save');
+        $this->alertRuleRepository->expects(self::never())->method('flush');
+
         $this->tester->execute([
             'path' => '/fixtures',
         ]);
 
         self::assertSame(1, $this->tester->getStatusCode());
         self::assertStringContainsString('not found', $this->tester->getDisplay());
+        self::assertStringContainsString('admin@test.com', $this->tester->getDisplay());
+    }
+
+    public function testLoaderCalledWithProvidedPath(): void
+    {
+        $this->userRepository->method('findByEmail')->willReturn(new User('admin@test.com', 'hashed'));
+        $this->alertRuleRepository->method('findByNameAndUser')->willReturn(null);
+        $this->alertRuleRepository->method('findByUser')->willReturn([]);
+
+        $this->loader->expects(self::once())
+            ->method('loadFromPath')
+            ->with('/custom/path/rules.yaml')
+            ->willReturn([]);
+
+        $this->tester->execute([
+            'path' => '/custom/path/rules.yaml',
+        ]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+    }
+
+    public function testEmptyFixturesProducesZeroStats(): void
+    {
+        $this->userRepository->method('findByEmail')->willReturn(new User('admin@test.com', 'hashed'));
+        $this->loader->method('loadFromPath')->willReturn([]);
+        $this->alertRuleRepository->method('findByUser')->willReturn([]);
+
+        $this->alertRuleRepository->expects(self::never())->method('save');
+        $this->alertRuleRepository->expects(self::once())->method('flush');
+
+        $this->tester->execute([
+            'path' => '/fixtures',
+        ]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertStringContainsString('0 created', $this->tester->getDisplay());
+        self::assertStringContainsString('0 updated', $this->tester->getDisplay());
     }
 
     private function fixture(string $name): AlertRuleFixture

--- a/tests/Unit/Notification/MessageHandler/SendNotificationHandlerTest.php
+++ b/tests/Unit/Notification/MessageHandler/SendNotificationHandlerTest.php
@@ -18,32 +18,24 @@ use App\Shared\Entity\Category;
 use App\Source\Entity\Source;
 use App\User\Entity\User;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 #[CoversClass(SendNotificationHandler::class)]
+#[UsesClass(SendNotificationMessage::class)]
+#[UsesClass(EvaluationResult::class)]
 final class SendNotificationHandlerTest extends TestCase
 {
-    /**
-     * @var AlertRuleRepositoryInterface&MockObject
-     */
-    private MockObject $alertRuleRepository;
+    private MockObject&AlertRuleRepositoryInterface $alertRuleRepository;
 
-    /**
-     * @var ArticleRepositoryInterface&MockObject
-     */
-    private MockObject $articleRepository;
+    private MockObject&ArticleRepositoryInterface $articleRepository;
 
-    /**
-     * @var NotificationDispatchServiceInterface&MockObject
-     */
-    private MockObject $dispatchService;
+    private MockObject&NotificationDispatchServiceInterface $dispatchService;
 
-    /**
-     * @var AiAlertEvaluationServiceInterface&MockObject
-     */
-    private MockObject $aiEvaluationService;
+    private MockObject&AiAlertEvaluationServiceInterface $aiEvaluationService;
 
     private SendNotificationHandler $handler;
 
@@ -92,10 +84,23 @@ final class SendNotificationHandlerTest extends TestCase
         $message = new SendNotificationMessage(999, 1, ['bitcoin']);
 
         $this->alertRuleRepository->method('findById')->willReturn(null);
+        $this->articleRepository->method('findById')->willReturn($this->article);
+
+        $this->dispatchService->expects(self::never())->method('dispatch');
+        $this->aiEvaluationService->expects(self::never())->method('evaluate');
+
+        ($this->handler)($message);
+    }
+
+    public function testSkipsWhenArticleNotFound(): void
+    {
+        $message = new SendNotificationMessage(1, 999, ['bitcoin']);
+
+        $this->alertRuleRepository->method('findById')->willReturn($this->rule);
         $this->articleRepository->method('findById')->willReturn(null);
 
-        $this->dispatchService->expects(self::never())
-            ->method('dispatch');
+        $this->dispatchService->expects(self::never())->method('dispatch');
+        $this->aiEvaluationService->expects(self::never())->method('evaluate');
 
         ($this->handler)($message);
     }
@@ -108,8 +113,8 @@ final class SendNotificationHandlerTest extends TestCase
         $this->alertRuleRepository->method('findById')->willReturn($this->rule);
         $this->articleRepository->method('findById')->willReturn($this->article);
 
-        $this->dispatchService->expects(self::never())
-            ->method('dispatch');
+        $this->dispatchService->expects(self::never())->method('dispatch');
+        $this->aiEvaluationService->expects(self::never())->method('evaluate');
 
         ($this->handler)($message);
     }
@@ -125,12 +130,52 @@ final class SendNotificationHandlerTest extends TestCase
         $this->alertRuleRepository->method('findById')->willReturn($rule);
         $this->articleRepository->method('findById')->willReturn($this->article);
 
-        $this->aiEvaluationService->method('evaluate')
+        $this->aiEvaluationService->expects(self::once())
+            ->method('evaluate')
+            ->with($this->article, $rule)
             ->willReturn($evaluation);
 
         $this->dispatchService->expects(self::once())
             ->method('dispatch')
             ->with($rule, $this->article, ['bitcoin'], $evaluation);
+
+        ($this->handler)($message);
+    }
+
+    public function testBothTypeRuleTriggersAiEvaluation(): void
+    {
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('Both Rule', AlertRuleType::Both, $user, new \DateTimeImmutable());
+        $evaluation = new EvaluationResult(9, 'Very critical', 'openrouter/auto');
+
+        $message = new SendNotificationMessage(1, 1, ['bitcoin']);
+
+        $this->alertRuleRepository->method('findById')->willReturn($rule);
+        $this->articleRepository->method('findById')->willReturn($this->article);
+
+        $this->aiEvaluationService->expects(self::once())
+            ->method('evaluate')
+            ->willReturn($evaluation);
+
+        $this->dispatchService->expects(self::once())
+            ->method('dispatch')
+            ->with($rule, $this->article, ['bitcoin'], $evaluation);
+
+        ($this->handler)($message);
+    }
+
+    public function testKeywordTypeRuleSkipsAiEvaluation(): void
+    {
+        $message = new SendNotificationMessage(1, 1, ['bitcoin']);
+
+        $this->alertRuleRepository->method('findById')->willReturn($this->rule); // Type: Keyword
+        $this->articleRepository->method('findById')->willReturn($this->article);
+
+        $this->aiEvaluationService->expects(self::never())->method('evaluate');
+
+        $this->dispatchService->expects(self::once())
+            ->method('dispatch')
+            ->with($this->rule, $this->article, ['bitcoin'], null);
 
         ($this->handler)($message);
     }
@@ -147,12 +192,120 @@ final class SendNotificationHandlerTest extends TestCase
         $this->alertRuleRepository->method('findById')->willReturn($rule);
         $this->articleRepository->method('findById')->willReturn($this->article);
 
-        $this->aiEvaluationService->method('evaluate')
-            ->willReturn($evaluation);
+        $this->aiEvaluationService->method('evaluate')->willReturn($evaluation);
 
-        $this->dispatchService->expects(self::never())
-            ->method('dispatch');
+        $this->dispatchService->expects(self::never())->method('dispatch');
 
         ($this->handler)($message);
+    }
+
+    public function testAiEvaluationAtExactThresholdDispatches(): void
+    {
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('AI Rule', AlertRuleType::Ai, $user, new \DateTimeImmutable());
+        $rule->setSeverityThreshold(5);
+        $evaluation = new EvaluationResult(5, 'Exactly threshold', 'openrouter/auto');
+
+        $message = new SendNotificationMessage(1, 1, ['bitcoin']);
+
+        $this->alertRuleRepository->method('findById')->willReturn($rule);
+        $this->articleRepository->method('findById')->willReturn($this->article);
+
+        $this->aiEvaluationService->method('evaluate')->willReturn($evaluation);
+
+        // Severity 5 is NOT less than threshold 5 -> should dispatch
+        $this->dispatchService->expects(self::once())->method('dispatch');
+
+        ($this->handler)($message);
+    }
+
+    public function testNullAiEvaluationStillDispatches(): void
+    {
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('AI Rule', AlertRuleType::Ai, $user, new \DateTimeImmutable());
+        $rule->setSeverityThreshold(5);
+
+        $message = new SendNotificationMessage(1, 1, ['bitcoin']);
+
+        $this->alertRuleRepository->method('findById')->willReturn($rule);
+        $this->articleRepository->method('findById')->willReturn($this->article);
+
+        $this->aiEvaluationService->method('evaluate')->willReturn(null);
+
+        // Null evaluation is NOT an instance of EvaluationResult, so severity check is skipped
+        $this->dispatchService->expects(self::once())
+            ->method('dispatch')
+            ->with($rule, $this->article, ['bitcoin'], null);
+
+        ($this->handler)($message);
+    }
+
+    public function testLoggerInfoOnSuccessfulDispatch(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info')
+            ->with(
+                self::stringContains('Notification sent'),
+                self::callback(static function (array $context): bool {
+                    return array_key_exists('rule', $context)
+                        && array_key_exists('rule_id', $context)
+                        && array_key_exists('article', $context)
+                        && array_key_exists('article_id', $context)
+                        && $context['rule'] === 'Test Rule'
+                        && $context['article'] === 'Test Article';
+                }),
+            );
+
+        $handler = new SendNotificationHandler(
+            $this->alertRuleRepository,
+            $this->articleRepository,
+            $this->dispatchService,
+            $this->aiEvaluationService,
+            $logger,
+        );
+
+        $message = new SendNotificationMessage(1, 1, ['bitcoin']);
+        $this->alertRuleRepository->method('findById')->willReturn($this->rule);
+        $this->articleRepository->method('findById')->willReturn($this->article);
+
+        ($handler)($message);
+    }
+
+    public function testLoggerInfoWhenAiSeverityBelowThreshold(): void
+    {
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('AI Rule', AlertRuleType::Ai, $user, new \DateTimeImmutable());
+        $rule->setSeverityThreshold(7);
+        $evaluation = new EvaluationResult(3, 'Low impact', 'openrouter/auto');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info')
+            ->with(
+                self::stringContains('skipped'),
+                self::callback(static function (array $context): bool {
+                    return array_key_exists('rule', $context)
+                        && array_key_exists('rule_id', $context)
+                        && array_key_exists('article_id', $context)
+                        && array_key_exists('severity', $context)
+                        && array_key_exists('threshold', $context)
+                        && $context['severity'] === 3
+                        && $context['threshold'] === 7;
+                }),
+            );
+
+        $handler = new SendNotificationHandler(
+            $this->alertRuleRepository,
+            $this->articleRepository,
+            $this->dispatchService,
+            $this->aiEvaluationService,
+            $logger,
+        );
+
+        $message = new SendNotificationMessage(1, 1, ['bitcoin']);
+        $this->alertRuleRepository->method('findById')->willReturn($rule);
+        $this->articleRepository->method('findById')->willReturn($this->article);
+        $this->aiEvaluationService->method('evaluate')->willReturn($evaluation);
+
+        ($handler)($message);
     }
 }

--- a/tests/Unit/Notification/Service/AiAlertEvaluationServiceTest.php
+++ b/tests/Unit/Notification/Service/AiAlertEvaluationServiceTest.php
@@ -8,17 +8,120 @@ use App\Article\Entity\Article;
 use App\Notification\Entity\AlertRule;
 use App\Notification\Service\AiAlertEvaluationService;
 use App\Notification\ValueObject\AlertRuleType;
+use App\Notification\ValueObject\EvaluationResult;
 use App\Shared\Entity\Category;
 use App\Source\Entity\Source;
 use App\User\Entity\User;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Test\InMemoryPlatform;
 
 #[CoversClass(AiAlertEvaluationService::class)]
+#[UsesClass(EvaluationResult::class)]
 final class AiAlertEvaluationServiceTest extends TestCase
 {
+    public function testSuccessfulAiEvaluation(): void
+    {
+        $platform = new InMemoryPlatform("SEVERITY: 8\nEXPLANATION: Critical vulnerability affecting enterprise systems");
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $result = $service->evaluate($this->createArticle(), $this->createRule());
+
+        self::assertInstanceOf(EvaluationResult::class, $result);
+        self::assertSame(8, $result->severity);
+        self::assertSame('Critical vulnerability affecting enterprise systems', $result->explanation);
+        self::assertSame('openrouter/free', $result->modelUsed);
+    }
+
+    public function testParsesMinSeverity(): void
+    {
+        $platform = new InMemoryPlatform("SEVERITY: 1\nEXPLANATION: Minor issue with no impact");
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $result = $service->evaluate($this->createArticle(), $this->createRule());
+
+        self::assertInstanceOf(EvaluationResult::class, $result);
+        self::assertSame(1, $result->severity);
+        self::assertSame('Minor issue with no impact', $result->explanation);
+        self::assertSame('openrouter/free', $result->modelUsed);
+    }
+
+    public function testParsesMaxSeverity(): void
+    {
+        $platform = new InMemoryPlatform("SEVERITY: 10\nEXPLANATION: Catastrophic failure imminent");
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $result = $service->evaluate($this->createArticle(), $this->createRule());
+
+        self::assertInstanceOf(EvaluationResult::class, $result);
+        self::assertSame(10, $result->severity);
+        self::assertSame('Catastrophic failure imminent', $result->explanation);
+    }
+
+    public function testReturnsNullForSeverityZero(): void
+    {
+        $platform = new InMemoryPlatform("SEVERITY: 0\nEXPLANATION: Nothing");
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $result = $service->evaluate($this->createArticle(), $this->createRule());
+
+        self::assertNull($result);
+    }
+
+    public function testReturnsNullForSeverityAboveTen(): void
+    {
+        $platform = new InMemoryPlatform("SEVERITY: 11\nEXPLANATION: Something");
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $result = $service->evaluate($this->createArticle(), $this->createRule());
+
+        self::assertNull($result);
+    }
+
+    public function testReturnsNullForEmptyExplanation(): void
+    {
+        $platform = new InMemoryPlatform("SEVERITY: 5\nEXPLANATION:  ");
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $result = $service->evaluate($this->createArticle(), $this->createRule());
+
+        self::assertNull($result);
+    }
+
+    public function testReturnsNullForMissingSeverity(): void
+    {
+        $platform = new InMemoryPlatform('EXPLANATION: Something happened');
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $result = $service->evaluate($this->createArticle(), $this->createRule());
+
+        self::assertNull($result);
+    }
+
+    public function testReturnsNullForMissingExplanation(): void
+    {
+        $platform = new InMemoryPlatform('SEVERITY: 5');
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $result = $service->evaluate($this->createArticle(), $this->createRule());
+
+        self::assertNull($result);
+    }
+
+    public function testReturnsNullForGarbageResponse(): void
+    {
+        $platform = new InMemoryPlatform("I don't know what to do with this");
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $result = $service->evaluate($this->createArticle(), $this->createRule());
+
+        self::assertNull($result);
+    }
+
     public function testFallsBackToRuleBasedOnAiFailure(): void
     {
         $platform = $this->createStub(PlatformInterface::class);
@@ -27,24 +130,166 @@ final class AiAlertEvaluationServiceTest extends TestCase
         $service = new AiAlertEvaluationService($platform, new NullLogger());
         $result = $service->evaluate($this->createArticle(), $this->createRule());
 
-        self::assertNotNull($result);
+        self::assertInstanceOf(EvaluationResult::class, $result);
         self::assertGreaterThanOrEqual(1, $result->severity);
         self::assertLessThanOrEqual(10, $result->severity);
-        self::assertNull($result->modelUsed); // Rule-based has no model
+        self::assertNull($result->modelUsed);
+        self::assertSame('Rule-based severity estimate based on keyword overlap', $result->explanation);
     }
 
-    public function testFallsBackWhenNoContextPrompt(): void
+    public function testFallsBackWhenContextPromptIsNull(): void
     {
-        $platform = $this->createStub(PlatformInterface::class);
+        $platform = $this->createMock(PlatformInterface::class);
+        // Platform should NOT be called since no context prompt
+        $platform->expects(self::never())->method('invoke');
+
         $service = new AiAlertEvaluationService($platform, new NullLogger());
 
         $user = new User('admin@example.com', 'hashed');
         $rule = new AlertRule('No Context', AlertRuleType::Ai, $user, new \DateTimeImmutable());
-        // No context prompt set
+        // contextPrompt defaults to null
 
         $result = $service->evaluate($this->createArticle(), $rule);
 
-        self::assertNotNull($result);
+        self::assertInstanceOf(EvaluationResult::class, $result);
+        self::assertNull($result->modelUsed);
+    }
+
+    public function testFallsBackWhenContextPromptIsEmpty(): void
+    {
+        $platform = $this->createMock(PlatformInterface::class);
+        $platform->expects(self::never())->method('invoke');
+
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('Empty Context', AlertRuleType::Ai, $user, new \DateTimeImmutable());
+        $rule->setContextPrompt('');
+
+        $result = $service->evaluate($this->createArticle(), $rule);
+
+        self::assertInstanceOf(EvaluationResult::class, $result);
+        self::assertNull($result->modelUsed);
+    }
+
+    public function testRuleBasedFallbackCalculatesOverlapCorrectly(): void
+    {
+        $platform = $this->createStub(PlatformInterface::class);
+        $platform->method('invoke')->willThrowException(new \RuntimeException('API down'));
+
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        // Rule with context words that appear in the article
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('Overlap Test', AlertRuleType::Ai, $user, new \DateTimeImmutable());
+        $rule->setKeywords(['security']);
+        $rule->setContextPrompt('critical security vulnerability software enterprise');
+
+        // Article text: "Critical Security Flaw" + summary has "critical vulnerability was discovered in major software"
+        $article = $this->createArticle();
+
+        $result = $service->evaluate($article, $rule);
+
+        self::assertInstanceOf(EvaluationResult::class, $result);
+        // "critical" (>3 chars, found), "security" (>3 chars, found), "vulnerability" (>3 chars, found),
+        // "software" (>3 chars, found), "enterprise" (>3 chars, not found in article text)
+        // overlap=4, severity = min(10, max(1, round(4*2))) = 8
+        self::assertSame(8, $result->severity);
+    }
+
+    public function testRuleBasedFallbackIgnoresShortWords(): void
+    {
+        $platform = $this->createStub(PlatformInterface::class);
+        $platform->method('invoke')->willThrowException(new \RuntimeException('API down'));
+
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('Short Words', AlertRuleType::Ai, $user, new \DateTimeImmutable());
+        // Only short words (<=3 chars) — should count as 0 overlap
+        $rule->setContextPrompt('the and for is');
+
+        $result = $service->evaluate($this->createArticle(), $rule);
+
+        self::assertInstanceOf(EvaluationResult::class, $result);
+        // overlap=0, severity = min(10, max(1, round(0*2))) = max(1, 0) = 1
+        self::assertSame(1, $result->severity);
+    }
+
+    public function testRuleBasedFallbackCapsAtTen(): void
+    {
+        $platform = $this->createStub(PlatformInterface::class);
+        $platform->method('invoke')->willThrowException(new \RuntimeException('API down'));
+
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('Many Overlaps', AlertRuleType::Ai, $user, new \DateTimeImmutable());
+        // Many words that appear in the article (title + summary)
+        $rule->setContextPrompt('critical security vulnerability discovered major software flaw');
+
+        $article = $this->createArticle();
+        $result = $service->evaluate($article, $rule);
+
+        self::assertInstanceOf(EvaluationResult::class, $result);
+        self::assertLessThanOrEqual(10, $result->severity);
+        self::assertGreaterThanOrEqual(1, $result->severity);
+    }
+
+    public function testArticleWithoutSummaryStillEvaluates(): void
+    {
+        // Article without summary — AI should still work, using title as fallback
+        $category = new Category('Tech', 'tech', 10, '#3B82F6');
+        $source = new Source('Src', 'https://example.com/feed', $category, new \DateTimeImmutable());
+        $article = new Article('Critical Security Flaw', 'https://example.com/1', $source, new \DateTimeImmutable());
+        // No summary set — getSummary() returns null, so title is used as fallback
+
+        $platform = new InMemoryPlatform("SEVERITY: 5\nEXPLANATION: Moderate issue detected");
+
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+        $result = $service->evaluate($article, $this->createRule());
+
+        self::assertInstanceOf(EvaluationResult::class, $result);
+        self::assertSame(5, $result->severity);
+        self::assertSame('Moderate issue detected', $result->explanation);
+    }
+
+    public function testParsesResponseWithWhitespace(): void
+    {
+        $platform = new InMemoryPlatform("  SEVERITY: 7  \n  EXPLANATION: Whitespace padded response  ");
+        $service = new AiAlertEvaluationService($platform, new NullLogger());
+
+        $result = $service->evaluate($this->createArticle(), $this->createRule());
+
+        self::assertInstanceOf(EvaluationResult::class, $result);
+        self::assertSame(7, $result->severity);
+        self::assertSame('Whitespace padded response', $result->explanation);
+    }
+
+    public function testLoggerCalledOnFailureWithContext(): void
+    {
+        $platform = $this->createStub(PlatformInterface::class);
+        $platform->method('invoke')->willThrowException(new \RuntimeException('API down'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')
+            ->with(
+                self::stringContains('AI alert evaluation failed'),
+                self::callback(static function (array $context): bool {
+                    return array_key_exists('rule', $context)
+                        && array_key_exists('rule_id', $context)
+                        && array_key_exists('article', $context)
+                        && array_key_exists('article_id', $context)
+                        && array_key_exists('model', $context)
+                        && array_key_exists('error', $context)
+                        && $context['rule'] === 'Security Alert'
+                        && $context['model'] === 'openrouter/free'
+                        && $context['error'] === 'API down';
+                }),
+            );
+
+        $service = new AiAlertEvaluationService($platform, $logger);
+        $service->evaluate($this->createArticle(), $this->createRule());
     }
 
     private function createArticle(): Article

--- a/tests/Unit/Notification/Service/ArticleMatcherServiceTest.php
+++ b/tests/Unit/Notification/Service/ArticleMatcherServiceTest.php
@@ -10,22 +10,22 @@ use App\Notification\Repository\AlertRuleRepositoryInterface;
 use App\Notification\Repository\NotificationLogRepositoryInterface;
 use App\Notification\Service\ArticleMatcherService;
 use App\Notification\ValueObject\AlertRuleType;
+use App\Notification\ValueObject\MatchResult;
 use App\Shared\Entity\Category;
 use App\Source\Entity\Source;
 use App\User\Entity\User;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
 
 #[CoversClass(ArticleMatcherService::class)]
+#[UsesClass(MatchResult::class)]
 final class ArticleMatcherServiceTest extends TestCase
 {
     public function testMatchesKeywordInTitle(): void
     {
-        $user = new User('admin@example.com', 'hashed');
-        $rule = new AlertRule('Breaking News', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
-        $rule->setKeywords(['earthquake', 'tsunami']);
-
+        $rule = $this->createRule(['earthquake', 'tsunami']);
         $matcher = $this->createMatcher($rule);
         $article = $this->createArticle('Major earthquake strikes region');
 
@@ -34,14 +34,12 @@ final class ArticleMatcherServiceTest extends TestCase
 
         self::assertCount(1, $resultsArray);
         self::assertSame(['earthquake'], $resultsArray[0]->matchedKeywords);
+        self::assertSame($rule, $resultsArray[0]->alertRule);
     }
 
     public function testMatchesKeywordInContent(): void
     {
-        $user = new User('admin@example.com', 'hashed');
-        $rule = new AlertRule('Tech Alert', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
-        $rule->setKeywords(['vulnerability']);
-
+        $rule = $this->createRule(['vulnerability']);
         $matcher = $this->createMatcher($rule);
         $article = $this->createArticle('Security Update', 'Critical vulnerability found in software');
 
@@ -52,12 +50,36 @@ final class ArticleMatcherServiceTest extends TestCase
         self::assertSame(['vulnerability'], $resultsArray[0]->matchedKeywords);
     }
 
+    public function testMatchesKeywordInSummary(): void
+    {
+        $rule = $this->createRule(['exploit']);
+        $matcher = $this->createMatcher($rule);
+        $article = $this->createArticle('Security Update', null, 'A new exploit was discovered');
+
+        $results = $matcher->match($article);
+        $resultsArray = $results->toArray();
+
+        self::assertCount(1, $resultsArray);
+        self::assertSame(['exploit'], $resultsArray[0]->matchedKeywords);
+    }
+
+    public function testMatchesMultipleKeywords(): void
+    {
+        $rule = $this->createRule(['earthquake', 'tsunami', 'disaster']);
+        $matcher = $this->createMatcher($rule);
+        $article = $this->createArticle('Earthquake triggers tsunami disaster');
+
+        $results = $matcher->match($article);
+        $resultsArray = $results->toArray();
+
+        self::assertCount(1, $resultsArray);
+        self::assertCount(3, $resultsArray[0]->matchedKeywords);
+        self::assertSame(['earthquake', 'tsunami', 'disaster'], $resultsArray[0]->matchedKeywords);
+    }
+
     public function testNoMatchReturnsEmpty(): void
     {
-        $user = new User('admin@example.com', 'hashed');
-        $rule = new AlertRule('Weather', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
-        $rule->setKeywords(['hurricane', 'tornado']);
-
+        $rule = $this->createRule(['hurricane', 'tornado']);
         $matcher = $this->createMatcher($rule);
         $article = $this->createArticle('Tech company launches new product');
 
@@ -66,11 +88,20 @@ final class ArticleMatcherServiceTest extends TestCase
         self::assertCount(0, $results);
     }
 
+    public function testMatchIsCaseInsensitive(): void
+    {
+        $rule = $this->createRule(['EARTHQUAKE']);
+        $matcher = $this->createMatcher($rule);
+        $article = $this->createArticle('Major Earthquake strikes');
+
+        $results = $matcher->match($article);
+
+        self::assertCount(1, $results);
+    }
+
     public function testRespectsCategories(): void
     {
-        $user = new User('admin@example.com', 'hashed');
-        $rule = new AlertRule('Sports Only', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
-        $rule->setKeywords(['breaking']);
+        $rule = $this->createRule(['breaking']);
         $rule->setCategories(['sports']); // Only match sports
 
         $matcher = $this->createMatcher($rule);
@@ -79,6 +110,132 @@ final class ArticleMatcherServiceTest extends TestCase
         $results = $matcher->match($article);
 
         self::assertCount(0, $results); // Category mismatch
+    }
+
+    public function testEmptyCategoriesMatchesAll(): void
+    {
+        $rule = $this->createRule(['breaking']);
+        $rule->setCategories([]); // Empty = match all
+
+        $matcher = $this->createMatcher($rule);
+        $article = $this->createArticle('Breaking news in tech');
+
+        $results = $matcher->match($article);
+
+        self::assertCount(1, $results);
+    }
+
+    public function testMatchesCategoryWhenArticleHasMatchingCategory(): void
+    {
+        $rule = $this->createRule(['breaking']);
+        $rule->setCategories(['tech', 'science']);
+
+        $matcher = $this->createMatcher($rule);
+        $article = $this->createArticle('Breaking news in tech'); // Category is 'tech'
+
+        $results = $matcher->match($article);
+
+        self::assertCount(1, $results);
+    }
+
+    public function testArticleWithoutCategoryFailsCategoryFilter(): void
+    {
+        $rule = $this->createRule(['breaking']);
+        $rule->setCategories(['tech']);
+
+        $matcher = $this->createMatcher($rule);
+
+        // Article with no category set
+        $source = new Source('Src', 'https://example.com/feed', new Category('Tech', 'tech', 10, '#3B82F6'), new \DateTimeImmutable());
+        $article = new Article('Breaking news', 'https://example.com/' . random_int(1, 99999), $source, new \DateTimeImmutable());
+        // No category set -> getCategory() returns null -> getSlug() is null
+
+        $results = $matcher->match($article);
+
+        self::assertCount(0, $results);
+    }
+
+    public function testSkipsRuleInCooldown(): void
+    {
+        $rule = $this->createRule(['earthquake']);
+        // Set a persisted ID so cooldown check actually runs
+        $idProp = new \ReflectionProperty(AlertRule::class, 'id');
+        $idProp->setValue($rule, 42);
+
+        $alertRuleRepo = $this->createStub(AlertRuleRepositoryInterface::class);
+        $alertRuleRepo->method('findEnabled')->willReturn([$rule]);
+
+        $logRepo = $this->createStub(NotificationLogRepositoryInterface::class);
+        $logRepo->method('existsRecentForRule')->willReturn(true); // In cooldown
+
+        $matcher = new ArticleMatcherService($alertRuleRepo, $logRepo, new MockClock('2026-04-04 12:00:00'));
+        $article = $this->createArticle('Major earthquake strikes');
+
+        $results = $matcher->match($article);
+
+        self::assertCount(0, $results);
+    }
+
+    public function testRuleWithNullIdSkipsCooldownCheck(): void
+    {
+        // A rule with no persisted ID (id=null) should not be cooldown-checked
+        $rule = $this->createRule(['earthquake']); // id is null since not persisted
+
+        $alertRuleRepo = $this->createStub(AlertRuleRepositoryInterface::class);
+        $alertRuleRepo->method('findEnabled')->willReturn([$rule]);
+
+        $logRepo = $this->createMock(NotificationLogRepositoryInterface::class);
+        // existsRecentForRule should NOT be called since ruleId is null
+        $logRepo->expects(self::never())->method('existsRecentForRule');
+
+        $matcher = new ArticleMatcherService($alertRuleRepo, $logRepo, new MockClock('2026-04-04 12:00:00'));
+        $article = $this->createArticle('Major earthquake strikes');
+
+        $results = $matcher->match($article);
+
+        self::assertCount(1, $results);
+    }
+
+    public function testMultipleRulesCanMatch(): void
+    {
+        $rule1 = $this->createRule(['earthquake']);
+        $rule2 = $this->createRule(['major']);
+
+        $alertRuleRepo = $this->createStub(AlertRuleRepositoryInterface::class);
+        $alertRuleRepo->method('findEnabled')->willReturn([$rule1, $rule2]);
+
+        $logRepo = $this->createStub(NotificationLogRepositoryInterface::class);
+        $logRepo->method('existsRecentForRule')->willReturn(false);
+
+        $matcher = new ArticleMatcherService($alertRuleRepo, $logRepo, new MockClock('2026-04-04 12:00:00'));
+        $article = $this->createArticle('Major earthquake strikes');
+
+        $results = $matcher->match($article);
+
+        self::assertCount(2, $results);
+    }
+
+    public function testEmptyKeywordsDoNotMatch(): void
+    {
+        $rule = $this->createRule([]);
+        $matcher = $this->createMatcher($rule);
+        $article = $this->createArticle('Any title here');
+
+        $results = $matcher->match($article);
+
+        self::assertCount(0, $results);
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    private function createRule(array $keywords): AlertRule
+    {
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('Test Rule', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
+        $rule->setKeywords($keywords);
+
+        return $rule;
     }
 
     private function createMatcher(AlertRule $rule): ArticleMatcherService
@@ -92,12 +249,13 @@ final class ArticleMatcherServiceTest extends TestCase
         return new ArticleMatcherService($alertRuleRepo, $logRepo, new MockClock('2026-04-04 12:00:00'));
     }
 
-    private function createArticle(string $title = 'Test Article', ?string $content = null): Article
+    private function createArticle(string $title = 'Test Article', ?string $content = null, ?string $summary = null): Article
     {
         $category = new Category('Tech', 'tech', 10, '#3B82F6');
         $source = new Source('Src', 'https://example.com/feed', $category, new \DateTimeImmutable());
         $article = new Article($title, 'https://example.com/' . random_int(1, 99999), $source, new \DateTimeImmutable());
         $article->setContentText($content);
+        $article->setSummary($summary);
         $article->setCategory($category);
 
         return $article;

--- a/tests/Unit/Notification/Service/NotificationDispatchServiceTest.php
+++ b/tests/Unit/Notification/Service/NotificationDispatchServiceTest.php
@@ -10,6 +10,7 @@ use App\Notification\Entity\NotificationLog;
 use App\Notification\Repository\NotificationLogRepositoryInterface;
 use App\Notification\Service\NotificationDispatchService;
 use App\Notification\ValueObject\AlertRuleType;
+use App\Notification\ValueObject\AlertUrgency;
 use App\Notification\ValueObject\DeliveryStatus;
 use App\Notification\ValueObject\EvaluationResult;
 use App\Shared\Entity\Category;
@@ -20,6 +21,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\NotifierInterface;
 
 #[CoversClass(NotificationDispatchService::class)]
@@ -216,5 +218,221 @@ final class NotificationDispatchServiceTest extends TestCase
         );
 
         self::assertTrue($service->hasTransport());
+    }
+
+    public function testHasTransportReturnsFalseForEmptyDsn(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->logRepository,
+            $this->clock,
+            '',
+        );
+
+        self::assertFalse($service->hasTransport());
+    }
+
+    public function testDispatchWithoutEvaluationSetsKeywordMatchType(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->logRepository,
+            $this->clock,
+            '',
+        );
+
+        $savedLog = null;
+        $this->logRepository->expects(self::once())
+            ->method('save')
+            ->with(self::callback(static function (NotificationLog $log) use (&$savedLog): bool {
+                $savedLog = $log;
+
+                return true;
+            }), true);
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin']);
+
+        self::assertInstanceOf(NotificationLog::class, $savedLog);
+        self::assertSame('keyword', $savedLog->getMatchType());
+        self::assertNull($savedLog->getAiSeverity());
+        self::assertNull($savedLog->getAiExplanation());
+        self::assertNull($savedLog->getAiModelUsed());
+    }
+
+    public function testDispatchWithEvaluationSetsAiMatchType(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->logRepository,
+            $this->clock,
+            '',
+        );
+
+        $evaluation = new EvaluationResult(5, 'Moderate event', 'test-model');
+
+        $savedLog = null;
+        $this->logRepository->expects(self::once())
+            ->method('save')
+            ->with(self::callback(static function (NotificationLog $log) use (&$savedLog): bool {
+                $savedLog = $log;
+
+                return true;
+            }), true);
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin'], $evaluation);
+
+        self::assertInstanceOf(NotificationLog::class, $savedLog);
+        self::assertSame('ai', $savedLog->getMatchType());
+        self::assertSame(5, $savedLog->getAiSeverity());
+        self::assertSame('Moderate event', $savedLog->getAiExplanation());
+        self::assertSame('test-model', $savedLog->getAiModelUsed());
+    }
+
+    public function testDispatchSavesWithFlush(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->logRepository,
+            $this->clock,
+            '',
+        );
+
+        $this->logRepository->expects(self::once())
+            ->method('save')
+            ->with(self::isInstanceOf(NotificationLog::class), true);
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin']);
+    }
+
+    public function testHighUrgencyRuleSendsNotification(): void
+    {
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('High Rule', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
+        $rule->setUrgency(AlertUrgency::High);
+
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->logRepository,
+            $this->clock,
+            'pushover://USER@TOKEN',
+        );
+
+        $this->notifier->expects(self::once())->method('send')
+            ->with(self::callback(static function (Notification $n): bool {
+                return $n->getImportance() === Notification::IMPORTANCE_URGENT;
+            }));
+
+        $this->logRepository->method('save');
+
+        $service->dispatch($rule, $this->article, ['bitcoin']);
+    }
+
+    public function testLowUrgencyRuleSendsNotification(): void
+    {
+        $user = new User('admin@example.com', 'hashed');
+        $rule = new AlertRule('Low Rule', AlertRuleType::Keyword, $user, new \DateTimeImmutable());
+        $rule->setUrgency(AlertUrgency::Low);
+
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->logRepository,
+            $this->clock,
+            'pushover://USER@TOKEN',
+        );
+
+        $this->notifier->expects(self::once())->method('send')
+            ->with(self::callback(static function (Notification $n): bool {
+                return $n->getImportance() === Notification::IMPORTANCE_MEDIUM;
+            }));
+
+        $this->logRepository->method('save');
+
+        $service->dispatch($rule, $this->article, ['bitcoin']);
+    }
+
+    public function testNotificationSubjectContainsUrgencyAndTitle(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->logRepository,
+            $this->clock,
+            'pushover://USER@TOKEN',
+        );
+
+        $this->notifier->expects(self::once())->method('send')
+            ->with(self::callback(static function (Notification $n): bool {
+                return str_contains($n->getSubject(), 'MEDIUM')
+                    && str_contains($n->getSubject(), 'Test Article');
+            }));
+
+        $this->logRepository->method('save');
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin']);
+    }
+
+    public function testNotificationContentContainsRuleNameAndUrl(): void
+    {
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->logRepository,
+            $this->clock,
+            'pushover://USER@TOKEN',
+        );
+
+        $this->notifier->expects(self::once())->method('send')
+            ->with(self::callback(static function (Notification $n): bool {
+                $content = $n->getContent();
+
+                return str_contains($content, 'Rule: Test Rule')
+                    && str_contains($content, 'Keywords: bitcoin')
+                    && str_contains($content, 'URL: https://example.com/1');
+            }));
+
+        $this->logRepository->method('save');
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin']);
+    }
+
+    public function testNotificationContentIncludesSummaryWhenPresent(): void
+    {
+        $this->article->setSummary('An important summary');
+
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->logRepository,
+            $this->clock,
+            'pushover://USER@TOKEN',
+        );
+
+        $this->notifier->expects(self::once())->method('send')
+            ->with(self::callback(static function (Notification $n): bool {
+                return str_contains($n->getContent(), 'Summary: An important summary');
+            }));
+
+        $this->logRepository->method('save');
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin']);
+    }
+
+    public function testNotificationContentIncludesAiEvaluation(): void
+    {
+        $evaluation = new EvaluationResult(9, 'Critical event', 'test-model');
+
+        $service = new NotificationDispatchService(
+            $this->notifier,
+            $this->logRepository,
+            $this->clock,
+            'pushover://USER@TOKEN',
+        );
+
+        $this->notifier->expects(self::once())->method('send')
+            ->with(self::callback(static function (Notification $n): bool {
+                return str_contains($n->getContent(), 'AI Severity: 9/10')
+                    && str_contains($n->getContent(), 'AI Analysis: Critical event');
+            }));
+
+        $this->logRepository->method('save');
+
+        $service->dispatch($this->rule, $this->article, ['bitcoin'], $evaluation);
     }
 }

--- a/tests/Unit/Shared/AI/Service/ModelDiscoveryServiceTest.php
+++ b/tests/Unit/Shared/AI/Service/ModelDiscoveryServiceTest.php
@@ -7,9 +7,11 @@ namespace App\Tests\Unit\Shared\AI\Service;
 use App\Shared\AI\Service\ModelDiscoveryService;
 use App\Shared\AI\ValueObject\CircuitBreakerState;
 use App\Shared\AI\ValueObject\ModelId;
+use App\Shared\AI\ValueObject\ModelIdCollection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Clock\MockClock;
@@ -18,9 +20,13 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 #[CoversClass(ModelDiscoveryService::class)]
 #[UsesClass(CircuitBreakerState::class)]
+#[UsesClass(ModelId::class)]
+#[UsesClass(ModelIdCollection::class)]
 final class ModelDiscoveryServiceTest extends TestCase
 {
     private const string BREAKER_KEY = 'openrouter_cb';
+
+    private const string CACHE_KEY = 'openrouter_free_models';
 
     public function testDiscoversFreeModels(): void
     {
@@ -36,6 +42,72 @@ final class ModelDiscoveryServiceTest extends TestCase
         self::assertContains('free-model-2', $values);
         self::assertNotContains('paid-model', $values);
         self::assertNotContains('free-small', $values);
+    }
+
+    public function testFiltersPaidModels(): void
+    {
+        $service = $this->createService($this->clientWithModels([
+            [
+                'id' => 'free-one',
+                'context_length' => 32768,
+                'pricing' => [
+                    'prompt' => '0',
+                    'completion' => '0',
+                ],
+            ],
+            [
+                'id' => 'paid-prompt',
+                'context_length' => 32768,
+                'pricing' => [
+                    'prompt' => '0.001',
+                    'completion' => '0',
+                ],
+            ],
+            [
+                'id' => 'paid-completion',
+                'context_length' => 32768,
+                'pricing' => [
+                    'prompt' => '0',
+                    'completion' => '0.002',
+                ],
+            ],
+        ]));
+
+        $models = $service->discoverFreeModels();
+
+        self::assertCount(1, $models);
+        $first = $models->first();
+        self::assertInstanceOf(ModelId::class, $first);
+        self::assertSame('free-one', $first->value);
+    }
+
+    public function testFiltersModelsBelowMinContextLength(): void
+    {
+        $service = $this->createService($this->clientWithModels([
+            [
+                'id' => 'large-context',
+                'context_length' => 8192,
+                'pricing' => [
+                    'prompt' => '0',
+                    'completion' => '0',
+                ],
+            ],
+            [
+                'id' => 'small-context',
+                'context_length' => 4096,
+                'pricing' => [
+                    'prompt' => '0',
+                    'completion' => '0',
+                ],
+            ],
+        ]));
+
+        $models = $service->discoverFreeModels();
+
+        self::assertCount(1, $models);
+        $first = $models->first();
+        self::assertInstanceOf(ModelId::class, $first);
+        self::assertSame('large-context', $first->value);
     }
 
     public function testFilterBlockedModels(): void
@@ -70,6 +142,43 @@ final class ModelDiscoveryServiceTest extends TestCase
         self::assertSame('good-model', $first->value);
     }
 
+    public function testFilterMultipleBlockedModels(): void
+    {
+        $service = $this->createService(
+            $this->clientWithModels([
+                [
+                    'id' => 'good-model',
+                    'context_length' => 32768,
+                    'pricing' => [
+                        'prompt' => '0',
+                        'completion' => '0',
+                    ],
+                ],
+                [
+                    'id' => 'blocked-1',
+                    'context_length' => 32768,
+                    'pricing' => [
+                        'prompt' => '0',
+                        'completion' => '0',
+                    ],
+                ],
+                [
+                    'id' => 'blocked-2',
+                    'context_length' => 32768,
+                    'pricing' => [
+                        'prompt' => '0',
+                        'completion' => '0',
+                    ],
+                ],
+            ]),
+            blockedModels: 'blocked-1, blocked-2',
+        );
+
+        $models = $service->discoverFreeModels();
+
+        self::assertCount(1, $models);
+    }
+
     public function testCachesResults(): void
     {
         $callCount = 0;
@@ -85,6 +194,23 @@ final class ModelDiscoveryServiceTest extends TestCase
         $service->discoverFreeModels();
 
         self::assertSame(1, $callCount);
+    }
+
+    public function testCacheStoresModelIds(): void
+    {
+        $cache = new ArrayAdapter();
+        $service = $this->createService($this->successClient(), cache: $cache);
+
+        $service->discoverFreeModels();
+
+        $cacheItem = $cache->getItem(self::CACHE_KEY);
+        self::assertTrue($cacheItem->isHit());
+
+        /** @var list<string> $cached */
+        $cached = $cacheItem->get();
+        self::assertContains('free-model-1', $cached);
+        self::assertContains('free-model-2', $cached);
+        self::assertNotContains('paid-model', $cached);
     }
 
     public function testCircuitBreakerOpensAfterThresholdFailures(): void
@@ -110,6 +236,8 @@ final class ModelDiscoveryServiceTest extends TestCase
         /** @var array{state: string, failures: int, opened_at: ?int} $data */
         $data = $breakerItem->get();
         self::assertSame(CircuitBreakerState::Open->value, $data['state']);
+        self::assertSame(3, $data['failures']);
+        self::assertSame($clock->now()->getTimestamp(), $data['opened_at']);
     }
 
     public function testOpenBreakerReturnsCachedModelsWithoutApiCall(): void
@@ -141,6 +269,20 @@ final class ModelDiscoveryServiceTest extends TestCase
         self::assertCount(2, $models);
     }
 
+    public function testOpenBreakerWithNoCacheReturnsEmpty(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        // Open breaker without any cached models
+        $this->setBreakerState($cache, CircuitBreakerState::Open, openedAt: $clock->now()->getTimestamp());
+
+        $service = $this->createService($this->failingClient(), cache: $cache, clock: $clock);
+        $models = $service->discoverFreeModels();
+
+        self::assertCount(0, $models);
+    }
+
     public function testHalfOpenAfterResetPeriod(): void
     {
         $cache = new ArrayAdapter();
@@ -152,7 +294,7 @@ final class ModelDiscoveryServiceTest extends TestCase
         // Advance clock past reset period (24h)
         $clock->modify('+25 hours');
 
-        // Service should detect expired Open → HalfOpen → probe API
+        // Service should detect expired Open -> HalfOpen -> probe API
         $service = $this->createService($this->successClient(), cache: $cache, clock: $clock);
         $models = $service->discoverFreeModels();
 
@@ -185,6 +327,33 @@ final class ModelDiscoveryServiceTest extends TestCase
         /** @var array{state: string, failures: int, opened_at: ?int} $data */
         $data = $breakerItem->get();
         self::assertSame(CircuitBreakerState::Open->value, $data['state']);
+        self::assertSame(3, $data['failures']);
+        self::assertNotNull($data['opened_at']);
+    }
+
+    public function testBreakerStaysOpenBeforeResetPeriod(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        // Open breaker at time 0
+        $this->setBreakerState($cache, CircuitBreakerState::Open, openedAt: $clock->now()->getTimestamp());
+
+        // Advance only 23 hours — not enough
+        $clock->modify('+23 hours');
+
+        $apiCallCount = 0;
+        $factory = function () use (&$apiCallCount): MockResponse {
+            $apiCallCount++;
+
+            return new MockResponse($this->modelsJson());
+        };
+
+        $service = $this->createService(new MockHttpClient($factory), cache: $cache, clock: $clock);
+        $service->discoverFreeModels();
+
+        // Should NOT have called API — breaker is still open
+        self::assertSame(0, $apiCallCount);
     }
 
     public function testFailureCountPersistsAcrossInstances(): void
@@ -206,6 +375,99 @@ final class ModelDiscoveryServiceTest extends TestCase
         /** @var array{state: string, failures: int, opened_at: ?int} $data */
         $data = $breakerItem->get();
         self::assertSame(2, $data['failures']);
+        self::assertSame(CircuitBreakerState::Closed->value, $data['state']);
+    }
+
+    public function testSuccessfulFetchResetsBreaker(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        // Set one failure
+        $failService = $this->createService($this->failingClient(), cache: $cache, clock: $clock);
+        $failService->discoverFreeModels();
+
+        // Successful fetch should delete breaker data
+        $successService = $this->createService($this->successClient(), cache: $cache, clock: $clock);
+        // Clear model cache to force API call
+        $cache->deleteItem(self::CACHE_KEY);
+        $successService->discoverFreeModels();
+
+        $breakerItem = $cache->getItem(self::BREAKER_KEY);
+        self::assertFalse($breakerItem->isHit());
+    }
+
+    public function testHandlesEmptyDataArray(): void
+    {
+        $client = new MockHttpClient(new MockResponse(json_encode([
+            'data' => [],
+        ], JSON_THROW_ON_ERROR)));
+        $service = $this->createService($client);
+
+        $models = $service->discoverFreeModels();
+
+        self::assertCount(0, $models);
+    }
+
+    public function testHandlesMissingDataKey(): void
+    {
+        $client = new MockHttpClient(new MockResponse(json_encode([], JSON_THROW_ON_ERROR)));
+        $service = $this->createService($client);
+
+        $models = $service->discoverFreeModels();
+
+        self::assertCount(0, $models);
+    }
+
+    public function testLoggerInfoOnSuccessfulDiscovery(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info')
+            ->with(self::stringContains('Discovered'), self::callback(static fn (array $ctx): bool => $ctx['count'] === 2));
+
+        $service = new ModelDiscoveryService(
+            $this->successClient(),
+            new ArrayAdapter(),
+            new MockClock(),
+            $logger,
+        );
+        $service->discoverFreeModels();
+    }
+
+    public function testLoggerWarningOnFailure(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')
+            ->with(self::stringContains('failed'));
+
+        $service = new ModelDiscoveryService(
+            $this->failingClient(),
+            new ArrayAdapter(),
+            new MockClock(),
+            $logger,
+        );
+        $service->discoverFreeModels();
+    }
+
+    public function testLoggerWarningOnBreakerOpen(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        // Should log "Circuit breaker opened" when threshold hit
+        $logger->expects(self::atLeastOnce())->method('warning');
+
+        // Three consecutive failures to trigger breaker
+        for ($i = 0; $i < 3; $i++) {
+            $service = new ModelDiscoveryService(
+                $this->failingClient(),
+                $cache,
+                $clock,
+                $logger,
+            );
+            $service->discoverFreeModels();
+        }
     }
 
     private function createService(

--- a/tests/Unit/Shared/AI/Service/ModelQualityTrackerTest.php
+++ b/tests/Unit/Shared/AI/Service/ModelQualityTrackerTest.php
@@ -54,4 +54,48 @@ final class ModelQualityTrackerTest extends TestCase
         self::assertTrue($all->containsKey('model-y'));
         self::assertContainsOnlyInstancesOf(ModelQualityStats::class, $all->toArray());
     }
+
+    public function testRecordRejectionOnly(): void
+    {
+        $this->tracker->recordRejection('model-b');
+
+        $stats = $this->tracker->getStats('model-b');
+
+        self::assertSame(0, $stats->accepted);
+        self::assertSame(1, $stats->rejected);
+        self::assertSame(0.0, $stats->acceptanceRate);
+    }
+
+    public function testRecordAcceptanceOnly(): void
+    {
+        $this->tracker->recordAcceptance('model-c');
+
+        $stats = $this->tracker->getStats('model-c');
+
+        self::assertSame(1, $stats->accepted);
+        self::assertSame(0, $stats->rejected);
+        self::assertSame(1.0, $stats->acceptanceRate);
+    }
+
+    public function testIndexDoesNotDuplicate(): void
+    {
+        $this->tracker->recordAcceptance('model-d');
+        $this->tracker->recordAcceptance('model-d');
+        $this->tracker->recordAcceptance('model-d');
+
+        $all = $this->tracker->getAllStats();
+
+        // Model-d should appear only once
+        self::assertCount(1, $all);
+        $stats = $all->get('model-d');
+        self::assertInstanceOf(ModelQualityStats::class, $stats);
+        self::assertSame(3, $stats->accepted);
+    }
+
+    public function testGetAllStatsEmptyWhenNoRecords(): void
+    {
+        $all = $this->tracker->getAllStats();
+
+        self::assertCount(0, $all);
+    }
 }

--- a/tests/Unit/Shared/Command/CleanupCommandTest.php
+++ b/tests/Unit/Shared/Command/CleanupCommandTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Shared\Command;
 use App\Shared\Command\CleanupCommand;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -14,14 +15,21 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(CleanupCommand::class)]
 final class CleanupCommandTest extends TestCase
 {
+    private MockObject&Connection $connection;
+
+    private MockClock $clock;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->clock = new MockClock('2026-04-04 12:00:00');
+    }
+
     public function testExecutesCleanup(): void
     {
-        $connection = $this->createStub(Connection::class);
-        $connection->method('executeStatement')->willReturn(5);
+        $this->connection->method('executeStatement')->willReturn(5);
 
-        $clock = new MockClock('2026-04-04 12:00:00');
-
-        $command = new CleanupCommand($connection, $clock, 90, 30);
+        $command = new CleanupCommand($this->connection, $this->clock, 90, 30);
         $tester = new CommandTester($command);
 
         $tester->execute([]);
@@ -29,5 +37,137 @@ final class CleanupCommandTest extends TestCase
         self::assertSame(0, $tester->getStatusCode());
         self::assertStringContainsString('Cleanup complete', $tester->getDisplay());
         self::assertStringContainsString('90 days articles', $tester->getDisplay());
+        self::assertStringContainsString('30 days logs', $tester->getDisplay());
+    }
+
+    public function testExecutesFourDeleteStatements(): void
+    {
+        $this->connection->expects(self::exactly(4))
+            ->method('executeStatement')
+            ->willReturn(0);
+
+        $command = new CleanupCommand($this->connection, $this->clock, 90, 30);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testDeletesReadStatesFirst(): void
+    {
+        $callOrder = [];
+        $this->connection->expects(self::exactly(4))
+            ->method('executeStatement')
+            ->willReturnCallback(function (string $sql) use (&$callOrder): int {
+                $callOrder[] = $sql;
+
+                return 0;
+            });
+
+        $command = new CleanupCommand($this->connection, $this->clock, 90, 30);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        self::assertStringContainsString('user_article_read', $callOrder[0]);
+        self::assertStringContainsString('article', $callOrder[1]);
+        self::assertStringContainsString('notification_log', $callOrder[2]);
+        self::assertStringContainsString('digest_log', $callOrder[3]);
+    }
+
+    public function testUsesArticleRetentionForReadStatesAndArticles(): void
+    {
+        $expectedArticleCutoff = $this->clock->now()->modify('-90 days')->format('Y-m-d H:i:s');
+
+        $sqlParams = [];
+        $this->connection->expects(self::exactly(4))
+            ->method('executeStatement')
+            ->willReturnCallback(function (string $sql, array $params) use (&$sqlParams): int {
+                $sqlParams[] = [
+                    'sql' => $sql,
+                    'params' => $params,
+                ];
+
+                return 0;
+            });
+
+        $command = new CleanupCommand($this->connection, $this->clock, 90, 30);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        // First two statements use article retention cutoff
+        self::assertSame($expectedArticleCutoff, $sqlParams[0]['params']['cutoff']);
+        self::assertSame($expectedArticleCutoff, $sqlParams[1]['params']['cutoff']);
+    }
+
+    public function testUsesLogRetentionForNotificationAndDigestLogs(): void
+    {
+        $expectedLogCutoff = $this->clock->now()->modify('-30 days')->format('Y-m-d H:i:s');
+
+        $sqlParams = [];
+        $this->connection->expects(self::exactly(4))
+            ->method('executeStatement')
+            ->willReturnCallback(function (string $sql, array $params) use (&$sqlParams): int {
+                $sqlParams[] = [
+                    'sql' => $sql,
+                    'params' => $params,
+                ];
+
+                return 0;
+            });
+
+        $command = new CleanupCommand($this->connection, $this->clock, 90, 30);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        // Last two statements use log retention cutoff
+        self::assertSame($expectedLogCutoff, $sqlParams[2]['params']['cutoff']);
+        self::assertSame($expectedLogCutoff, $sqlParams[3]['params']['cutoff']);
+    }
+
+    public function testDisplaysDeletedCounts(): void
+    {
+        $callIndex = 0;
+        $this->connection->expects(self::exactly(4))
+            ->method('executeStatement')
+            ->willReturnCallback(function () use (&$callIndex): int {
+                $counts = [3, 10, 5, 2];
+
+                return $counts[$callIndex++];
+            });
+
+        $command = new CleanupCommand($this->connection, $this->clock, 90, 30);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('3 old read states', $display);
+        self::assertStringContainsString('10 old articles', $display);
+        self::assertStringContainsString('5 old notification logs', $display);
+        self::assertStringContainsString('2 old digest logs', $display);
+    }
+
+    public function testUsesCustomRetentionValues(): void
+    {
+        $this->connection->method('executeStatement')->willReturn(0);
+
+        $command = new CleanupCommand($this->connection, $this->clock, 180, 60);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('180 days articles', $display);
+        self::assertStringContainsString('60 days logs', $display);
+    }
+
+    public function testAlwaysReturnsSuccess(): void
+    {
+        $this->connection->method('executeStatement')->willReturn(0);
+
+        $command = new CleanupCommand($this->connection, $this->clock);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
     }
 }


### PR DESCRIPTION
## Summary

Closes #59

### CI Fix
Remove `|| true` from Infection step — CI now fails when MSI < 80% or covered MSI < 90%.

### Test Improvements
Added 153 new tests (176 → 329) with 968 assertions to bring MSI from 64% to 82%:

| File | Escaped Before | Tests Added |
|------|---------------|-------------|
| AiAlertEvaluationService | 43 | 18 |
| ModelDiscoveryService | 26 | 12 |
| LoadAlertRulesCommand | 25 | 8 |
| ScoringService | 17 | 11 |
| CleanupCommand | 16 | 6 |
| ArticleMatcherService | 16 | 10 |
| SendNotificationHandler | 15 | 5 |
| AI enrichment services (4) | 58 | 28 |
| Rule-based services (3) | 40 | 15 |
| Other files | 55 | 40 |

Key changes:
- Switched AI service tests to `InMemoryPlatform` (Symfony AI test utility)
- Added `ModelQualityTracker` mock expectations
- Boundary condition tests for scoring, quality gate, summarization
- Logger context verification throughout

## Test plan

- [x] All 329 tests pass
- [x] PHPStan clean, ECS clean, Rector clean
- [x] MSI 82% (above 80% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)