### PR TITLE
feat: drive dashboard category tabs from database (#74)

### DIFF
--- a/src/Shared/Controller/DashboardController.php
+++ b/src/Shared/Controller/DashboardController.php
@@ -6,6 +6,7 @@ namespace App\Shared\Controller;
 
 use App\Article\Entity\Article;
 use App\Article\Repository\ArticleRepositoryInterface;
+use App\Shared\Repository\CategoryRepositoryInterface;
 use App\Source\Repository\SourceRepositoryInterface;
 use App\User\Entity\User;
 use App\User\Repository\UserArticleReadRepositoryInterface;
@@ -22,6 +23,7 @@ final class DashboardController
         private readonly ArticleRepositoryInterface $articleRepository,
         private readonly UserArticleReadRepositoryInterface $userArticleReadRepository,
         private readonly SourceRepositoryInterface $sourceRepository,
+        private readonly CategoryRepositoryInterface $categoryRepository,
         private readonly ClockInterface $clock,
     ) {
     }
@@ -70,6 +72,7 @@ final class DashboardController
         return $this->controller->render('dashboard/index.html.twig', [
             'articles' => $articles,
             'currentCategory' => $category,
+            'categories' => $this->categoryRepository->findAllOrderedByWeight(),
             'articlesToday' => $articlesToday,
             'activeSources' => $activeSources,
             'page' => $page,

--- a/src/Shared/Repository/CategoryRepository.php
+++ b/src/Shared/Repository/CategoryRepository.php
@@ -32,6 +32,17 @@ final class CategoryRepository extends ServiceEntityRepository implements Catego
         return parent::findAll();
     }
 
+    /**
+     * @return list<Category>
+     */
+    public function findAllOrderedByWeight(): array
+    {
+        /** @var list<Category> */
+        return $this->findBy([], [
+            'weight' => 'ASC',
+        ]);
+    }
+
     public function findBySlug(string $slug): ?Category
     {
         return $this->findOneBy([

--- a/src/Shared/Repository/CategoryRepositoryInterface.php
+++ b/src/Shared/Repository/CategoryRepositoryInterface.php
@@ -17,6 +17,11 @@ interface CategoryRepositoryInterface
 
     public function findBySlug(string $slug): ?Category;
 
+    /**
+     * @return list<Category>
+     */
+    public function findAllOrderedByWeight(): array;
+
     public function save(Category $category, bool $flush = false): void;
 
     public function flush(): void;

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -12,11 +12,9 @@
     {# Category tabs #}
     <div class="tabs tabs-boxed mb-4 overflow-x-auto">
         <a href="{{ path('app_dashboard') }}" class="tab {{ currentCategory is null ? 'tab-active' : '' }}">All</a>
-        <a href="{{ path('app_dashboard', {category: 'politics'}) }}" class="tab {{ currentCategory == 'politics' ? 'tab-active' : '' }}">Politics</a>
-        <a href="{{ path('app_dashboard', {category: 'business'}) }}" class="tab {{ currentCategory == 'business' ? 'tab-active' : '' }}">Business</a>
-        <a href="{{ path('app_dashboard', {category: 'tech'}) }}" class="tab {{ currentCategory == 'tech' ? 'tab-active' : '' }}">Tech</a>
-        <a href="{{ path('app_dashboard', {category: 'science'}) }}" class="tab {{ currentCategory == 'science' ? 'tab-active' : '' }}">Science</a>
-        <a href="{{ path('app_dashboard', {category: 'sports'}) }}" class="tab {{ currentCategory == 'sports' ? 'tab-active' : '' }}">Sports</a>
+        {% for category in categories %}
+            <a href="{{ path('app_dashboard', {category: category.slug}) }}" class="tab {{ currentCategory == category.slug ? 'tab-active' : '' }}">{{ category.name }}</a>
+        {% endfor %}
     </div>
 
     {# Unread filter + Mark all read #}


### PR DESCRIPTION
## Summary
- Replace 5 hardcoded category tabs with a dynamic `{% for %}` loop over categories from the database
- Add `findAllOrderedByWeight()` to `CategoryRepositoryInterface` (ordered by weight ASC)
- `DashboardController` injects `CategoryRepositoryInterface` and passes categories to the template
- "All" tab remains static as the first entry

Closes #74

## Test plan
- [x] `make quality` (ECS + PHPStan max + Rector) green
- [x] `make test` — 465 tests pass
- [ ] Manual: verify category tabs render correctly on dashboard
- [ ] Manual: verify category filtering still works
- [ ] Manual: verify adding a new category in DB shows up without template change

🤖 Generated with [Claude Code](https://claude.com/claude-code)