### PR TITLE
feat: auto-mark articles as read on scroll + improved read/unread visuals (#104)

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,3 +1,17 @@
 body {
     background-color: skyblue;
 }
+
+/* Article read/unread visual distinction */
+.article-unread {
+    border-left: 4px solid oklch(var(--p));
+}
+
+.article-read {
+    border-left: 4px solid transparent;
+    opacity: 0.7;
+}
+
+.article-read .card-title a {
+    opacity: 0.8;
+}

--- a/assets/ts/mark-as-read.ts
+++ b/assets/ts/mark-as-read.ts
@@ -1,4 +1,7 @@
-function markAsRead(articleId: string): void {
+const DWELL_TIME_MS = 2000;
+const VISIBILITY_THRESHOLD = 0.5;
+
+function markAsRead(articleId: string, card: Element): void {
     void fetch(`/articles/${articleId}/read`, {
         method: 'POST',
         headers: {
@@ -6,21 +9,94 @@ function markAsRead(articleId: string): void {
         },
     });
 
-    // Visual feedback: dim the card
-    const card = document.querySelector(`[data-article-id="${articleId}"]`);
-    if (card) {
-        card.classList.add('opacity-60');
-    }
+    applyReadStyle(card);
 }
 
-// Event delegation on article links
+function applyReadStyle(card: Element): void {
+    card.classList.remove('article-unread');
+    card.classList.add('article-read');
+}
+
+function isAlreadyRead(card: Element): boolean {
+    return card.classList.contains('article-read');
+}
+
+// --- Click handler (existing behavior) ---
+
 document.addEventListener('click', (event: Event) => {
     const target = event.target as HTMLElement;
     const link = target.closest<HTMLAnchorElement>('.article-link');
     if (link) {
         const articleId = link.dataset.articleId;
-        if (articleId) {
-            markAsRead(articleId);
+        const card = link.closest<HTMLElement>('[data-article-id]');
+        if (articleId && card) {
+            markAsRead(articleId, card);
         }
     }
 });
+
+// --- Scroll-based auto-mark with dwell timer ---
+
+const dwellTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function handleIntersection(entries: IntersectionObserverEntry[]): void {
+    for (const entry of entries) {
+        const card = entry.target;
+        const articleId = card.getAttribute('data-article-id');
+        if (!articleId) continue;
+
+        if (entry.isIntersecting) {
+            if (isAlreadyRead(card) || dwellTimers.has(articleId)) continue;
+
+            const timer = setTimeout(() => {
+                dwellTimers.delete(articleId);
+                if (isAlreadyRead(card)) return;
+
+                markAsRead(articleId, card);
+                scrollObserver.unobserve(card);
+            }, DWELL_TIME_MS);
+
+            dwellTimers.set(articleId, timer);
+        } else {
+            const existing = dwellTimers.get(articleId);
+            if (existing !== undefined) {
+                clearTimeout(existing);
+                dwellTimers.delete(articleId);
+            }
+        }
+    }
+}
+
+const scrollObserver = new IntersectionObserver(handleIntersection, {
+    threshold: VISIBILITY_THRESHOLD,
+});
+
+function observeArticleCards(): void {
+    const cards = document.querySelectorAll<HTMLElement>('[data-article-id]');
+    for (const card of cards) {
+        if (!isAlreadyRead(card)) {
+            scrollObserver.observe(card);
+        }
+    }
+}
+
+// Observe initial cards
+observeArticleCards();
+
+// Re-observe after infinite scroll loads new cards
+const feed = document.querySelector<HTMLElement>('#article-feed');
+if (feed) {
+    const mutationObserver = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (node instanceof HTMLElement && node.hasAttribute('data-article-id')) {
+                    if (!isAlreadyRead(node)) {
+                        scrollObserver.observe(node);
+                    }
+                }
+            }
+        }
+    });
+
+    mutationObserver.observe(feed, { childList: true });
+}

--- a/templates/components/_article_card.html.twig
+++ b/templates/components/_article_card.html.twig
@@ -1,5 +1,6 @@
-{# Expects: article (Article entity) #}
-<div class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow {{ article_read is defined and article_read ? 'opacity-60' : '' }}"
+{# Expects: article (Article entity), readArticleIds (optional array<int, true>) #}
+{% set is_read = readArticleIds is defined and article.id in readArticleIds|keys %}
+<div class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow {{ is_read ? 'article-read' : 'article-unread' }}"
     data-article-id="{{ article.id }}"
     data-searchable="{{ article.title|lower }} {{ article.summary|default('')|lower }}"
     data-title-default="{{ article.title|e('html_attr') }}"


### PR DESCRIPTION
## Summary
- **IntersectionObserver + 2s dwell timer**: articles auto-mark as read when visible for 2+ seconds
- **MutationObserver**: handles infinite scroll — new cards get observed automatically  
- **Visual distinction**: unread articles get left border accent (DaisyUI primary), read articles get muted opacity
- Click-to-mark still works (existing behavior preserved)
- Works on desktop and mobile (IntersectionObserver is universally supported)

Closes #104

## Test plan
- [x] `make quality` green
- [x] `make test` — 514 tests pass
- [x] `make ts-build` compiles cleanly
- [x] Browser: screenshot confirms left border accent on unread articles
- [ ] Manual: scroll dashboard, verify articles mark as read after 2s dwell
- [ ] Manual: fast scroll, verify no accidental marking

🤖 Generated with [Claude Code](https://claude.com/claude-code)