### PR TITLE
fix: backfill translations for legacy articles (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Translation Backfill
+- `app:backfill-translations` command — dispatches re-enrichment for legacy articles missing translations (#146)
+
 #### Bookmarks
 - Article bookmark / save for later — toggle bookmark via htmx button on article cards, filter dashboard to show bookmarked articles only, persisted per-user with unique constraint (#134)
 

--- a/src/Article/Command/BackfillTranslationsCommand.php
+++ b/src/Article/Command/BackfillTranslationsCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Article\Command;
+
+use App\Article\Message\EnrichArticleMessage;
+use App\Article\Repository\ArticleRepositoryInterface;
+use App\Article\ValueObject\EnrichmentStatus;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsCommand(
+    name: 'app:backfill-translations',
+    description: 'Dispatch enrichment for articles missing translations',
+)]
+final class BackfillTranslationsCommand extends Command
+{
+    public function __construct(
+        private readonly ArticleRepositoryInterface $articleRepository,
+        private readonly MessageBusInterface $messageBus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('limit', 'l', InputOption::VALUE_REQUIRED, 'Max articles to dispatch', '50');
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show count without dispatching');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        /** @var string $limitStr */
+        $limitStr = $input->getOption('limit');
+        $limit = (int) $limitStr;
+        $dryRun = $input->getOption('dry-run') === true;
+
+        $articles = $this->articleRepository->findWithoutTranslations($limit);
+
+        if ($articles === []) {
+            $io->success('All articles have translations.');
+
+            return Command::SUCCESS;
+        }
+
+        $io->info(sprintf('Found %d articles without translations (limit: %d).', count($articles), $limit));
+
+        if ($dryRun) {
+            $io->note('Dry run — no messages dispatched.');
+
+            return Command::SUCCESS;
+        }
+
+        // Set enrichmentStatus to Pending so EnrichArticleHandler will process them
+        // (handler skips articles with null status as "legacy complete")
+        foreach ($articles as $article) {
+            $article->setEnrichmentStatus(EnrichmentStatus::Pending);
+        }
+        $this->articleRepository->flush();
+
+        $dispatched = 0;
+        foreach ($articles as $article) {
+            $id = $article->getId();
+            if ($id === null) {
+                continue;
+            }
+
+            $this->messageBus->dispatch(new EnrichArticleMessage($id));
+            ++$dispatched;
+        }
+
+        $io->success(sprintf('Dispatched %d enrichment messages to async_enrich queue.', $dispatched));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Article/Repository/ArticleRepository.php
+++ b/src/Article/Repository/ArticleRepository.php
@@ -195,6 +195,19 @@ final class ArticleRepository extends ServiceEntityRepository implements Article
             ->getResult();
     }
 
+    public function findWithoutTranslations(int $limit): array
+    {
+        /** @var list<Article> */
+        return $this->createQueryBuilder('a')
+            ->where('a.translations IS NULL')
+            ->andWhere('a.enrichmentMethod = :method')
+            ->setParameter('method', 'ai')
+            ->orderBy('a.id', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
     public function save(Article $article, bool $flush = false): void
     {
         $this->getEntityManager()->persist($article);

--- a/src/Article/Repository/ArticleRepositoryInterface.php
+++ b/src/Article/Repository/ArticleRepositoryInterface.php
@@ -51,6 +51,11 @@ interface ArticleRepositoryInterface
      */
     public function findUnreadForUser(User $user): array;
 
+    /**
+     * @return list<Article>
+     */
+    public function findWithoutTranslations(int $limit): array;
+
     public function save(Article $article, bool $flush = false): void;
 
     public function flush(): void;


### PR DESCRIPTION
## Summary

Legacy articles (pre-async enrichment) show German titles with English summaries — no translations JSON exists. New `app:backfill-translations` command dispatches re-enrichment for these articles.

## Root Cause

661 AI-enriched articles were created before the translation system was added. They have:
- Title: original source language (DE)
- Summary: AI-generated in EN
- Translations: NULL

The language selector has nothing to swap, creating a DE/EN mix.

## Fix

`app:backfill-translations` command:
- Finds articles with `translations IS NULL AND enrichment_method = 'ai'`
- Sets `enrichmentStatus = Pending` (so EnrichArticleHandler processes them)
- Dispatches `EnrichArticleMessage` to async_enrich queue
- Supports `--limit` (default 50) and `--dry-run`

Usage: `make sf c="app:backfill-translations --limit=100"`

## Test plan

- [x] `make quality` passes
- [ ] Run `app:backfill-translations --dry-run` to verify count
- [ ] Run `app:backfill-translations --limit=10` and verify articles get translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)