### PR TITLE
docs: require screenshots for UI features in PRs and docs

### DIFF
--- a/.claude/agents/qa-specialist.md
+++ b/.claude/agents/qa-specialist.md
@@ -50,8 +50,9 @@ You are the quiet one in the room. When you speak, it is worth hearing. You do n
 1. Start from `git diff main...HEAD` — the diff is your primary source of truth
 2. Read the PR description second — verify claims against actual changes
 3. Check: spec compliance, scope drift, security, logic correctness, standards, test coverage
-4. **Browser verification**: If the change affects UI or user-visible behavior (enrichment output, page rendering, navigation, stats display), use `BROWSE_PASSWORD=demo bun run bin/browse.ts <path>` to verify the running app. This is NOT optional for UI/content changes.
-5. For each finding, state: what is wrong, where (file:line), and what the fix should be
+4. **Browser verification**: If the change affects UI or user-visible behavior, use Playwright MCP tools (`browser_navigate`, `browser_snapshot`, `browser_take_screenshot`) to verify. Login: `demo@localhost` / `demo`. This is NOT optional for UI/content changes.
+5. **Screenshot check**: If the PR changes UI, verify that screenshots exist in `docs/screenshots/` and are referenced in the PR description. If missing, flag as a condition.
+6. For each finding, state: what is wrong, where (file:line), and what the fix should be
 6. Verdict is one of:
    - **APPROVED** — ship it
    - **APPROVED WITH CONDITIONS** — specific fixes required, then re-review

--- a/.claude/agents/senior-developer.md
+++ b/.claude/agents/senior-developer.md
@@ -60,7 +60,8 @@ Before considering work complete, ask yourself:
 5. Does `make infection` pass? (run before submitting — catches MSI failures early, saves a CI round)
 6. Did I update tests for changed behavior?
 7. Did I update CLAUDE.md / docs if the change affects conventions?
-8. **Mutation testing**: will my tests kill mutants? (see checklist below)
+8. **Screenshots**: if this changes UI, capture with Playwright MCP and save to `docs/screenshots/`
+9. **Mutation testing**: will my tests kill mutants? (see checklist below)
 
 ### Token Efficiency Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,7 @@ Grep before Read. Never read a whole file to find one thing.
 - Scope lock: when you find unrelated issues during work, log them in `docs/todo/` or create a GitHub issue — do not fix inline
 - Use `make sf c="make:entity"` to scaffold entities — never write entity + repository files manually
 - Always spawn implementation agents in foreground, never background (they need tool approval)
+- **Screenshots required for UI features**: use Playwright MCP (`browser_navigate` + `browser_take_screenshot`) to capture screenshots of new/changed UI. Save to `docs/screenshots/` and embed in PR description. Login: `demo@localhost` / `demo`
 
 ## Hard Rules
 


### PR DESCRIPTION
## Summary

Adds screenshot requirement to all three touchpoints in the agent workflow:

1. **CLAUDE.md** — Workflow Expectations: screenshot rule with Playwright MCP instructions
2. **senior-developer.md** — Self-review gate step #8: capture screenshots for UI changes
3. **qa-specialist.md** — Review protocol step #5: verify screenshots exist in `docs/screenshots/` and PR description

Screenshots use Playwright MCP tools (`browser_navigate` + `browser_take_screenshot`). Login: `demo@localhost` / `demo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)