### PR TITLE
fix: re-enable MBString mutations for multi-language safety

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -21,7 +21,6 @@
         "DecrementInteger": false,
         "IncrementInteger": false,
         "UnwrapTrim": false,
-        "MBString": false,
         "ConcatOperandRemoval": {
             "ignoreSourceCodeByRegex": [
                 "logger->|->info\\(|->warning\\(|->debug\\("


### PR DESCRIPTION
## Summary

Re-enables MBString mutator in `infection.json5`. These were incorrectly excluded as false positives — they catch real bugs when processing non-ASCII text (German umlauts, French accents, potential Chinese/Japanese support).

The multibyte tests already in place (from the previous PR) kill all MBString mutations. Covered MSI stays at 90%.

## Test plan

- [x] Infection passes: MSI 80%, covered MSI 90%
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)