### PR TITLE
chore: implement token optimization recommendations (#123)

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -83,6 +83,22 @@ For features requiring implementation + review:
 4. Handle REVIEW-FEEDBACK.md: CONDITIONS → route back to developer, REJECTED → rethink
 5. On APPROVED: commit, push, update BUILD-LOG.md and SESSION-CHECKPOINT.md
 
+### Brief Template (target: 60-80 lines)
+
+Keep briefs concise. The senior dev reads code — don't describe what they can see. Focus on:
+
+```
+# Architect Brief
+## Feature — {title} ({issues})
+### Branch: `feat/{branch-name}`
+### What Needs to Change (entity, repo, controller, template — table format)
+### Key Decisions (numbered, with rationale — only non-obvious ones)
+### Build Order (numbered steps)
+### Flags (gotchas, constraints, things that break if done wrong)
+```
+
+**Avoid**: restating the issue body, listing acceptance criteria verbatim, describing existing code at length. The brief tells the dev WHAT to build and WHY the non-obvious choices were made.
+
 ## Collaboration
 
 - **senior-developer** — hand off via ARCHITECT-BRIEF.md, receive via REVIEW-REQUEST.md

--- a/.claude/agents/senior-developer.md
+++ b/.claude/agents/senior-developer.md
@@ -55,10 +55,19 @@ Build exactly what was specified. When you find unrelated issues, log them in `d
 Before considering work complete, ask yourself:
 1. Would the QA Specialist flag anything in this diff?
 2. Does `make quality` pass? (ECS + PHPStan max + Rector)
-3. Do `make test` pass?
-4. Did I update tests for changed behavior?
-5. Did I update CLAUDE.md / docs if the change affects conventions?
-6. **Mutation testing**: will my tests kill mutants? (see checklist below)
+3. Does `make test-unit` pass? (use this during development — fast, saves tokens)
+4. Does `make test` pass? (run ONCE before final commit — includes integration/functional)
+5. Does `make infection` pass? (run before submitting — catches MSI failures early, saves a CI round)
+6. Did I update tests for changed behavior?
+7. Did I update CLAUDE.md / docs if the change affects conventions?
+8. **Mutation testing**: will my tests kill mutants? (see checklist below)
+
+### Token Efficiency Rules
+
+- Use `make test-unit` during iteration, not `make test` — unit tests are 10x faster with 10x less output
+- Run `make test` only once before the final commit
+- Run `make infection` before submitting — a CI mutation failure costs ~20K tokens to fix
+- Don't read files for style reference — conventions are in `.claude/testing.md` and `.claude/coding-php.md`
 
 ### Mutation Testing Checklist (check before submitting)
 
@@ -91,10 +100,12 @@ make sf c="make:domain-exception"    # Exception with named constructor
 make sf c="make:enum"                # String-backed enum
 make sf c="make:dto"                 # Readonly DTO
 
-# Quality
+# Quality (token-efficient order)
 make ecs-fix               # Fix coding standards
 make quality               # ECS + PHPStan + Rector (must pass)
-make test                  # All tests must pass
+make test-unit             # Unit tests — use during development (fast, small output)
+make test                  # All tests — run ONCE before final commit only
+make infection             # Mutation testing — run before submitting to catch MSI failures early
 ```
 
 ## Hard Rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,9 @@ Grep before Read. Never read a whole file to find one thing.
 ## Workflow Expectations
 
 - Run `make quality` after every code change — do not consider a task complete until it passes
-- Run `make test` before committing — all tests must pass
+- Run `make test-unit` during development — fast feedback, low token cost
+- Run `make test` once before final commit — includes integration/functional tests
+- Run `make infection` before submitting PR — catches mutation MSI failures early (saves ~20K tokens per CI fix round)
 - One issue per branch — do not bundle unrelated changes
 - Scope lock: when you find unrelated issues during work, log them in `docs/todo/` or create a GitHub issue — do not fix inline
 - Use `make sf c="make:entity"` to scaffold entities — never write entity + repository files manually


### PR DESCRIPTION
## Summary

Implements the top optimization recommendations from the token usage analysis (#123).

### Changes

**Senior Developer agent** (`.claude/agents/senior-developer.md`):
- `make test-unit` during development (10x faster, 10x less output than `make test`)
- `make test` only once before final commit
- `make infection` before submitting — catches MSI failures early, saves ~20K tokens per CI fix round
- Token Efficiency Rules section in self-review gate

**Architect agent** (`.claude/agents/architect.md`):
- Brief template targeting 60-80 lines (down from ~120 average)
- Focus on decisions and build order, skip restating issue body

**CLAUDE.md**:
- Updated workflow expectations with token-efficient test strategy

### Expected savings per session
- ~200K tokens from test strategy (unit-only during dev)
- ~20K/PR from pre-submission mutation testing
- ~5K/feature from shorter architect briefs

🤖 Generated with [Claude Code](https://claude.com/claude-code)