### PR TITLE
fix: show match count and last triggered on alert rules page (#87)

### DIFF
--- a/src/Notification/Controller/AlertRuleController.php
+++ b/src/Notification/Controller/AlertRuleController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Notification\Controller;
 
 use App\Notification\Repository\AlertRuleRepositoryInterface;
+use App\Notification\Repository\NotificationLogRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -14,6 +15,7 @@ final class AlertRuleController
     public function __construct(
         private readonly ControllerHelper $controller,
         private readonly AlertRuleRepositoryInterface $alertRuleRepository,
+        private readonly NotificationLogRepositoryInterface $notificationLogRepository,
     ) {
     }
 
@@ -22,6 +24,7 @@ final class AlertRuleController
     {
         return $this->controller->render('alert/index.html.twig', [
             'rules' => $this->alertRuleRepository->findAll(),
+            'matchStats' => $this->notificationLogRepository->getMatchStatsByAlertRule(),
         ]);
     }
 }

--- a/src/Notification/Repository/NotificationLogRepository.php
+++ b/src/Notification/Repository/NotificationLogRepository.php
@@ -57,4 +57,31 @@ final class NotificationLogRepository extends ServiceEntityRepository implements
     {
         $this->getEntityManager()->flush();
     }
+
+    /**
+     * @return array<int, array{count: int, lastTriggeredAt: \DateTimeImmutable|null}>
+     */
+    public function getMatchStatsByAlertRule(): array
+    {
+        /** @var list<array{ruleId: string, matchCount: string, lastTriggeredAt: string|null}> $rows */
+        $rows = $this->createQueryBuilder('l')
+            ->select('IDENTITY(l.alertRule) AS ruleId')
+            ->addSelect('COUNT(l.id) AS matchCount')
+            ->addSelect('MAX(l.sentAt) AS lastTriggeredAt')
+            ->groupBy('l.alertRule')
+            ->getQuery()
+            ->getArrayResult();
+
+        $stats = [];
+        foreach ($rows as $row) {
+            $stats[(int) $row['ruleId']] = [
+                'count' => (int) $row['matchCount'],
+                'lastTriggeredAt' => $row['lastTriggeredAt'] !== null
+                    ? new \DateTimeImmutable($row['lastTriggeredAt'])
+                    : null,
+            ];
+        }
+
+        return $stats;
+    }
 }

--- a/src/Notification/Repository/NotificationLogRepositoryInterface.php
+++ b/src/Notification/Repository/NotificationLogRepositoryInterface.php
@@ -18,4 +18,9 @@ interface NotificationLogRepositoryInterface
     public function save(NotificationLog $log, bool $flush = false): void;
 
     public function flush(): void;
+
+    /**
+     * @return array<int, array{count: int, lastTriggeredAt: \DateTimeImmutable|null}>
+     */
+    public function getMatchStatsByAlertRule(): array;
 }

--- a/templates/alert/index.html.twig
+++ b/templates/alert/index.html.twig
@@ -23,6 +23,8 @@
                         <th>Urgency</th>
                         <th>Cooldown</th>
                         <th>Enabled</th>
+                        <th>Matches</th>
+                        <th>Last Triggered</th>
                         <th>Actions</th>
                     </tr>
                 </thead>
@@ -42,6 +44,18 @@
                                     <span class="badge badge-success badge-sm">yes</span>
                                 {% else %}
                                     <span class="badge badge-ghost badge-sm">no</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% set stats = matchStats[rule.id] ?? null %}
+                                {{ stats ? stats.count : 0 }}
+                            </td>
+                            <td>
+                                {% set stats = matchStats[rule.id] ?? null %}
+                                {% if stats and stats.lastTriggeredAt %}
+                                    <time datetime="{{ stats.lastTriggeredAt|date('c') }}" class="timeago">{{ stats.lastTriggeredAt|date('Y-m-d H:i') }}</time>
+                                {% else %}
+                                    <span class="text-base-content/50">never</span>
                                 {% endif %}
                             </td>
                             <td>


### PR DESCRIPTION
## Summary
- Add `getMatchStatsByAlertRule()` to `NotificationLogRepository` — single GROUP BY query, no N+1
- Alert rules table now shows "Matches" count and "Last Triggered" with relative time
- Shows "never" for rules that haven't triggered

Closes #87

## Test plan
- [x] `make quality` green
- [x] `make test` — all tests pass
- [ ] Manual: verify match counts and timestamps on /alerts page

🤖 Generated with [Claude Code](https://claude.com/claude-code)