### PR TITLE
feat: add /health endpoint for container orchestration (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Health Check Endpoint
+- GET `/health` endpoint for container orchestration — returns 200 `{"status":"ok"}` when database is reachable, 503 with error message otherwise (#153)
+- No authentication required — added to public access firewall
+
 #### Dynamic Paid Model Usage During High Pipeline Load
 - Queue-aware model routing in `ModelFailoverPlatform` — automatically skips free models when enrichment queue is deep (#157)
 - Three routing modes: normal (queue < 20), accelerated (queue 20-49: primary free then paid), skip-free (queue >= 50: paid only)

--- a/compose.yaml
+++ b/compose.yaml
@@ -28,6 +28,12 @@ services:
         target: 443
         published: ${HTTP3_PORT:-8443}
         protocol: udp
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       database:
         condition: service_healthy

--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -41,6 +41,10 @@ return static function (ContainerConfigurator $container): void {
         // Note: Only the *first* matching rule is applied
         'access_control' => [
             [
+                'path' => '^/health$',
+                'roles' => 'PUBLIC_ACCESS',
+            ],
+            [
                 'path' => '^/login',
                 'roles' => 'PUBLIC_ACCESS',
             ],

--- a/src/Shared/Controller/HealthController.php
+++ b/src/Shared/Controller/HealthController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Controller;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class HealthController
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    #[Route('/health', name: 'app_health', methods: ['GET'])]
+    public function __invoke(): JsonResponse
+    {
+        try {
+            $this->connection->executeQuery('SELECT 1');
+
+            return new JsonResponse([
+                'status' => 'ok',
+            ]);
+        } catch (\Throwable $exception) {
+            return new JsonResponse(
+                [
+                    'status' => 'error',
+                    'message' => $exception->getMessage(),
+                ],
+                Response::HTTP_SERVICE_UNAVAILABLE,
+            );
+        }
+    }
+}

--- a/tests/Unit/Shared/Controller/HealthControllerTest.php
+++ b/tests/Unit/Shared/Controller/HealthControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Controller;
+
+use App\Shared\Controller\HealthController;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversNothing]
+final class HealthControllerTest extends TestCase
+{
+    private Connection&MockObject $connection;
+
+    private HealthController $controller;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->controller = new HealthController($this->connection);
+    }
+
+    public function testReturnsOkWhenDatabaseIsReachable(): void
+    {
+        $this->connection
+            ->expects(self::once())
+            ->method('executeQuery')
+            ->with('SELECT 1');
+
+        $response = ($this->controller)();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame('{"status":"ok"}', $response->getContent());
+    }
+
+    public function testReturns503WhenDatabaseIsUnreachable(): void
+    {
+        $this->connection
+            ->expects(self::once())
+            ->method('executeQuery')
+            ->willThrowException(new \RuntimeException('Connection refused'));
+
+        $response = ($this->controller)();
+
+        self::assertSame(Response::HTTP_SERVICE_UNAVAILABLE, $response->getStatusCode());
+
+        /** @var array{status: string, message: string} $data */
+        $data = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertSame('error', $data['status']);
+        self::assertSame('Connection refused', $data['message']);
+    }
+}


### PR DESCRIPTION
## Summary

GET `/health` endpoint for Docker/K8s health probes. No authentication required.

- 200 `{"status":"ok"}` when DB reachable
- 503 `{"status":"error","message":"..."}` when DB unreachable  
- Security firewall: `PUBLIC_ACCESS` for `/health`
- Docker healthcheck added to php service

## Test plan
- [x] `make quality` passes
- [x] `make test-unit` passes (749 tests)
- [x] `make infection` passes (pre-push hook verified)
- [ ] CI green
- [ ] QA browser: curl /health returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)