### PR TITLE
fix: add Playwright MCP tools to senior developer agent

### DIFF
--- a/.claude/agents/senior-developer.md
+++ b/.claude/agents/senior-developer.md
@@ -18,6 +18,13 @@ tools:
   - mcp__code-review-graph__build_or_update_graph_tool
   - mcp__plugin_context7_context7__resolve-library-id
   - mcp__plugin_context7_context7__query-docs
+  - mcp__playwright__browser_navigate
+  - mcp__playwright__browser_snapshot
+  - mcp__playwright__browser_take_screenshot
+  - mcp__playwright__browser_click
+  - mcp__playwright__browser_fill_form
+  - mcp__playwright__browser_type
+  - mcp__playwright__browser_wait_for
 ---
 
 # Senior Developer — Implementation Specialist


### PR DESCRIPTION
## Problem

The senior developer agent had instructions to take screenshots via Playwright MCP but lacked the tools in its tool list. Every screenshot delegation failed silently — the agent fell back to raw Chrome CLI, producing broken images with transparent areas. This caused 3+ retake fix commits this session (~50K tokens wasted).

## Fix

Added 7 Playwright MCP tools to senior-developer.md:
- browser_navigate, browser_snapshot, browser_take_screenshot
- browser_click, browser_fill_form, browser_type, browser_wait_for

## Deep Analysis

Full token usage analysis at `docs/research/token-usage-deep-analysis.md`. Key findings:
- Screenshots: ~50K tokens wasted on retakes (this fix)
- Mutation test fix rounds: ~50K tokens (guidance in testing.md helps)
- CSRF test fragility: ~25K tokens (DOM extraction pattern — separate fix)
- Duplicate quality runs: ~10K/PR (acceptable trade-off for local confidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)