### PR TITLE
feat: tool-calling model discovery for chat agent pool

### DIFF
--- a/src/Shared/AI/Command/AiModelStatsCommand.php
+++ b/src/Shared/AI/Command/AiModelStatsCommand.php
@@ -60,6 +60,15 @@ final class AiModelStatsCommand extends Command
             $io->listing(array_map(static fn (ModelId $model): string => (string) $model, $freeModels->toArray()));
         }
 
+        // Show available tool-calling models
+        $toolModels = $this->modelDiscovery->discoverToolCallingModels();
+        if ($toolModels->isEmpty()) {
+            $io->warning('No tool-calling models discovered (circuit breaker may be open).');
+        } else {
+            $io->section(sprintf('Available tool-calling models (%d)', $toolModels->count()));
+            $io->listing(array_map(static fn (ModelId $model): string => (string) $model, $toolModels->toArray()));
+        }
+
         return Command::SUCCESS;
     }
 }

--- a/src/Shared/AI/Service/ModelDiscoveryService.php
+++ b/src/Shared/AI/Service/ModelDiscoveryService.php
@@ -14,11 +14,15 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
 {
-    private const string CACHE_KEY = 'openrouter_free_models';
+    private const string CACHE_KEY_FREE = 'openrouter_free_models';
+
+    private const string CACHE_KEY_TOOL_CALLING = 'openrouter_tool_calling_models';
 
     private const int CACHE_TTL = 3600;
 
-    private const string BREAKER_KEY = 'openrouter_cb';
+    private const string BREAKER_KEY_FREE = 'openrouter_cb';
+
+    private const string BREAKER_KEY_TOOL_CALLING = 'openrouter_tool_calling_cb';
 
     private const int BREAKER_THRESHOLD = 3;
 
@@ -37,17 +41,46 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
 
     public function discoverFreeModels(): ModelIdCollection
     {
-        $state = $this->getState();
+        return $this->discoverModels(
+            self::CACHE_KEY_FREE,
+            self::BREAKER_KEY_FREE,
+            'free',
+            $this->fetchFreeModels(...),
+        );
+    }
+
+    public function discoverToolCallingModels(): ModelIdCollection
+    {
+        return $this->discoverModels(
+            self::CACHE_KEY_TOOL_CALLING,
+            self::BREAKER_KEY_TOOL_CALLING,
+            'tool-calling',
+            $this->fetchToolCallingModels(...),
+        );
+    }
+
+    /**
+     * @param \Closure(): ModelIdCollection $fetchFn
+     */
+    private function discoverModels(
+        string $cacheKey,
+        string $breakerKey,
+        string $poolName,
+        \Closure $fetchFn,
+    ): ModelIdCollection {
+        $state = $this->getState($breakerKey);
 
         if ($state === CircuitBreakerState::Open) {
-            $this->logger->debug('Circuit breaker open, using cached model list');
+            $this->logger->debug('Circuit breaker open for {pool} pool, using cached model list', [
+                'pool' => $poolName,
+            ]);
 
-            return $this->getCachedModels();
+            return $this->getCachedModels($cacheKey);
         }
 
         // Closed state: check model cache first
         if ($state === CircuitBreakerState::Closed) {
-            $cacheItem = $this->cache->getItem(self::CACHE_KEY);
+            $cacheItem = $this->cache->getItem($cacheKey);
             if ($cacheItem->isHit()) {
                 /** @var list<string> $cached */
                 $cached = $cacheItem->get();
@@ -58,33 +91,54 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
 
         // Closed (cache miss) or HalfOpen: probe the API
         if ($state === CircuitBreakerState::HalfOpen) {
-            $this->logger->debug('Circuit breaker half-open, attempting probe request');
+            $this->logger->debug('Circuit breaker half-open for {pool} pool, attempting probe request', [
+                'pool' => $poolName,
+            ]);
         }
 
-        return $this->fetchWithCircuitBreaker($state);
+        return $this->fetchWithCircuitBreaker(
+            $cacheKey,
+            $breakerKey,
+            $poolName,
+            $state,
+            $fetchFn,
+        );
     }
 
-    private function fetchWithCircuitBreaker(CircuitBreakerState $state): ModelIdCollection
-    {
+    /**
+     * @param \Closure(): ModelIdCollection $fetchFn
+     */
+    private function fetchWithCircuitBreaker(
+        string $cacheKey,
+        string $breakerKey,
+        string $poolName,
+        CircuitBreakerState $state,
+        \Closure $fetchFn,
+    ): ModelIdCollection {
         try {
-            $models = $this->fetchFreeModels();
+            $models = $fetchFn();
 
-            $this->resetBreaker();
-            $this->cacheModels($models);
+            $this->resetBreaker($breakerKey);
+            $this->cacheModels($models, $cacheKey);
 
-            $this->logger->info('Discovered {count} free OpenRouter models', [
+            $this->logger->info('Discovered {count} {pool} OpenRouter models', [
                 'count' => $models->count(),
+                'pool' => $poolName,
             ]);
 
             return $models;
         } catch (\Throwable $e) {
-            return $this->handleFailure($e, $state);
+            return $this->handleFailure($e, $state, $cacheKey, $breakerKey);
         }
     }
 
-    private function handleFailure(\Throwable $e, CircuitBreakerState $state): ModelIdCollection
-    {
-        $failures = $this->incrementFailures();
+    private function handleFailure(
+        \Throwable $e,
+        CircuitBreakerState $state,
+        string $cacheKey,
+        string $breakerKey,
+    ): ModelIdCollection {
+        $failures = $this->incrementFailures($breakerKey);
 
         $this->logger->warning('Model discovery failed ({count}/{threshold}): {error}', [
             'count' => $failures,
@@ -94,18 +148,18 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
 
         // HalfOpen probe failed or threshold reached: open the breaker
         if ($state === CircuitBreakerState::HalfOpen || $failures >= self::BREAKER_THRESHOLD) {
-            $this->openBreaker();
+            $this->openBreaker($breakerKey);
         }
 
-        return $this->getCachedModels();
+        return $this->getCachedModels($cacheKey);
     }
 
     /**
      * @return array{state: string, failures: int, opened_at: ?int}
      */
-    private function getBreakerData(): array
+    private function getBreakerData(string $breakerKey): array
     {
-        $item = $this->cache->getItem(self::BREAKER_KEY);
+        $item = $this->cache->getItem($breakerKey);
         if (! $item->isHit()) {
             return [
                 'state' => CircuitBreakerState::Closed->value,
@@ -120,21 +174,21 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
         return $data;
     }
 
-    private function getState(): CircuitBreakerState
+    private function getState(string $breakerKey): CircuitBreakerState
     {
-        $data = $this->getBreakerData();
+        $data = $this->getBreakerData($breakerKey);
         $state = CircuitBreakerState::tryFrom($data['state']) ?? CircuitBreakerState::Closed;
 
         if ($state !== CircuitBreakerState::Open) {
             return $state;
         }
 
-        // Check if Open state has expired → transition to HalfOpen
+        // Check if Open state has expired -> transition to HalfOpen
         $openedAt = $data['opened_at'];
         if ($openedAt !== null) {
             $elapsed = $this->clock->now()->getTimestamp() - $openedAt;
             if ($elapsed >= self::BREAKER_RESET_SECONDS) {
-                $this->saveBreakerData(CircuitBreakerState::HalfOpen, $data['failures'], $openedAt);
+                $this->saveBreakerData($breakerKey, CircuitBreakerState::HalfOpen, $data['failures'], $openedAt);
 
                 return CircuitBreakerState::HalfOpen;
             }
@@ -143,19 +197,20 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
         return CircuitBreakerState::Open;
     }
 
-    private function incrementFailures(): int
+    private function incrementFailures(string $breakerKey): int
     {
-        $data = $this->getBreakerData();
+        $data = $this->getBreakerData($breakerKey);
         $failures = $data['failures'] + 1;
         $state = CircuitBreakerState::tryFrom($data['state']) ?? CircuitBreakerState::Closed;
-        $this->saveBreakerData($state, $failures, $data['opened_at']);
+        $this->saveBreakerData($breakerKey, $state, $failures, $data['opened_at']);
 
         return $failures;
     }
 
-    private function openBreaker(): void
+    private function openBreaker(string $breakerKey): void
     {
         $this->saveBreakerData(
+            $breakerKey,
             CircuitBreakerState::Open,
             self::BREAKER_THRESHOLD,
             $this->clock->now()->getTimestamp(),
@@ -166,14 +221,18 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
         ]);
     }
 
-    private function resetBreaker(): void
+    private function resetBreaker(string $breakerKey): void
     {
-        $this->cache->deleteItem(self::BREAKER_KEY);
+        $this->cache->deleteItem($breakerKey);
     }
 
-    private function saveBreakerData(CircuitBreakerState $state, int $failures, ?int $openedAt): void
-    {
-        $item = $this->cache->getItem(self::BREAKER_KEY);
+    private function saveBreakerData(
+        string $breakerKey,
+        CircuitBreakerState $state,
+        int $failures,
+        ?int $openedAt,
+    ): void {
+        $item = $this->cache->getItem($breakerKey);
         $item->set([
             'state' => $state->value,
             'failures' => $failures,
@@ -184,16 +243,19 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
         $this->cache->save($item);
     }
 
-    private function cacheModels(ModelIdCollection $models): void
+    private function cacheModels(ModelIdCollection $models, string $cacheKey): void
     {
         $rawIds = array_map(static fn (ModelId $m): string => $m->value, $models->toArray());
-        $cacheItem = $this->cache->getItem(self::CACHE_KEY);
+        $cacheItem = $this->cache->getItem($cacheKey);
         $cacheItem->set($rawIds);
         $cacheItem->expiresAfter(self::CACHE_TTL);
         $this->cache->save($cacheItem);
     }
 
-    private function fetchFreeModels(): ModelIdCollection
+    /**
+     * @return array{models: list<array{id: string, context_length: int, pricing: array{prompt: string, completion: string}, supported_parameters?: list<string>}>, blockedList: list<string>}
+     */
+    private function fetchModelData(): array
     {
         $response = $this->httpClient->request('GET', 'https://openrouter.ai/api/v1/models');
         $data = $response->toArray();
@@ -202,14 +264,22 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
             ? array_map('trim', explode(',', $this->blockedModels))
             : [];
 
-        $freeModels = [];
-        /** @var list<array{id: string, context_length: int, pricing: array{prompt: string, completion: string}}> $models */
+        /** @var list<array{id: string, context_length: int, pricing: array{prompt: string, completion: string}, supported_parameters?: list<string>}> $models */
         $models = $data['data'] ?? [];
-        foreach ($models as $model) {
-            $isFree = $model['pricing']['prompt'] === '0'
-                && $model['pricing']['completion'] === '0';
 
-            if (! $isFree) {
+        return [
+            'models' => $models,
+            'blockedList' => $blockedList,
+        ];
+    }
+
+    private function fetchFreeModels(): ModelIdCollection
+    {
+        ['models' => $models, 'blockedList' => $blockedList] = $this->fetchModelData();
+
+        $freeModels = [];
+        foreach ($models as $model) {
+            if (! $this->isFreeModel($model)) {
                 continue;
             }
 
@@ -227,9 +297,47 @@ final class ModelDiscoveryService implements ModelDiscoveryServiceInterface
         return new ModelIdCollection($freeModels);
     }
 
-    private function getCachedModels(): ModelIdCollection
+    private function fetchToolCallingModels(): ModelIdCollection
     {
-        $item = $this->cache->getItem(self::CACHE_KEY);
+        ['models' => $models, 'blockedList' => $blockedList] = $this->fetchModelData();
+
+        $toolModels = [];
+        foreach ($models as $model) {
+            if (! $this->isFreeModel($model)) {
+                continue;
+            }
+
+            if ($model['context_length'] < self::MIN_CONTEXT_LENGTH) {
+                continue;
+            }
+
+            if (in_array($model['id'], $blockedList, true)) {
+                continue;
+            }
+
+            $supportedParams = $model['supported_parameters'] ?? [];
+            if (! in_array('tools', $supportedParams, true)) {
+                continue;
+            }
+
+            $toolModels[] = new ModelId($model['id']);
+        }
+
+        return new ModelIdCollection($toolModels);
+    }
+
+    /**
+     * @param array{pricing: array{prompt: string, completion: string}} $model
+     */
+    private function isFreeModel(array $model): bool
+    {
+        return $model['pricing']['prompt'] === '0'
+            && $model['pricing']['completion'] === '0';
+    }
+
+    private function getCachedModels(string $cacheKey): ModelIdCollection
+    {
+        $item = $this->cache->getItem($cacheKey);
         if ($item->isHit()) {
             /** @var list<string> $cached */
             $cached = $item->get();

--- a/src/Shared/AI/Service/ModelDiscoveryServiceInterface.php
+++ b/src/Shared/AI/Service/ModelDiscoveryServiceInterface.php
@@ -9,4 +9,6 @@ use App\Shared\AI\ValueObject\ModelIdCollection;
 interface ModelDiscoveryServiceInterface
 {
     public function discoverFreeModels(): ModelIdCollection;
+
+    public function discoverToolCallingModels(): ModelIdCollection;
 }

--- a/tests/Unit/Shared/AI/Service/ModelDiscoveryServiceTest.php
+++ b/tests/Unit/Shared/AI/Service/ModelDiscoveryServiceTest.php
@@ -28,6 +28,10 @@ final class ModelDiscoveryServiceTest extends TestCase
 
     private const string CACHE_KEY = 'openrouter_free_models';
 
+    private const string TOOL_CALLING_BREAKER_KEY = 'openrouter_tool_calling_cb';
+
+    private const string TOOL_CALLING_CACHE_KEY = 'openrouter_tool_calling_models';
+
     public function testDiscoversFreeModels(): void
     {
         $service = $this->createService($this->successClient());
@@ -423,7 +427,7 @@ final class ModelDiscoveryServiceTest extends TestCase
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('info')
-            ->with(self::stringContains('Discovered'), self::callback(static fn (array $ctx): bool => $ctx['count'] === 2));
+            ->with(self::stringContains('Discovered'), self::callback(static fn (array $ctx): bool => $ctx['count'] === 2 && $ctx['pool'] === 'free'));
 
         $service = new ModelDiscoveryService(
             $this->successClient(),
@@ -529,6 +533,395 @@ final class ModelDiscoveryServiceTest extends TestCase
         self::assertTrue($found, 'Expected "Circuit breaker opened" warning was not logged');
     }
 
+    public function testDiscoversToolCallingModels(): void
+    {
+        $service = $this->createService($this->toolCallingClient());
+
+        $models = $service->discoverToolCallingModels();
+
+        self::assertCount(2, $models);
+        $values = array_map(static fn (ModelId $m): string => $m->value, $models->toArray());
+        self::assertContains('tool-model-1', $values);
+        self::assertContains('tool-model-2', $values);
+        self::assertNotContains('no-tools-model', $values);
+        self::assertNotContains('paid-tool-model', $values);
+    }
+
+    public function testToolCallingFiltersModelsWithoutToolsParam(): void
+    {
+        $service = $this->createService($this->clientWithModels([
+            [
+                'id' => 'has-tools',
+                'context_length' => 32768,
+                'pricing' => [
+                    'prompt' => '0',
+                    'completion' => '0',
+                ],
+                'supported_parameters' => [
+                    'tools',
+                    'temperature',
+                ],
+            ],
+            [
+                'id' => 'no-tools',
+                'context_length' => 32768,
+                'pricing' => [
+                    'prompt' => '0',
+                    'completion' => '0',
+                ],
+                'supported_parameters' => [
+                    'temperature',
+                ],
+            ],
+            [
+                'id' => 'missing-params',
+                'context_length' => 32768,
+                'pricing' => [
+                    'prompt' => '0',
+                    'completion' => '0',
+                ],
+            ],
+        ]));
+
+        $models = $service->discoverToolCallingModels();
+
+        self::assertCount(1, $models);
+        $first = $models->first();
+        self::assertInstanceOf(ModelId::class, $first);
+        self::assertSame('has-tools', $first->value);
+    }
+
+    public function testToolCallingFiltersPaidModels(): void
+    {
+        $service = $this->createService($this->clientWithModels([
+            [
+                'id' => 'free-tools',
+                'context_length' => 32768,
+                'pricing' => [
+                    'prompt' => '0',
+                    'completion' => '0',
+                ],
+                'supported_parameters' => [
+                    'tools',
+                ],
+            ],
+            [
+                'id' => 'paid-tools',
+                'context_length' => 32768,
+                'pricing' => [
+                    'prompt' => '0.001',
+                    'completion' => '0',
+                ],
+                'supported_parameters' => [
+                    'tools',
+                ],
+            ],
+        ]));
+
+        $models = $service->discoverToolCallingModels();
+
+        self::assertCount(1, $models);
+        $first = $models->first();
+        self::assertInstanceOf(ModelId::class, $first);
+        self::assertSame('free-tools', $first->value);
+    }
+
+    public function testToolCallingFiltersSmallContextModels(): void
+    {
+        $service = $this->createService($this->clientWithModels([
+            [
+                'id' => 'large-context-tools',
+                'context_length' => 8192,
+                'pricing' => [
+                    'prompt' => '0',
+                    'completion' => '0',
+                ],
+                'supported_parameters' => [
+                    'tools',
+                ],
+            ],
+            [
+                'id' => 'small-context-tools',
+                'context_length' => 4096,
+                'pricing' => [
+                    'prompt' => '0',
+                    'completion' => '0',
+                ],
+                'supported_parameters' => [
+                    'tools',
+                ],
+            ],
+        ]));
+
+        $models = $service->discoverToolCallingModels();
+
+        self::assertCount(1, $models);
+        $first = $models->first();
+        self::assertInstanceOf(ModelId::class, $first);
+        self::assertSame('large-context-tools', $first->value);
+    }
+
+    public function testToolCallingFiltersBlockedModels(): void
+    {
+        $service = $this->createService(
+            $this->clientWithModels([
+                [
+                    'id' => 'good-tool-model',
+                    'context_length' => 32768,
+                    'pricing' => [
+                        'prompt' => '0',
+                        'completion' => '0',
+                    ],
+                    'supported_parameters' => [
+                        'tools',
+                    ],
+                ],
+                [
+                    'id' => 'blocked-tool-model',
+                    'context_length' => 32768,
+                    'pricing' => [
+                        'prompt' => '0',
+                        'completion' => '0',
+                    ],
+                    'supported_parameters' => [
+                        'tools',
+                    ],
+                ],
+            ]),
+            blockedModels: 'blocked-tool-model',
+        );
+
+        $models = $service->discoverToolCallingModels();
+
+        self::assertCount(1, $models);
+        $first = $models->first();
+        self::assertInstanceOf(ModelId::class, $first);
+        self::assertSame('good-tool-model', $first->value);
+    }
+
+    public function testToolCallingCachesResults(): void
+    {
+        $callCount = 0;
+        $factory = function () use (&$callCount): MockResponse {
+            $callCount++;
+
+            return new MockResponse($this->toolCallingModelsJson());
+        };
+
+        $service = $this->createService(new MockHttpClient($factory));
+
+        $service->discoverToolCallingModels();
+        $service->discoverToolCallingModels();
+
+        self::assertSame(1, $callCount);
+    }
+
+    public function testToolCallingCacheStoresModelIds(): void
+    {
+        $cache = new ArrayAdapter();
+        $service = $this->createService($this->toolCallingClient(), cache: $cache);
+
+        $service->discoverToolCallingModels();
+
+        $cacheItem = $cache->getItem(self::TOOL_CALLING_CACHE_KEY);
+        self::assertTrue($cacheItem->isHit());
+
+        /** @var list<string> $cached */
+        $cached = $cacheItem->get();
+        self::assertContains('tool-model-1', $cached);
+        self::assertContains('tool-model-2', $cached);
+    }
+
+    public function testToolCallingUsesSeparateCacheFromFreeModels(): void
+    {
+        $cache = new ArrayAdapter();
+        $json = $this->toolCallingModelsJson();
+        $client = new MockHttpClient([
+            new MockResponse($json),
+            new MockResponse($json),
+        ]);
+        $service = $this->createService($client, cache: $cache);
+
+        $service->discoverFreeModels();
+        $service->discoverToolCallingModels();
+
+        $freeCacheItem = $cache->getItem(self::CACHE_KEY);
+        $toolCacheItem = $cache->getItem(self::TOOL_CALLING_CACHE_KEY);
+
+        self::assertTrue($freeCacheItem->isHit());
+        self::assertTrue($toolCacheItem->isHit());
+
+        /** @var list<string> $freeIds */
+        $freeIds = $freeCacheItem->get();
+        /** @var list<string> $toolIds */
+        $toolIds = $toolCacheItem->get();
+
+        // Free models pool should be larger (includes models without tool support)
+        self::assertGreaterThan(\count($toolIds), \count($freeIds));
+    }
+
+    public function testToolCallingCircuitBreakerIsIndependent(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        // Open the FREE models breaker
+        $this->setBreakerState($cache, CircuitBreakerState::Open, openedAt: $clock->now()->getTimestamp());
+
+        // Tool-calling breaker should still be closed — API call should happen
+        $apiCallCount = 0;
+        $factory = function () use (&$apiCallCount): MockResponse {
+            $apiCallCount++;
+
+            return new MockResponse($this->toolCallingModelsJson());
+        };
+
+        $service = $this->createService(new MockHttpClient($factory), cache: $cache, clock: $clock);
+        $models = $service->discoverToolCallingModels();
+
+        self::assertSame(1, $apiCallCount);
+        self::assertCount(2, $models);
+    }
+
+    public function testToolCallingBreakerOpensIndependently(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        // Three failures on tool-calling should open its own breaker
+        for ($i = 0; $i < 3; $i++) {
+            $service = $this->createService($this->failingClient(), cache: $cache, clock: $clock);
+            $service->discoverToolCallingModels();
+        }
+
+        // Verify tool-calling breaker is open
+        $toolBreakerItem = $cache->getItem(self::TOOL_CALLING_BREAKER_KEY);
+        self::assertTrue($toolBreakerItem->isHit());
+
+        /** @var array{state: string, failures: int, opened_at: ?int} $data */
+        $data = $toolBreakerItem->get();
+        self::assertSame(CircuitBreakerState::Open->value, $data['state']);
+
+        // Verify free models breaker is still closed (not in cache)
+        $freeBreakerItem = $cache->getItem(self::BREAKER_KEY);
+        self::assertFalse($freeBreakerItem->isHit());
+    }
+
+    public function testToolCallingOpenBreakerReturnsCachedModels(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        // Pre-populate tool-calling cache
+        $populateService = $this->createService($this->toolCallingClient(), cache: $cache, clock: $clock);
+        $populateService->discoverToolCallingModels();
+
+        // Open the tool-calling breaker
+        $this->setToolCallingBreakerState($cache, CircuitBreakerState::Open, openedAt: $clock->now()->getTimestamp());
+
+        // Should return cached models without API call
+        $apiCallCount = 0;
+        $factory = function () use (&$apiCallCount): MockResponse {
+            $apiCallCount++;
+
+            return new MockResponse('error', [
+                'error' => 'should not be called',
+            ]);
+        };
+
+        $service = $this->createService(new MockHttpClient($factory), cache: $cache, clock: $clock);
+        $models = $service->discoverToolCallingModels();
+
+        self::assertSame(0, $apiCallCount);
+        self::assertCount(2, $models);
+    }
+
+    public function testToolCallingOpenBreakerWithNoCacheReturnsEmpty(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        $this->setToolCallingBreakerState($cache, CircuitBreakerState::Open, openedAt: $clock->now()->getTimestamp());
+
+        $service = $this->createService($this->failingClient(), cache: $cache, clock: $clock);
+        $models = $service->discoverToolCallingModels();
+
+        self::assertCount(0, $models);
+    }
+
+    public function testToolCallingReturnsEmptyWhenNoToolModelsExist(): void
+    {
+        $service = $this->createService($this->clientWithModels([
+            [
+                'id' => 'free-no-tools',
+                'context_length' => 32768,
+                'pricing' => [
+                    'prompt' => '0',
+                    'completion' => '0',
+                ],
+                'supported_parameters' => [
+                    'temperature',
+                ],
+            ],
+        ]));
+
+        $models = $service->discoverToolCallingModels();
+
+        self::assertCount(0, $models);
+    }
+
+    public function testToolCallingLoggerInfoOnSuccessfulDiscovery(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info')
+            ->with(
+                self::stringContains('Discovered'),
+                self::callback(static fn (array $ctx): bool => $ctx['count'] === 2 && $ctx['pool'] === 'tool-calling'),
+            );
+
+        $service = new ModelDiscoveryService(
+            $this->toolCallingClient(),
+            new ArrayAdapter(),
+            new MockClock(),
+            $logger,
+        );
+        $service->discoverToolCallingModels();
+    }
+
+    public function testToolCallingLoggerWarningOnFailure(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning')
+            ->with(self::stringContains('failed'));
+
+        $service = new ModelDiscoveryService(
+            $this->failingClient(),
+            new ArrayAdapter(),
+            new MockClock(),
+            $logger,
+        );
+        $service->discoverToolCallingModels();
+    }
+
+    public function testToolCallingHalfOpenAfterResetPeriod(): void
+    {
+        $cache = new ArrayAdapter();
+        $clock = new MockClock('2026-01-01 00:00:00');
+
+        $this->setToolCallingBreakerState($cache, CircuitBreakerState::Open, openedAt: $clock->now()->getTimestamp());
+
+        $clock->modify('+25 hours');
+
+        $service = $this->createService($this->toolCallingClient(), cache: $cache, clock: $clock);
+        $models = $service->discoverToolCallingModels();
+
+        self::assertCount(2, $models);
+
+        // Breaker should be reset after successful probe
+        $breakerItem = $cache->getItem(self::TOOL_CALLING_BREAKER_KEY);
+        self::assertFalse($breakerItem->isHit());
+    }
+
     private function createService(
         MockHttpClient $client,
         ?ArrayAdapter $cache = null,
@@ -557,7 +950,7 @@ final class ModelDiscoveryServiceTest extends TestCase
     }
 
     /**
-     * @param list<array{id: string, context_length: int, pricing: array{prompt: string, completion: string}}> $models
+     * @param list<array<string, mixed>> $models
      */
     private function clientWithModels(array $models): MockHttpClient
     {
@@ -608,6 +1001,73 @@ final class ModelDiscoveryServiceTest extends TestCase
         ], JSON_THROW_ON_ERROR);
     }
 
+    private function toolCallingClient(): MockHttpClient
+    {
+        return new MockHttpClient(new MockResponse($this->toolCallingModelsJson()));
+    }
+
+    private function toolCallingModelsJson(): string
+    {
+        return json_encode([
+            'data' => [
+                [
+                    'id' => 'tool-model-1',
+                    'context_length' => 32768,
+                    'pricing' => [
+                        'prompt' => '0',
+                        'completion' => '0',
+                    ],
+                    'supported_parameters' => [
+                        'tools',
+                        'temperature',
+                    ],
+                ],
+                [
+                    'id' => 'no-tools-model',
+                    'context_length' => 32768,
+                    'pricing' => [
+                        'prompt' => '0',
+                        'completion' => '0',
+                    ],
+                    'supported_parameters' => [
+                        'temperature',
+                    ],
+                ],
+                [
+                    'id' => 'paid-tool-model',
+                    'context_length' => 32768,
+                    'pricing' => [
+                        'prompt' => '0.001',
+                        'completion' => '0.002',
+                    ],
+                    'supported_parameters' => [
+                        'tools',
+                    ],
+                ],
+                [
+                    'id' => 'tool-model-2',
+                    'context_length' => 16384,
+                    'pricing' => [
+                        'prompt' => '0',
+                        'completion' => '0',
+                    ],
+                    'supported_parameters' => [
+                        'tools',
+                        'top_p',
+                    ],
+                ],
+                [
+                    'id' => 'free-no-params',
+                    'context_length' => 32768,
+                    'pricing' => [
+                        'prompt' => '0',
+                        'completion' => '0',
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR);
+    }
+
     private function setBreakerState(
         ArrayAdapter $cache,
         CircuitBreakerState $state,
@@ -615,6 +1075,22 @@ final class ModelDiscoveryServiceTest extends TestCase
         ?int $openedAt = null,
     ): void {
         $item = $cache->getItem(self::BREAKER_KEY);
+        $item->set([
+            'state' => $state->value,
+            'failures' => $failures,
+            'opened_at' => $openedAt ?? 1_735_689_600,
+        ]);
+        $item->expiresAfter(172_800);
+        $cache->save($item);
+    }
+
+    private function setToolCallingBreakerState(
+        ArrayAdapter $cache,
+        CircuitBreakerState $state,
+        int $failures = 3,
+        ?int $openedAt = null,
+    ): void {
+        $item = $cache->getItem(self::TOOL_CALLING_BREAKER_KEY);
         $item->set([
             'state' => $state->value,
             'failures' => $failures,


### PR DESCRIPTION
## Summary

- Extends `ModelDiscoveryService` with `discoverToolCallingModels()` that filters free OpenRouter models for `"tools"` in `supported_parameters`
- Uses separate cache key (`openrouter_tool_calling_models`) and independent circuit breaker (`openrouter_tool_calling_cb`) from the enrichment model pool
- Updates `app:ai-model-stats` command to display discovered tool-calling models
- 16 new unit tests covering discovery, filtering, caching, circuit breaker independence, and logging

Closes #187

## Test plan

- [x] `make quality` passes (ECS + PHPStan max + Rector)
- [x] `make test-unit` passes (875 tests, 0 failures)
- [x] `make infection` passes (90% covered MSI)
- [x] Existing `discoverFreeModels()` behavior unchanged (all pre-existing tests pass)
- [x] Tool-calling and free model circuit breakers operate independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)