### PR TITLE
feat: add Playwright MCP server for interactive browser testing

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -8,6 +8,12 @@ tools:
   - Grep
   - Bash
   - Skill
+  - mcp__playwright__browser_navigate
+  - mcp__playwright__browser_snapshot
+  - mcp__playwright__browser_click
+  - mcp__playwright__browser_take_screenshot
+  - mcp__playwright__browser_wait_for
+  - mcp__playwright__browser_evaluate
 ---
 
 # Product Owner — Requirements & Prioritization

--- a/.claude/agents/qa-specialist.md
+++ b/.claude/agents/qa-specialist.md
@@ -14,6 +14,17 @@ tools:
   - mcp__code-review-graph__query_graph_tool
   - mcp__code-review-graph__get_impact_radius_tool
   - mcp__code-review-graph__semantic_search_nodes_tool
+  - mcp__playwright__browser_navigate
+  - mcp__playwright__browser_snapshot
+  - mcp__playwright__browser_click
+  - mcp__playwright__browser_take_screenshot
+  - mcp__playwright__browser_wait_for
+  - mcp__playwright__browser_evaluate
+  - mcp__playwright__browser_run_code
+  - mcp__playwright__browser_type
+  - mcp__playwright__browser_fill_form
+  - mcp__playwright__browser_press_key
+  - mcp__playwright__browser_network_requests
 ---
 
 # QA Specialist — Quality Gate Guardian

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "bunx",
+      "args": [
+        "playwright-mcp",
+        "--headless",
+        "--ignore-https-errors",
+        "--viewport-size", "1280x720"
+      ]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,14 @@ src/
 | `/review` | Review current branch using QA Specialist agent |
 | `/browse [--screenshot] <path>` | Browse the running UI via Playwright, return page text |
 
+## Browser Tools (Playwright MCP)
+
+PO and QA agents have access to interactive browser tools via the Playwright MCP server (`.mcp.json`). These support persistent sessions, clicking, scrolling, form filling, and screenshots — unlike `/browse` which is a single-shot text dump.
+
+Key tools: `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_take_screenshot`, `browser_evaluate`, `browser_wait_for`, `browser_fill_form`, `browser_run_code`.
+
+Login required: navigate to the app URL first, then use `browser_fill_form` to log in. Session persists across tool calls.
+
 ## Agent Handoff Workflow
 
 For multi-step features, agents communicate through structured files in `.claude/handoff/`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "dependencies": {
+    "@playwright/mcp": "^0.0.70",
     "playwright": "^1.59.1"
   }
 }


### PR DESCRIPTION
## Summary
- Add `.mcp.json` configuring `@playwright/mcp` with headless mode + self-signed cert support
- PO agent gains 6 browser tools: navigate, snapshot, click, screenshot, wait_for, evaluate
- QA agent gains 10 browser tools: all PO tools + run_code, type, fill_form, press_key, network_requests
- Persistent browser session across tool calls — login once, interact many times
- Enables real interaction testing (scroll, click, form fill) that `/browse` can't do
- Documented in CLAUDE.md

## What this enables
- QA can test scroll-to-mark-as-read by navigating, scrolling, waiting, then checking CSS classes
- PO can click category tabs, use the language selector, and verify interactive features
- Both agents can fill and submit forms (e.g., test alert rule editing)

## Test plan
- [x] `bunx playwright-mcp --headless` starts and responds to tool listing
- [x] Agent definitions updated with correct tool names
- [x] No PHP changes — `make quality` unaffected
- [ ] Manual: restart Claude Code session, verify MCP server connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)