### PR TITLE
fix: add CSRF protection to OPML import POST

### DIFF
--- a/src/Source/Controller/ImportOpmlController.php
+++ b/src/Source/Controller/ImportOpmlController.php
@@ -28,6 +28,13 @@ final class ImportOpmlController
     #[Route('/sources/import', name: 'app_sources_import_opml_post', methods: ['POST'])]
     public function handleImport(Request $request): Response
     {
+        $token = $request->request->getString('_token');
+        if (! $this->controller->isCsrfTokenValid('import_opml', $token)) {
+            return $this->controller->render('source/import.html.twig', [
+                'error' => 'Invalid CSRF token. Please try again.',
+            ]);
+        }
+
         $file = $request->files->get('opml_file');
 
         if (! $file instanceof UploadedFile || ! $file->isValid()) {

--- a/templates/source/import.html.twig
+++ b/templates/source/import.html.twig
@@ -26,6 +26,7 @@
                       hx-target="#import-result"
                       hx-swap="innerHTML"
                       hx-encoding="multipart/form-data">
+                    <input type="hidden" name="_token" value="{{ csrf_token('import_opml') }}">
                     <div class="form-control mb-4">
                         <label class="label" for="opml_file">
                             <span class="label-text">OPML File</span>


### PR DESCRIPTION
QA condition from #162: OPML import POST had no CSRF validation. Added token validation + hidden input to form template.