### PR TITLE
feat: htmx enhancements — category tabs, filters, inline delete, live search (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 #### Post-Release Features
+- htmx enhancements across dashboard and CRUD pages — no-reload category tabs, unread toggle, Mark All Read, live search, inline delete with confirmation, digest Run Now (#122)
 - Dashboard stats row: added Alerts Today count and Last Fetch relative timestamp (#75)
 - Async two-phase enrichment — Phase 1 (sync) applies rule-based categorization/summarization/keywords/scoring, Phase 2 (async via `async_enrich` transport) runs full AI enrichment + translation; articles appear instantly and upgrade in-place (#114)
 - Mercure real-time updates — SSE push via built-in FrankenPHP/Caddy Mercure hub; "new articles" banner on dashboard, in-place article card updates when AI enrichment completes (#119)

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -15,3 +15,18 @@ body {
 .article-read .card-title a {
     opacity: 0.8;
 }
+
+/* htmx transitions */
+.htmx-swapping {
+    opacity: 0;
+    transition: opacity 300ms ease-out;
+}
+
+.htmx-indicator {
+    display: none;
+}
+
+.htmx-request .htmx-indicator,
+.htmx-request.htmx-indicator {
+    display: flex;
+}

--- a/src/Digest/Controller/DeleteDigestConfigController.php
+++ b/src/Digest/Controller/DeleteDigestConfigController.php
@@ -9,7 +9,8 @@ use App\Digest\Repository\DigestConfigRepositoryInterface;
 use App\User\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -19,20 +20,26 @@ final class DeleteDigestConfigController
         private readonly ControllerHelper $controller,
         private readonly DigestConfigRepositoryInterface $digestConfigRepository,
         private readonly UrlGeneratorInterface $urlGenerator,
-        private readonly RequestStack $requestStack,
     ) {
     }
 
     #[Route('/digests/{id}/delete', name: 'app_digests_delete', methods: ['POST'])]
-    public function __invoke(int $id): RedirectResponse
+    public function __invoke(Request $request, int $id): Response
     {
         $user = $this->controller->getUser();
         if (! $user instanceof User) {
             return new RedirectResponse($this->urlGenerator->generate('app_login'));
         }
 
-        $token = $this->requestStack->getCurrentRequest()?->request->getString('_token');
+        $isHtmx = $request->headers->has('HX-Request');
+
+        $token = $request->headers->get('X-CSRF-Token')
+            ?? $request->request->getString('_token');
         if (! $this->controller->isCsrfTokenValid('delete_digest_config', $token)) {
+            if ($isHtmx) {
+                return new Response('Invalid CSRF token.', Response::HTTP_FORBIDDEN);
+            }
+
             $this->controller->addFlash('error', 'Invalid CSRF token.');
 
             return new RedirectResponse($this->urlGenerator->generate('app_digests'));
@@ -40,12 +47,20 @@ final class DeleteDigestConfigController
 
         $config = $this->digestConfigRepository->findById($id);
         if (! $config instanceof DigestConfig) {
+            if ($isHtmx) {
+                return new Response('Digest configuration not found.', Response::HTTP_NOT_FOUND);
+            }
+
             $this->controller->addFlash('error', 'Digest configuration not found.');
 
             return new RedirectResponse($this->urlGenerator->generate('app_digests'));
         }
 
         $this->digestConfigRepository->remove($config, flush: true);
+
+        if ($isHtmx) {
+            return new Response('');
+        }
 
         $this->controller->addFlash('success', 'Digest configuration deleted.');
 

--- a/src/Digest/Controller/TriggerDigestController.php
+++ b/src/Digest/Controller/TriggerDigestController.php
@@ -10,7 +10,8 @@ use App\Digest\Repository\DigestConfigRepositoryInterface;
 use App\User\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -22,20 +23,26 @@ final class TriggerDigestController
         private readonly DigestConfigRepositoryInterface $digestConfigRepository,
         private readonly MessageBusInterface $messageBus,
         private readonly UrlGeneratorInterface $urlGenerator,
-        private readonly RequestStack $requestStack,
     ) {
     }
 
     #[Route('/digests/{id}/trigger', name: 'app_digests_trigger', methods: ['POST'])]
-    public function __invoke(int $id): RedirectResponse
+    public function __invoke(Request $request, int $id): Response
     {
         $user = $this->controller->getUser();
         if (! $user instanceof User) {
             return new RedirectResponse($this->urlGenerator->generate('app_login'));
         }
 
-        $token = $this->requestStack->getCurrentRequest()?->request->getString('_token');
+        $isHtmx = $request->headers->has('HX-Request');
+
+        $token = $request->headers->get('X-CSRF-Token')
+            ?? $request->request->getString('_token');
         if (! $this->controller->isCsrfTokenValid('trigger_digest', $token)) {
+            if ($isHtmx) {
+                return new Response('Invalid CSRF token.', Response::HTTP_FORBIDDEN);
+            }
+
             $this->controller->addFlash('error', 'Invalid CSRF token.');
 
             return new RedirectResponse($this->urlGenerator->generate('app_digests'));
@@ -43,6 +50,10 @@ final class TriggerDigestController
 
         $config = $this->digestConfigRepository->findById($id);
         if (! $config instanceof DigestConfig) {
+            if ($isHtmx) {
+                return new Response('Digest configuration not found.', Response::HTTP_NOT_FOUND);
+            }
+
             $this->controller->addFlash('error', 'Digest configuration not found.');
 
             return new RedirectResponse($this->urlGenerator->generate('app_digests'));
@@ -51,6 +62,12 @@ final class TriggerDigestController
         /** @var int $configId */
         $configId = $config->getId();
         $this->messageBus->dispatch(new GenerateDigestMessage($configId, force: true));
+
+        if ($isHtmx) {
+            return $this->controller->render('digest/_trigger_confirmation.html.twig', [
+                'config' => $config,
+            ]);
+        }
 
         $this->controller->addFlash('success', 'Digest generation triggered. It will appear in history shortly.');
 

--- a/src/Notification/Controller/DeleteAlertRuleController.php
+++ b/src/Notification/Controller/DeleteAlertRuleController.php
@@ -9,7 +9,8 @@ use App\Notification\Repository\AlertRuleRepositoryInterface;
 use App\User\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -19,20 +20,26 @@ final class DeleteAlertRuleController
         private readonly ControllerHelper $controller,
         private readonly AlertRuleRepositoryInterface $alertRuleRepository,
         private readonly UrlGeneratorInterface $urlGenerator,
-        private readonly RequestStack $requestStack,
     ) {
     }
 
     #[Route('/alerts/{id}/delete', name: 'app_alerts_delete', methods: ['POST'])]
-    public function __invoke(int $id): RedirectResponse
+    public function __invoke(Request $request, int $id): Response
     {
         $user = $this->controller->getUser();
         if (! $user instanceof User) {
             return new RedirectResponse($this->urlGenerator->generate('app_login'));
         }
 
-        $token = $this->requestStack->getCurrentRequest()?->request->getString('_token');
+        $isHtmx = $request->headers->has('HX-Request');
+
+        $token = $request->headers->get('X-CSRF-Token')
+            ?? $request->request->getString('_token');
         if (! $this->controller->isCsrfTokenValid('delete_alert_rule', $token)) {
+            if ($isHtmx) {
+                return new Response('Invalid CSRF token.', Response::HTTP_FORBIDDEN);
+            }
+
             $this->controller->addFlash('error', 'Invalid CSRF token.');
 
             return new RedirectResponse($this->urlGenerator->generate('app_alerts'));
@@ -40,12 +47,20 @@ final class DeleteAlertRuleController
 
         $rule = $this->alertRuleRepository->findById($id);
         if (! $rule instanceof AlertRule) {
+            if ($isHtmx) {
+                return new Response('Alert rule not found.', Response::HTTP_NOT_FOUND);
+            }
+
             $this->controller->addFlash('error', 'Alert rule not found.');
 
             return new RedirectResponse($this->urlGenerator->generate('app_alerts'));
         }
 
         $this->alertRuleRepository->remove($rule, flush: true);
+
+        if ($isHtmx) {
+            return new Response('');
+        }
 
         $this->controller->addFlash('success', 'Alert rule deleted.');
 

--- a/src/Shared/Controller/SearchController.php
+++ b/src/Shared/Controller/SearchController.php
@@ -7,6 +7,7 @@ namespace App\Shared\Controller;
 use App\Article\Repository\ArticleRepositoryInterface;
 use App\Shared\Search\Service\ArticleSearchServiceInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
 use Symfony\Component\Routing\Attribute\Route;
@@ -22,6 +23,7 @@ final class SearchController
 
     #[Route('/search', name: 'app_search')]
     public function __invoke(
+        Request $request,
         #[MapQueryParameter]
         string $q = '',
         #[MapQueryParameter]
@@ -39,7 +41,11 @@ final class SearchController
             }
         }
 
-        return $this->controller->render('search/index.html.twig', [
+        $template = $request->headers->has('HX-Request')
+            ? 'search/_results.html.twig'
+            : 'search/index.html.twig';
+
+        return $this->controller->render($template, [
             'query' => $query,
             'results' => $results,
         ]);

--- a/src/Source/Controller/DeleteSourceController.php
+++ b/src/Source/Controller/DeleteSourceController.php
@@ -9,7 +9,8 @@ use App\Source\Repository\SourceRepositoryInterface;
 use App\User\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -19,20 +20,26 @@ final class DeleteSourceController
         private readonly ControllerHelper $controller,
         private readonly SourceRepositoryInterface $sourceRepository,
         private readonly UrlGeneratorInterface $urlGenerator,
-        private readonly RequestStack $requestStack,
     ) {
     }
 
     #[Route('/sources/{id}/delete', name: 'app_sources_delete', methods: ['POST'])]
-    public function __invoke(int $id): RedirectResponse
+    public function __invoke(Request $request, int $id): Response
     {
         $user = $this->controller->getUser();
         if (! $user instanceof User) {
             return new RedirectResponse($this->urlGenerator->generate('app_login'));
         }
 
-        $token = $this->requestStack->getCurrentRequest()?->request->getString('_token');
+        $isHtmx = $request->headers->has('HX-Request');
+
+        $token = $request->headers->get('X-CSRF-Token')
+            ?? $request->request->getString('_token');
         if (! $this->controller->isCsrfTokenValid('delete_source', $token)) {
+            if ($isHtmx) {
+                return new Response('Invalid CSRF token.', Response::HTTP_FORBIDDEN);
+            }
+
             $this->controller->addFlash('error', 'Invalid CSRF token.');
 
             return new RedirectResponse($this->urlGenerator->generate('app_sources'));
@@ -40,12 +47,20 @@ final class DeleteSourceController
 
         $source = $this->sourceRepository->findById($id);
         if (! $source instanceof Source) {
+            if ($isHtmx) {
+                return new Response('Source not found.', Response::HTTP_NOT_FOUND);
+            }
+
             $this->controller->addFlash('error', 'Source not found.');
 
             return new RedirectResponse($this->urlGenerator->generate('app_sources'));
         }
 
         $this->sourceRepository->remove($source, flush: true);
+
+        if ($isHtmx) {
+            return new Response('');
+        }
 
         $this->controller->addFlash('success', 'Source deleted.');
 

--- a/src/User/Controller/MarkAllReadController.php
+++ b/src/User/Controller/MarkAllReadController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\User\Controller;
 
+use App\Article\Entity\Article;
 use App\Article\Repository\ArticleRepositoryInterface;
 use App\User\Entity\User;
 use App\User\Entity\UserArticleRead;
@@ -11,7 +12,8 @@ use App\User\Repository\UserArticleReadRepositoryInterface;
 use Psr\Clock\ClockInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -23,24 +25,32 @@ final class MarkAllReadController
         private readonly UserArticleReadRepositoryInterface $userArticleReadRepository,
         private readonly ClockInterface $clock,
         private readonly UrlGeneratorInterface $urlGenerator,
-        private readonly RequestStack $requestStack,
     ) {
     }
 
     #[Route('/articles/read-all', name: 'app_articles_read_all', methods: ['POST'])]
-    public function __invoke(): RedirectResponse
+    public function __invoke(Request $request): Response
     {
         $user = $this->controller->getUser();
         if (! $user instanceof User) {
             return new RedirectResponse($this->urlGenerator->generate('app_login'));
         }
 
-        $token = $this->requestStack->getCurrentRequest()?->request->getString('_token');
+        $token = $request->headers->get('X-CSRF-Token')
+            ?? $request->request->getString('_token');
         if (! $this->controller->isCsrfTokenValid('mark_all_read', $token)) {
+            if ($request->headers->has('HX-Request')) {
+                return new Response('Invalid CSRF token.', Response::HTTP_FORBIDDEN);
+            }
+
             return new RedirectResponse($this->urlGenerator->generate('app_dashboard'));
         }
 
         $this->markUnreadArticles($user);
+
+        if ($request->headers->has('HX-Request')) {
+            return $this->renderArticleFeed($user);
+        }
 
         return new RedirectResponse($this->urlGenerator->generate('app_dashboard'));
     }
@@ -55,5 +65,30 @@ final class MarkAllReadController
         }
 
         $this->userArticleReadRepository->flush();
+    }
+
+    private function renderArticleFeed(User $user): Response
+    {
+        $limit = 20;
+        $articles = $this->articleRepository->findPaginated(null, null, 1, $limit);
+
+        $articleIds = array_map(
+            static fn (Article $a): int => (int) $a->getId(),
+            $articles,
+        );
+
+        $readArticleIds = $this->userArticleReadRepository->findReadArticleIdsForUser(
+            $user,
+            $articleIds,
+        );
+
+        return $this->controller->render('dashboard/_article_list.html.twig', [
+            'articles' => $articles,
+            'readArticleIds' => $readArticleIds,
+            'currentPage' => 1,
+            'currentCategory' => null,
+            'unreadOnly' => false,
+            'hasMore' => \count($articles) >= $limit,
+        ]);
     }
 }

--- a/templates/alert/index.html.twig
+++ b/templates/alert/index.html.twig
@@ -60,10 +60,12 @@
                             </td>
                             <td class="flex gap-1">
                                 <a href="{{ path('app_alerts_edit', {id: rule.id}) }}" class="btn btn-ghost btn-xs">Edit</a>
-                                <form method="POST" action="{{ path('app_alerts_delete', {id: rule.id}) }}" onsubmit="return confirm('Delete this alert rule?')">
-                                    <input type="hidden" name="_token" value="{{ csrf_token('delete_alert_rule') }}">
-                                    <button type="submit" class="btn btn-ghost btn-xs text-error">Delete</button>
-                                </form>
+                                <button hx-post="{{ path('app_alerts_delete', {id: rule.id}) }}"
+                                        hx-headers='{"X-CSRF-Token": "{{ csrf_token('delete_alert_rule') }}"}'
+                                        hx-confirm="Delete this alert rule?"
+                                        hx-target="closest tr"
+                                        hx-swap="outerHTML swap:300ms"
+                                        class="btn btn-ghost btn-xs text-error">Delete</button>
                             </td>
                         </tr>
                     {% endfor %}

--- a/templates/dashboard/_article_list.html.twig
+++ b/templates/dashboard/_article_list.html.twig
@@ -9,3 +9,13 @@
         hasMore: hasMore,
     } %}
 {% endif %}
+
+{# OOB swap: update filter bar when category/unread changes (only on non-pagination requests) #}
+{% if currentPage is defined and currentPage == 1 %}
+    <div id="filter-bar" hx-swap-oob="innerHTML" class="flex items-center gap-3 mb-4">
+        {% include 'dashboard/_filter_bar.html.twig' with {
+            currentCategory: currentCategory|default(null),
+            unreadOnly: unreadOnly|default(false),
+        } %}
+    </div>
+{% endif %}

--- a/templates/dashboard/_filter_bar.html.twig
+++ b/templates/dashboard/_filter_bar.html.twig
@@ -1,0 +1,22 @@
+{% if unreadOnly %}
+    <a hx-get="{{ path('app_dashboard', {category: currentCategory}) }}"
+       hx-target="#article-feed"
+       hx-swap="innerHTML"
+       hx-push-url="true"
+       hx-indicator="#feed-loader"
+       class="btn btn-sm btn-outline btn-active">Unread Only</a>
+{% else %}
+    <a hx-get="{{ path('app_dashboard', {category: currentCategory, unreadOnly: 1}) }}"
+       hx-target="#article-feed"
+       hx-swap="innerHTML"
+       hx-push-url="true"
+       hx-indicator="#feed-loader"
+       class="btn btn-sm btn-outline">Unread Only</a>
+{% endif %}
+<button hx-post="{{ path('app_articles_read_all') }}"
+        hx-target="#article-feed"
+        hx-swap="innerHTML"
+        hx-indicator="#feed-loader"
+        hx-headers='{"X-CSRF-Token": "{{ csrf_token('mark_all_read') }}"}'
+        class="btn btn-sm btn-ghost">Mark All Read</button>
+<input id="article-filter" type="text" placeholder="Filter articles..." class="input input-bordered input-sm flex-1" />

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -21,31 +21,42 @@
     </div>
 
     {# Category tabs #}
-    <div class="tabs tabs-boxed mb-4 overflow-x-auto">
-        <a href="{{ path('app_dashboard') }}" class="tab {{ currentCategory is null ? 'tab-active' : '' }}">All</a>
+    <div id="category-tabs" class="tabs tabs-boxed mb-4 overflow-x-auto">
+        <a hx-get="{{ path('app_dashboard') }}"
+           hx-target="#article-feed"
+           hx-swap="innerHTML"
+           hx-push-url="true"
+           hx-indicator="#feed-loader"
+           class="tab {{ currentCategory is null ? 'tab-active' : '' }}"
+           hx-on:click="this.closest('.tabs').querySelectorAll('.tab').forEach(t => t.classList.remove('tab-active')); this.classList.add('tab-active')">All</a>
         {% for category in categories %}
-            <a href="{{ path('app_dashboard', {category: category.slug}) }}" class="tab {{ currentCategory == category.slug ? 'tab-active' : '' }}">{{ category.name }}</a>
+            <a hx-get="{{ path('app_dashboard', {category: category.slug}) }}"
+               hx-target="#article-feed"
+               hx-swap="innerHTML"
+               hx-push-url="true"
+               hx-indicator="#feed-loader"
+               class="tab {{ currentCategory == category.slug ? 'tab-active' : '' }}"
+               hx-on:click="this.closest('.tabs').querySelectorAll('.tab').forEach(t => t.classList.remove('tab-active')); this.classList.add('tab-active')">{{ category.name }}</a>
         {% endfor %}
     </div>
 
     {# Unread filter + Mark all read #}
-    <div class="flex items-center gap-3 mb-4">
-        {% if unreadOnly %}
-            <a href="{{ path('app_dashboard', {category: currentCategory}) }}" class="btn btn-sm btn-outline">Show All</a>
-        {% else %}
-            <a href="{{ path('app_dashboard', {category: currentCategory, unreadOnly: 1}) }}" class="btn btn-sm btn-outline">Unread Only</a>
-        {% endif %}
-        <form method="POST" action="{{ path('app_articles_read_all') }}">
-            <input type="hidden" name="_token" value="{{ csrf_token('mark_all_read') }}">
-            <button type="submit" class="btn btn-sm btn-ghost">Mark All Read</button>
-        </form>
-        <input id="article-filter" type="text" placeholder="Filter articles..." class="input input-bordered input-sm flex-1" />
+    <div id="filter-bar" class="flex items-center gap-3 mb-4">
+        {% include 'dashboard/_filter_bar.html.twig' with {
+            currentCategory: currentCategory,
+            unreadOnly: unreadOnly,
+        } %}
     </div>
 
     {# New articles banner (shown via Mercure SSE) #}
     <div id="new-articles-banner" class="alert alert-info mb-4 hidden cursor-pointer" role="button">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
         <span id="new-articles-count"></span>
+    </div>
+
+    {# Loading indicator #}
+    <div id="feed-loader" class="htmx-indicator flex justify-center py-4">
+        <span class="loading loading-spinner loading-lg text-primary"></span>
     </div>
 
     {# Article feed #}

--- a/templates/digest/_trigger_confirmation.html.twig
+++ b/templates/digest/_trigger_confirmation.html.twig
@@ -1,0 +1,1 @@
+<span class="badge badge-success badge-sm">Triggered</span>

--- a/templates/digest/index.html.twig
+++ b/templates/digest/index.html.twig
@@ -41,14 +41,17 @@
                             </td>
                             <td class="flex gap-1">
                                 <a href="{{ path('app_digests_edit', {id: config.id}) }}" class="btn btn-ghost btn-xs">Edit</a>
-                                <form method="POST" action="{{ path('app_digests_trigger', {id: config.id}) }}" class="inline">
-                                    <input type="hidden" name="_token" value="{{ csrf_token('trigger_digest') }}">
-                                    <button type="submit" class="btn btn-ghost btn-xs text-info">Run Now</button>
-                                </form>
-                                <form method="POST" action="{{ path('app_digests_delete', {id: config.id}) }}" onsubmit="return confirm('Delete this digest configuration?')" class="inline">
-                                    <input type="hidden" name="_token" value="{{ csrf_token('delete_digest_config') }}">
-                                    <button type="submit" class="btn btn-ghost btn-xs text-error">Delete</button>
-                                </form>
+                                <button hx-post="{{ path('app_digests_trigger', {id: config.id}) }}"
+                                        hx-headers='{"X-CSRF-Token": "{{ csrf_token('trigger_digest') }}"}'
+                                        hx-target="this"
+                                        hx-swap="outerHTML"
+                                        class="btn btn-ghost btn-xs text-info">Run Now</button>
+                                <button hx-post="{{ path('app_digests_delete', {id: config.id}) }}"
+                                        hx-headers='{"X-CSRF-Token": "{{ csrf_token('delete_digest_config') }}"}'
+                                        hx-confirm="Delete this digest configuration?"
+                                        hx-target="closest tr"
+                                        hx-swap="outerHTML swap:300ms"
+                                        class="btn btn-ghost btn-xs text-error">Delete</button>
                             </td>
                         </tr>
                     {% endfor %}

--- a/templates/search/_results.html.twig
+++ b/templates/search/_results.html.twig
@@ -1,0 +1,14 @@
+{% if query %}
+    {% if results is empty %}
+        {% include 'components/_empty_state.html.twig' with {
+            message: 'No results for "' ~ query ~ '"'
+        } %}
+    {% else %}
+        <p class="text-base-content/50 mb-4">{{ results|length }} result(s) for "{{ query }}"</p>
+        <div class="flex flex-col gap-3">
+            {% for article in results %}
+                {% include 'components/_article_card.html.twig' %}
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endif %}

--- a/templates/search/index.html.twig
+++ b/templates/search/index.html.twig
@@ -5,23 +5,27 @@
 
     <form action="{{ path('app_search') }}" method="GET" class="mb-6">
         <div class="join w-full max-w-lg">
-            <input type="text" name="q" value="{{ query }}" placeholder="Search articles..." class="input input-bordered join-item w-full" autofocus>
+            <input type="text"
+                   name="q"
+                   value="{{ query }}"
+                   placeholder="Search articles..."
+                   class="input input-bordered join-item w-full"
+                   hx-get="{{ path('app_search') }}"
+                   hx-trigger="keyup changed delay:500ms, search"
+                   hx-target="#search-results"
+                   hx-swap="innerHTML"
+                   hx-push-url="true"
+                   hx-indicator="#search-loader"
+                   autofocus>
             <button type="submit" class="btn btn-primary join-item">Search</button>
         </div>
     </form>
 
-    {% if query %}
-        {% if results is empty %}
-            {% include 'components/_empty_state.html.twig' with {
-                message: 'No results for "' ~ query ~ '"'
-            } %}
-        {% else %}
-            <p class="text-base-content/50 mb-4">{{ results|length }} result(s) for "{{ query }}"</p>
-            <div class="flex flex-col gap-3">
-                {% for article in results %}
-                    {% include 'components/_article_card.html.twig' %}
-                {% endfor %}
-            </div>
-        {% endif %}
-    {% endif %}
+    <div id="search-loader" class="htmx-indicator flex justify-center py-4">
+        <span class="loading loading-spinner loading-lg text-primary"></span>
+    </div>
+
+    <div id="search-results">
+        {% include 'search/_results.html.twig' %}
+    </div>
 {% endblock %}

--- a/templates/source/index.html.twig
+++ b/templates/source/index.html.twig
@@ -60,10 +60,12 @@
                             </td>
                             <td class="flex gap-1">
                                 <a href="{{ path('app_sources_edit', {id: source.id}) }}" class="btn btn-ghost btn-xs">Edit</a>
-                                <form method="POST" action="{{ path('app_sources_delete', {id: source.id}) }}" onsubmit="return confirm('Delete this source?')">
-                                    <input type="hidden" name="_token" value="{{ csrf_token('delete_source') }}">
-                                    <button type="submit" class="btn btn-ghost btn-xs text-error">Delete</button>
-                                </form>
+                                <button hx-post="{{ path('app_sources_delete', {id: source.id}) }}"
+                                        hx-headers='{"X-CSRF-Token": "{{ csrf_token('delete_source') }}"}'
+                                        hx-confirm="Delete this source?"
+                                        hx-target="closest tr"
+                                        hx-swap="outerHTML swap:300ms"
+                                        class="btn btn-ghost btn-xs text-error">Delete</button>
                             </td>
                         </tr>
                     {% endfor %}

--- a/tests/Functional/Digest/DeleteDigestConfigControllerTest.php
+++ b/tests/Functional/Digest/DeleteDigestConfigControllerTest.php
@@ -26,12 +26,16 @@ final class DeleteDigestConfigControllerTest extends WebTestCase
 
         $configId = $this->createConfigAndReturnId($user, 'To Delete', '0 8 * * *');
 
-        // GET to start session, then extract CSRF from rendered form
+        // GET index to extract CSRF token from htmx delete button
         $crawler = $client->request('GET', '/digests');
-        $deleteUrl = '/digests/' . $configId . '/delete';
-        $form = $crawler->filter('form[action="' . $deleteUrl . '"]')->first()->form();
+        $deleteBtn = $crawler->filter('button[hx-post$="/' . $configId . '/delete"]')->first();
+        /** @var array<string, string> $headers */
+        $headers = json_decode($deleteBtn->attr('hx-headers') ?? '{}', true, 512, JSON_THROW_ON_ERROR);
+        $token = $headers['X-CSRF-Token'];
 
-        $client->submit($form);
+        $client->request('POST', '/digests/' . $configId . '/delete', [
+            '_token' => $token,
+        ]);
 
         self::assertResponseRedirects('/digests');
 

--- a/tests/Functional/Digest/TriggerDigestControllerTest.php
+++ b/tests/Functional/Digest/TriggerDigestControllerTest.php
@@ -23,13 +23,18 @@ final class TriggerDigestControllerTest extends WebTestCase
         $user = $this->getOrCreateUser();
         $client->loginUser($user);
 
-        $this->createConfigAndReturnId($user, 'Trigger Test', '0 8 * * *');
+        $configId = $this->createConfigAndReturnId($user, 'Trigger Test', '0 8 * * *');
 
-        // GET index to start session and get the form with CSRF token
+        // GET index to extract CSRF token from htmx button
         $crawler = $client->request('GET', '/digests');
-        $form = $crawler->filter('form[action$="/trigger"]')->first()->form();
+        $triggerBtn = $crawler->filter('button[hx-post$="/trigger"]')->first();
+        /** @var array<string, string> $headers */
+        $headers = json_decode($triggerBtn->attr('hx-headers') ?? '{}', true, 512, JSON_THROW_ON_ERROR);
+        $token = $headers['X-CSRF-Token'];
 
-        $client->submit($form);
+        $client->request('POST', '/digests/' . $configId . '/trigger', [
+            '_token' => $token,
+        ]);
 
         self::assertResponseRedirects('/digests');
     }


### PR DESCRIPTION
## Summary

- **#122** — Systematic htmx adoption across dashboard and CRUD pages based on `docs/research/htmx-opportunities.md`

### Dashboard (no page reloads)
- Category tabs use `hx-get` + `hx-push-url` for instant filtering
- Unread Only toggle uses `hx-get` for instant filtering
- Mark All Read uses `hx-post` to update feed in-place
- Loading indicator during htmx requests

### CRUD pages (inline actions)
- Delete buttons on Sources, Alert Rules, and Digests use `hx-post` + `hx-confirm` + row fade-out removal
- Digest "Run Now" returns inline "Triggered" confirmation badge

### Search
- Live search with `hx-trigger="keyup changed delay:500ms"` — results update as you type
- SearchController returns `_results.html.twig` partial for htmx requests

### Decision: kept mercure-updates.ts
htmx SSE would require injecting Twig into MercurePublisherService (violates service/presentation boundary) and would lose client-side state like language selection. The existing TypeScript handles enrichment updates with fine-grained DOM manipulation that OOB swaps cannot replicate without full card re-rendering.

## Changes

- 6 controllers updated (HX-Request detection, CSRF via header, partial responses)
- 7 templates modified, 3 new partials created
- CSS transitions for htmx-swapping and htmx-indicator
- 2 functional tests updated for htmx button patterns

## Test plan

- [x] `make quality` passes (ECS + PHPStan max + Rector)
- [x] `make test-unit` passes (586 tests)
- [ ] Verify category tabs switch without page reload
- [ ] Verify delete removes row with animation
- [ ] Verify live search updates as you type
- [ ] Verify Mark All Read updates feed in-place

🤖 Generated with [Claude Code](https://claude.com/claude-code)