### PR TITLE
fix: split camelCase word-joining artifacts in AI summaries (#85)

### DIFF
--- a/src/Enrichment/Service/AiSummarizationService.php
+++ b/src/Enrichment/Service/AiSummarizationService.php
@@ -30,6 +30,7 @@ PROMPT;
         private AiQualityGateServiceInterface $qualityGate,
         private ModelQualityTrackerInterface $qualityTracker,
         private LoggerInterface $logger,
+        private AiTextCleanupService $textCleanup,
     ) {
     }
 
@@ -41,7 +42,7 @@ PROMPT;
         for ($attempt = 1; $attempt <= self::MAX_AI_ATTEMPTS; $attempt++) {
             try {
                 $result = $this->platform->invoke(self::MODEL, $input);
-                $summary = trim($result->asText());
+                $summary = $this->textCleanup->clean(trim($result->asText()));
                 /** @var string $actualModel */
                 $actualModel = $result->getMetadata()->get('actual_model', self::MODEL);
 

--- a/src/Enrichment/Service/AiTextCleanupService.php
+++ b/src/Enrichment/Service/AiTextCleanupService.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enrichment\Service;
+
+/**
+ * Post-processes AI-generated text to fix common artifacts from free-tier models.
+ *
+ * Primary fix: camelCase word-joining ("InformationSecurity" -> "Information Security").
+ * Regex requires 2+ lowercase chars before the uppercase boundary to preserve
+ * brand names like iPhone, eBay, and abbreviations like pH or HTTPServer.
+ */
+final readonly class AiTextCleanupService
+{
+    private const string CAMEL_CASE_JOIN_PATTERN = '/(?<=[a-z]{2})(?=[A-Z][a-z])/';
+
+    public function clean(string $text): string
+    {
+        return (string) preg_replace(self::CAMEL_CASE_JOIN_PATTERN, ' ', $text);
+    }
+}

--- a/src/Enrichment/Service/AiTranslationService.php
+++ b/src/Enrichment/Service/AiTranslationService.php
@@ -28,6 +28,7 @@ PROMPT;
         private PlatformInterface $platform,
         private TranslationServiceInterface $ruleBasedFallback,
         private LoggerInterface $logger,
+        private AiTextCleanupService $textCleanup,
     ) {
     }
 
@@ -44,7 +45,7 @@ PROMPT;
             try {
                 $prompt = sprintf(self::PROMPT_TEMPLATE, $fromLabel, $toLabel, $text);
                 $input = new MessageBag(Message::ofUser($prompt));
-                $translated = trim($this->platform->invoke(self::MODEL, $input)->asText());
+                $translated = $this->textCleanup->clean(trim($this->platform->invoke(self::MODEL, $input)->asText()));
 
                 if ($translated !== '' && ! $this->isTooSimilar($text, $translated)) {
                     return $translated;

--- a/tests/Unit/Enrichment/Service/AiSummarizationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiSummarizationServiceTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Enrichment\Service;
 
 use App\Enrichment\Service\AiQualityGateServiceInterface;
 use App\Enrichment\Service\AiSummarizationService;
+use App\Enrichment\Service\AiTextCleanupService;
 use App\Enrichment\Service\RuleBasedSummarizationService;
 use App\Enrichment\Service\SummarizationServiceInterface;
 use App\Enrichment\ValueObject\EnrichmentResult;
@@ -37,6 +38,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $qualityTracker,
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->summarize('Long article content about government economic measures and inflation...', 'Economy News');
@@ -74,6 +76,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $qualityTracker,
             $logger,
+            new AiTextCleanupService(),
         );
 
         $content = 'This is the first sentence of a long article. This is the second sentence with more detail. And a third one.';
@@ -111,6 +114,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $qualityTracker,
             $logger,
+            new AiTextCleanupService(),
         );
 
         $content = 'This is a sufficiently long article content for testing purposes. It should trigger the rule-based fallback.';
@@ -131,6 +135,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $content = 'This is a sufficiently long article content for testing purposes. It should trigger the rule-based fallback.';
@@ -155,6 +160,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->summarize('Content text', 'My Title');
@@ -173,6 +179,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->summarize($longContent, 'Title');
@@ -191,6 +198,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->summarize($multibyteContent, 'Title');
@@ -219,6 +227,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             $logger,
+            new AiTextCleanupService(),
         );
 
         $content = 'This is a sufficiently long article content for testing purposes. Second sentence here for rule based.';
@@ -240,6 +249,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $qualityTracker,
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $content = 'This is a sufficiently long article content for testing purposes. Second sentence here.';
@@ -259,6 +269,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $content = 'This is a sufficiently long article content for testing purposes. Second sentence here.';
@@ -275,6 +286,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->summarize('Zcontent text here', 'Title');
@@ -303,6 +315,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             $logger,
+            new AiTextCleanupService(),
         );
 
         $content = 'This is long enough content for the summarization service to process properly.';
@@ -319,6 +332,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->summarize('Long content text here', 'Title');
@@ -358,6 +372,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $qualityTracker,
             $logger,
+            new AiTextCleanupService(),
         );
 
         $content = 'This is a sufficiently long article content for testing purposes. Second sentence here.';
@@ -386,6 +401,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $qualityTracker,
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->summarize('Content text', 'Title');
@@ -420,6 +436,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $qualityTracker,
             $logger,
+            new AiTextCleanupService(),
         );
 
         $content = 'This is a sufficiently long article content for testing purposes. Second sentence here.';
@@ -449,6 +466,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $qualityTracker,
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->summarize('Content text', 'Title');
@@ -471,6 +489,7 @@ final class AiSummarizationServiceTest extends TestCase
             $this->createQualityGateStub(),
             $this->createStub(ModelQualityTrackerInterface::class),
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $content = 'This is a sufficiently long article content for testing purposes. Second sentence here.';

--- a/tests/Unit/Enrichment/Service/AiTextCleanupServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiTextCleanupServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Enrichment\Service;
+
+use App\Enrichment\Service\AiTextCleanupService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AiTextCleanupService::class)]
+final class AiTextCleanupServiceTest extends TestCase
+{
+    private AiTextCleanupService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new AiTextCleanupService();
+    }
+
+    #[DataProvider('splitProvider')]
+    public function testSplitsCamelCaseJoins(string $input, string $expected): void
+    {
+        self::assertSame($expected, $this->service->clean($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function splitProvider(): iterable
+    {
+        yield 'InformationSecurity' => ['InformationSecurity', 'Information Security'];
+        yield 'BayernMunich' => ['BayernMunich', 'Bayern Munich'];
+        yield 'NewYorkCity' => ['NewYorkCity', 'New York City'];
+        yield 'mid-sentence join' => [
+            'The report coversInformationSecurity threats in Europe.',
+            'The report covers Information Security threats in Europe.',
+        ];
+        yield 'multiple joins' => [
+            'BayernMunich beatRealMadrid inChampionsLeague',
+            'Bayern Munich beat Real Madrid in Champions League',
+        ];
+    }
+
+    #[DataProvider('preserveProvider')]
+    public function testPreservesBrandNamesAndAbbreviations(string $input): void
+    {
+        self::assertSame($input, $this->service->clean($input));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function preserveProvider(): iterable
+    {
+        yield 'iPhone' => ['iPhone'];
+        yield 'eBay' => ['eBay'];
+        yield "McDonald's" => ["McDonald's"];
+        yield 'pH' => ['pH'];
+        yield 'HTTPServer' => ['HTTPServer'];
+        yield 'iOS' => ['iOS'];
+        yield 'eCommerce' => ['eCommerce'];
+    }
+
+    public function testReturnsEmptyStringUnchanged(): void
+    {
+        self::assertSame('', $this->service->clean(''));
+    }
+
+    public function testPreservesAlreadyCorrectText(): void
+    {
+        $text = 'This is a normal sentence with proper spacing.';
+
+        self::assertSame($text, $this->service->clean($text));
+    }
+}

--- a/tests/Unit/Enrichment/Service/AiTranslationServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiTranslationServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Enrichment\Service;
 
+use App\Enrichment\Service\AiTextCleanupService;
 use App\Enrichment\Service\AiTranslationService;
 use App\Enrichment\Service\RuleBasedTranslationService;
 use App\Enrichment\Service\TranslationServiceInterface;
@@ -28,6 +29,7 @@ final class AiTranslationServiceTest extends TestCase
             $platform,
             new RuleBasedTranslationService(),
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->translate('Bundesregierung beschließt neue Maßnahmen', 'de', 'en');
@@ -55,7 +57,7 @@ final class AiTranslationServiceTest extends TestCase
         $fallback = $this->createStub(TranslationServiceInterface::class);
         $fallback->method('translate')->willReturn('fallback');
 
-        $service = new AiTranslationService($platform, $fallback, new NullLogger());
+        $service = new AiTranslationService($platform, $fallback, new NullLogger(), new AiTextCleanupService());
 
         $service->translate('Ein deutscher Text', 'de', 'en');
 
@@ -77,7 +79,7 @@ final class AiTranslationServiceTest extends TestCase
         $fallback = $this->createMock(TranslationServiceInterface::class);
         $fallback->expects(self::once())->method('translate')->willReturn('fallback');
 
-        $service = new AiTranslationService($platform, $fallback, new NullLogger());
+        $service = new AiTranslationService($platform, $fallback, new NullLogger(), new AiTextCleanupService());
 
         $result = $service->translate('Original text here', 'de', 'en');
 
@@ -109,7 +111,7 @@ final class AiTranslationServiceTest extends TestCase
                 }),
             );
 
-        $service = new AiTranslationService($platform, $fallback, $logger);
+        $service = new AiTranslationService($platform, $fallback, $logger, new AiTextCleanupService());
 
         $result = $service->translate('Original text', 'de', 'en');
 
@@ -128,7 +130,7 @@ final class AiTranslationServiceTest extends TestCase
         $fallback = $this->createMock(TranslationServiceInterface::class);
         $fallback->expects(self::never())->method('translate');
 
-        $service = new AiTranslationService($platform, $fallback, new NullLogger());
+        $service = new AiTranslationService($platform, $fallback, new NullLogger(), new AiTextCleanupService());
 
         $result = $service->translate('Original text here', 'de', 'en');
 
@@ -162,6 +164,7 @@ final class AiTranslationServiceTest extends TestCase
             $platform,
             $fallback,
             $logger,
+            new AiTextCleanupService(),
         );
 
         $result = $service->translate($original, 'de', 'en');
@@ -195,6 +198,7 @@ final class AiTranslationServiceTest extends TestCase
             $platform,
             $fallback,
             $logger,
+            new AiTextCleanupService(),
         );
 
         $result = $service->translate($original, 'de', 'en');
@@ -216,6 +220,7 @@ final class AiTranslationServiceTest extends TestCase
             $platform,
             $fallback,
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->translate($original, 'en', 'en');
@@ -236,6 +241,7 @@ final class AiTranslationServiceTest extends TestCase
             $platform,
             $fallback,
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->translate($original, 'de', 'en');
@@ -251,6 +257,7 @@ final class AiTranslationServiceTest extends TestCase
             $platform,
             new RuleBasedTranslationService(),
             new NullLogger(),
+            new AiTextCleanupService(),
         );
 
         $result = $service->translate('Original text that is different enough', 'de', 'en');
@@ -267,7 +274,7 @@ final class AiTranslationServiceTest extends TestCase
         $fallback = $this->createMock(TranslationServiceInterface::class);
         $fallback->expects(self::once())->method('translate')->willReturn('fallback');
 
-        $service = new AiTranslationService($platform, $fallback, new NullLogger());
+        $service = new AiTranslationService($platform, $fallback, new NullLogger(), new AiTextCleanupService());
 
         $result = $service->translate($original, 'de', 'en');
 
@@ -292,7 +299,7 @@ final class AiTranslationServiceTest extends TestCase
         $fallback = $this->createStub(TranslationServiceInterface::class);
         $fallback->method('translate')->willReturn('fallback');
 
-        $service = new AiTranslationService($platform, $fallback, $logger);
+        $service = new AiTranslationService($platform, $fallback, $logger, new AiTextCleanupService());
 
         $service->translate('Original text here', 'de', 'en');
     }


### PR DESCRIPTION
## Summary
- Create `AiTextCleanupService` with regex `(?<=[a-z]{2})(?=[A-Z][a-z])` to split camelCase joins
- "InformationSecurity" → "Information Security", preserves "iPhone", "eBay", "McDonald's"
- Applied as post-processing in `AiSummarizationService` and `AiTranslationService`

Closes #85

## Test plan
- [x] `make quality` green
- [x] `make test` — 515 tests pass
- [x] `make infection` — MSI 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)