### PR TITLE
feat: add edit functionality for alert rules (#73)

### DIFF
--- a/src/Notification/Controller/EditAlertRuleController.php
+++ b/src/Notification/Controller/EditAlertRuleController.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Controller;
+
+use App\Notification\Entity\AlertRule;
+use App\Notification\Repository\AlertRuleRepositoryInterface;
+use App\Notification\ValueObject\AlertRuleType;
+use App\Notification\ValueObject\AlertUrgency;
+use App\User\Entity\User;
+use Psr\Clock\ClockInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class EditAlertRuleController
+{
+    public function __construct(
+        private readonly ControllerHelper $controller,
+        private readonly AlertRuleRepositoryInterface $alertRuleRepository,
+        private readonly ClockInterface $clock,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    #[Route('/alerts/{id}/edit', name: 'app_alerts_edit', methods: ['GET', 'POST'])]
+    public function __invoke(int $id): Response
+    {
+        $user = $this->controller->getUser();
+        if (! $user instanceof User) {
+            return new RedirectResponse($this->urlGenerator->generate('app_login'));
+        }
+
+        $rule = $this->alertRuleRepository->findById($id);
+        if (! $rule instanceof AlertRule) {
+            $this->controller->addFlash('error', 'Alert rule not found.');
+
+            return new RedirectResponse($this->urlGenerator->generate('app_alerts'));
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request instanceof Request && $request->isMethod('POST')) {
+            return $this->handlePost($request, $rule, $id);
+        }
+
+        return $this->controller->render('alert/edit.html.twig', [
+            'rule' => $rule,
+        ]);
+    }
+
+    private function handlePost(
+        Request $request,
+        AlertRule $rule,
+        int $id,
+    ): RedirectResponse {
+        $name = trim((string) $request->request->get('name'));
+        $typeValue = (string) $request->request->get('type');
+        $keywordsRaw = trim((string) $request->request->get('keywords'));
+        $urgencyValue = (string) $request->request->get('urgency');
+        $contextPrompt = trim((string) $request->request->get('context_prompt'));
+        $severityThreshold = (int) $request->request->get('severity_threshold', 5);
+        $cooldownMinutes = (int) $request->request->get('cooldown_minutes', 60);
+
+        if ($name === '') {
+            $this->controller->addFlash('error', 'Name is required.');
+
+            return new RedirectResponse($this->urlGenerator->generate('app_alerts_edit', [
+                'id' => $id,
+            ]));
+        }
+
+        $type = AlertRuleType::tryFrom($typeValue);
+        if ($type === null) {
+            $this->controller->addFlash('error', 'Invalid alert type.');
+
+            return new RedirectResponse($this->urlGenerator->generate('app_alerts_edit', [
+                'id' => $id,
+            ]));
+        }
+
+        $urgency = AlertUrgency::tryFrom($urgencyValue) ?? AlertUrgency::Medium;
+        $keywords = $this->parseKeywords($keywordsRaw);
+
+        $rule->setName($name);
+        $rule->setType($type);
+        $rule->setKeywords($keywords);
+        $rule->setUrgency($urgency);
+        $rule->setSeverityThreshold($severityThreshold);
+        $rule->setCooldownMinutes($cooldownMinutes);
+        $rule->setContextPrompt($contextPrompt !== '' ? $contextPrompt : null);
+        $rule->setUpdatedAt($this->clock->now());
+
+        $this->alertRuleRepository->save($rule, flush: true);
+
+        $this->controller->addFlash('success', 'Alert rule updated.');
+
+        return new RedirectResponse($this->urlGenerator->generate('app_alerts'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseKeywords(string $raw): array
+    {
+        if ($raw === '') {
+            return [];
+        }
+
+        return array_values(
+            array_filter(
+                array_map(trim(...), explode(',', $raw)),
+                static fn (string $k): bool => $k !== '',
+            ),
+        );
+    }
+}

--- a/src/Notification/Entity/AlertRule.php
+++ b/src/Notification/Entity/AlertRule.php
@@ -85,9 +85,19 @@ class AlertRule
         return $this->name;
     }
 
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
     public function getType(): AlertRuleType
     {
         return $this->type;
+    }
+
+    public function setType(AlertRuleType $type): void
+    {
+        $this->type = $type;
     }
 
     /**

--- a/templates/alert/edit.html.twig
+++ b/templates/alert/edit.html.twig
@@ -1,0 +1,69 @@
+{% extends 'base.html.twig' %}
+{% block title %}Edit Alert Rule{% endblock %}
+{% block body %}
+    <h1 class="text-2xl font-bold mb-6">Edit Alert Rule</h1>
+
+    <form method="POST" action="{{ path('app_alerts_edit', {id: rule.id}) }}" class="max-w-lg flex flex-col gap-4">
+        <div class="form-control">
+            <label class="label" for="name">
+                <span class="label-text">Name</span>
+            </label>
+            <input type="text" id="name" name="name" class="input input-bordered" required value="{{ rule.name }}">
+        </div>
+
+        <div class="form-control">
+            <label class="label" for="type">
+                <span class="label-text">Type</span>
+            </label>
+            <select id="type" name="type" class="select select-bordered" required>
+                <option value="keyword" {{ rule.type.value == 'keyword' ? 'selected' : '' }}>Keyword</option>
+                <option value="ai" {{ rule.type.value == 'ai' ? 'selected' : '' }}>AI</option>
+                <option value="both" {{ rule.type.value == 'both' ? 'selected' : '' }}>Both</option>
+            </select>
+        </div>
+
+        <div class="form-control">
+            <label class="label" for="keywords">
+                <span class="label-text">Keywords (comma-separated)</span>
+            </label>
+            <input type="text" id="keywords" name="keywords" class="input input-bordered" value="{{ rule.keywords|join(', ') }}">
+        </div>
+
+        <div class="form-control">
+            <label class="label" for="urgency">
+                <span class="label-text">Urgency</span>
+            </label>
+            <select id="urgency" name="urgency" class="select select-bordered">
+                <option value="low" {{ rule.urgency.value == 'low' ? 'selected' : '' }}>Low</option>
+                <option value="medium" {{ rule.urgency.value == 'medium' ? 'selected' : '' }}>Medium</option>
+                <option value="high" {{ rule.urgency.value == 'high' ? 'selected' : '' }}>High</option>
+            </select>
+        </div>
+
+        <div class="form-control">
+            <label class="label" for="context_prompt">
+                <span class="label-text">Context Prompt (optional)</span>
+            </label>
+            <textarea id="context_prompt" name="context_prompt" class="textarea textarea-bordered" rows="3">{{ rule.contextPrompt }}</textarea>
+        </div>
+
+        <div class="form-control">
+            <label class="label" for="severity_threshold">
+                <span class="label-text">Severity Threshold (1-10)</span>
+            </label>
+            <input type="number" id="severity_threshold" name="severity_threshold" class="input input-bordered" value="{{ rule.severityThreshold }}" min="1" max="10">
+        </div>
+
+        <div class="form-control">
+            <label class="label" for="cooldown_minutes">
+                <span class="label-text">Cooldown (minutes)</span>
+            </label>
+            <input type="number" id="cooldown_minutes" name="cooldown_minutes" class="input input-bordered" value="{{ rule.cooldownMinutes }}" min="1">
+        </div>
+
+        <div class="flex gap-2 mt-2">
+            <button type="submit" class="btn btn-primary">Update Rule</button>
+            <a href="{{ path('app_alerts') }}" class="btn btn-ghost">Cancel</a>
+        </div>
+    </form>
+{% endblock %}

--- a/templates/alert/index.html.twig
+++ b/templates/alert/index.html.twig
@@ -58,7 +58,8 @@
                                     <span class="text-base-content/50">never</span>
                                 {% endif %}
                             </td>
-                            <td>
+                            <td class="flex gap-1">
+                                <a href="{{ path('app_alerts_edit', {id: rule.id}) }}" class="btn btn-ghost btn-xs">Edit</a>
                                 <form method="POST" action="{{ path('app_alerts_delete', {id: rule.id}) }}" onsubmit="return confirm('Delete this alert rule?')">
                                     <input type="hidden" name="_token" value="{{ csrf_token('delete_alert_rule') }}">
                                     <button type="submit" class="btn btn-ghost btn-xs text-error">Delete</button>

--- a/tests/Functional/Notification/EditAlertRuleControllerTest.php
+++ b/tests/Functional/Notification/EditAlertRuleControllerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Notification;
+
+use App\Notification\Entity\AlertRule;
+use App\Notification\Repository\AlertRuleRepository;
+use App\Notification\Repository\AlertRuleRepositoryInterface;
+use App\Notification\ValueObject\AlertRuleType;
+use App\User\Entity\User;
+use App\User\Repository\UserRepository;
+use App\User\Repository\UserRepositoryInterface;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+#[CoversNothing]
+final class EditAlertRuleControllerTest extends WebTestCase
+{
+    public function testGetEditFormRendersWithPrefilledValues(): void
+    {
+        $client = self::createClient();
+
+        $user = $this->getOrCreateUser();
+        $client->loginUser($user);
+
+        $ruleId = $this->createAlertRuleAndReturnId($user, 'Test Rule', AlertRuleType::Keyword);
+
+        $client->request('GET', '/alerts/' . $ruleId . '/edit');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('input[name="name"][value="Test Rule"]');
+        self::assertSelectorExists('select[name="type"]');
+    }
+
+    public function testPostUpdatesRuleAndRedirects(): void
+    {
+        $client = self::createClient();
+
+        $user = $this->getOrCreateUser();
+        $client->loginUser($user);
+
+        $ruleId = $this->createAlertRuleAndReturnId($user, 'Old Name', AlertRuleType::Keyword);
+
+        $client->request('POST', '/alerts/' . $ruleId . '/edit', [
+            'name' => 'Updated Name',
+            'type' => 'ai',
+            'keywords' => 'foo, bar',
+            'urgency' => 'high',
+            'context_prompt' => 'Some context',
+            'severity_threshold' => 8,
+            'cooldown_minutes' => 30,
+        ]);
+
+        self::assertResponseRedirects('/alerts');
+
+        $repository = $this->getAlertRuleRepository();
+        $updated = $repository->findById($ruleId);
+
+        self::assertNotNull($updated);
+        self::assertSame('Updated Name', $updated->getName());
+        self::assertSame(AlertRuleType::Ai, $updated->getType());
+        self::assertSame(['foo', 'bar'], $updated->getKeywords());
+        self::assertSame(8, $updated->getSeverityThreshold());
+        self::assertSame(30, $updated->getCooldownMinutes());
+    }
+
+    public function testGetReturnsRedirectForNonExistentRule(): void
+    {
+        $client = self::createClient();
+
+        $user = $this->getOrCreateUser();
+        $client->loginUser($user);
+
+        $client->request('GET', '/alerts/99999/edit');
+
+        self::assertResponseRedirects('/alerts');
+    }
+
+    public function testPostWithEmptyNameShowsError(): void
+    {
+        $client = self::createClient();
+
+        $user = $this->getOrCreateUser();
+        $client->loginUser($user);
+
+        $ruleId = $this->createAlertRuleAndReturnId($user, 'Some Rule', AlertRuleType::Keyword);
+
+        $client->request('POST', '/alerts/' . $ruleId . '/edit', [
+            'name' => '',
+            'type' => 'keyword',
+            'keywords' => '',
+            'urgency' => 'medium',
+            'severity_threshold' => 5,
+            'cooldown_minutes' => 60,
+        ]);
+
+        self::assertResponseRedirects('/alerts/' . $ruleId . '/edit');
+    }
+
+    private function getOrCreateUser(): User
+    {
+        /** @var UserRepository $repository */
+        $repository = self::getContainer()->get(UserRepositoryInterface::class);
+
+        $user = $repository->findFirst();
+        if (! $user instanceof User) {
+            $user = new User('test@example.com', 'hashed');
+            $repository->save($user, flush: true);
+        }
+
+        $user->setRoles(['ROLE_ADMIN']);
+        $repository->save($user, flush: true);
+
+        return $user;
+    }
+
+    private function getAlertRuleRepository(): AlertRuleRepository
+    {
+        /** @var AlertRuleRepository $repository */
+        $repository = self::getContainer()->get(AlertRuleRepositoryInterface::class);
+
+        return $repository;
+    }
+
+    private function createAlertRuleAndReturnId(User $user, string $name, AlertRuleType $type): int
+    {
+        $repository = $this->getAlertRuleRepository();
+
+        $rule = new AlertRule($name, $type, $user, new \DateTimeImmutable());
+        $rule->setKeywords(['test']);
+        $repository->save($rule, flush: true);
+
+        $id = $rule->getId();
+        self::assertNotNull($id);
+
+        return $id;
+    }
+}


### PR DESCRIPTION
## Summary
- New `EditAlertRuleController` with GET (pre-filled form) + POST (validate/save)
- Edit template mirroring create form with all fields pre-populated
- Edit link added to alert rules list alongside Delete
- `setName()` and `setType()` setters added to `AlertRule` entity
- 4 functional tests: edit form, update persistence, 404 handling, validation

Closes #73

## Test plan
- [x] `make quality` green
- [x] `make test` — 519 tests pass
- [x] Browser: Edit link visible on /alerts page
- [ ] Manual: edit a rule, verify changes persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)