### PR TITLE
fix: show warning badge for enabled sources that never fetched (#86)

### DIFF
--- a/templates/source/index.html.twig
+++ b/templates/source/index.html.twig
@@ -45,6 +45,8 @@
                             <td>
                                 {% if source.lastFetchedAt %}
                                     <time datetime="{{ source.lastFetchedAt|date('c') }}" class="timeago">{{ source.lastFetchedAt|date('Y-m-d H:i') }}</time>
+                                {% elseif source.enabled %}
+                                    <span class="badge badge-warning badge-sm">Never fetched</span>
                                 {% else %}
                                     <span class="text-base-content/30">never</span>
                                 {% endif %}


### PR DESCRIPTION
## Summary
- Enabled sources with `lastFetchedAt = null` now show a yellow "Never fetched" badge
- Disabled sources still show plain "never" (expected behavior)
- Template-only change, 2 lines

Closes #86

## Test plan
- [x] `make quality` green
- [ ] Manual: verify badge appears on Yahoo Finance source

🤖 Generated with [Claude Code](https://claude.com/claude-code)