### PR TITLE
feat: pgvector infrastructure + article embedding column

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -39,7 +39,7 @@ services:
         condition: service_healthy
 
   database:
-    image: postgres:${POSTGRES_VERSION:-17}-alpine
+    image: pgvector/pgvector:pg${POSTGRES_VERSION:-17}
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-app}

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,3 +1,7 @@
+-- Enable pgvector extension on default database
+\c app
+CREATE EXTENSION IF NOT EXISTS vector;
+
 -- Create test database for integration tests
 CREATE DATABASE app_test;
 GRANT ALL PRIVILEGES ON DATABASE app_test TO app;
@@ -5,3 +9,4 @@ GRANT ALL PRIVILEGES ON DATABASE app_test TO app;
 -- Connect to test database and grant schema privileges
 \c app_test
 GRANT ALL ON SCHEMA public TO app;
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/migrations/Version20260410195004.php
+++ b/migrations/Version20260410195004.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260410195004 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Enable pgvector extension and add embedding column to article';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE EXTENSION IF NOT EXISTS vector');
+        $this->addSql('ALTER TABLE article ADD embedding vector(1536) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE article DROP embedding');
+        $this->addSql('DROP EXTENSION IF EXISTS vector');
+    }
+}

--- a/src/Article/Entity/Article.php
+++ b/src/Article/Entity/Article.php
@@ -95,6 +95,9 @@ class Article
     #[ORM\Column(length: 20, nullable: true, enumType: FullTextStatus::class)]
     private ?FullTextStatus $fullTextStatus = null;
 
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $embedding = null;
+
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     private \DateTimeImmutable $fetchedAt;
 
@@ -342,6 +345,16 @@ class Article
     public function setFullTextStatus(?FullTextStatus $fullTextStatus): void
     {
         $this->fullTextStatus = $fullTextStatus;
+    }
+
+    public function getEmbedding(): ?string
+    {
+        return $this->embedding;
+    }
+
+    public function setEmbedding(?string $embedding): void
+    {
+        $this->embedding = $embedding;
     }
 
     public function getFetchedAt(): \DateTimeImmutable


### PR DESCRIPTION
## Summary
- Switch database image from `postgres:17-alpine` to `pgvector/pgvector:pg17` for vector similarity search support
- Add Doctrine migration that enables the `vector` extension and creates a `vector(1536)` embedding column on the `article` table
- Add nullable `embedding` property (mapped as `TEXT` in Doctrine, actual DB type is `vector(1536)`) with getter/setter on the Article entity
- Update `docker/postgres/init.sql` to pre-create the pgvector extension on both `app` and `app_test` databases

Closes #185

## Test plan
- [x] `make quality` passes (ECS + PHPStan + Rector)
- [x] `make test-unit` passes (859 tests, 2285 assertions)
- [x] `make test-integration` passes (24 tests, 162 assertions)
- [x] Migration runs successfully, column confirmed as `vector(1536)` in database
- [x] pgvector extension v0.8.2 available and installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)