### PR TITLE
fix: fast-fail on rate limiting in ModelFailoverPlatform

### DIFF
--- a/src/Shared/AI/Platform/ModelFailoverPlatform.php
+++ b/src/Shared/AI/Platform/ModelFailoverPlatform.php
@@ -59,6 +59,11 @@ final class ModelFailoverPlatform implements PlatformInterface
                     'model' => $candidateModel,
                     'error' => $e->getMessage(),
                 ]);
+
+                // Rate limiting affects the entire provider — don't waste time trying other models
+                if (str_contains($e->getMessage(), 'Rate limit')) {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
## Problem
When OpenRouter is rate limited, `ModelFailoverPlatform` tries ALL 6 models in the chain sequentially — each returns "Rate limit exceeded" after ~0.5-1s. With 5 enrichment calls per article, that's 15-30 seconds of wasted HTTP calls before falling back to rule-based.

## Fix
Break out of the failover loop immediately when the error message contains "Rate limit". All models share the same OpenRouter provider, so if one is rate limited, they all are.

## Impact
- Rate-limited articles now fall back to rule-based in <1s instead of 15-30s
- Normal operation (no rate limiting) is unaffected — the break only fires on rate limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)