### PR TITLE
feat(chat): hybrid search tool — pgvector semantic + Loupe keyword (#188)

### DIFF
--- a/src/Chat/Repository/VectorSearchRepository.php
+++ b/src/Chat/Repository/VectorSearchRepository.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Repository;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Psr\Log\LoggerInterface;
+
+final readonly class VectorSearchRepository implements VectorSearchRepositoryInterface
+{
+    public function __construct(
+        private Connection $connection,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function findBySimilarity(array $queryVector, int $limit, ?\DateTimeImmutable $since = null): array
+    {
+        if ($queryVector === []) {
+            return [];
+        }
+
+        $vectorString = '[' . implode(',', $queryVector) . ']';
+
+        $sql = 'SELECT id, 1 - (embedding <=> :query_vector::vector) AS similarity'
+            . ' FROM article'
+            . ' WHERE embedding IS NOT NULL';
+
+        $params = [
+            'query_vector' => $vectorString,
+            'limit' => $limit,
+        ];
+        $types = [
+            'limit' => ParameterType::INTEGER,
+        ];
+
+        if ($since instanceof \DateTimeImmutable) {
+            $sql .= ' AND published_at >= :since';
+            $params['since'] = $since->format('Y-m-d H:i:s');
+        }
+
+        $sql .= ' ORDER BY embedding <=> :query_vector::vector LIMIT :limit';
+
+        try {
+            /** @var list<array{id: int|string, similarity: float|string}> $rows */
+            $rows = $this->connection->fetchAllAssociative($sql, $params, $types);
+        } catch (\Throwable $e) {
+            $this->logger->warning('Vector search query failed: {error}', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+
+        return array_map(
+            static fn (array $row): array => [
+                'id' => (int) $row['id'],
+                'similarity' => (float) $row['similarity'],
+            ],
+            $rows,
+        );
+    }
+}

--- a/src/Chat/Repository/VectorSearchRepositoryInterface.php
+++ b/src/Chat/Repository/VectorSearchRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Repository;
+
+interface VectorSearchRepositoryInterface
+{
+    /**
+     * Find articles by cosine similarity to the given embedding vector.
+     *
+     * @param list<float> $queryVector
+     *
+     * @return list<array{id: int, similarity: float}>
+     */
+    public function findBySimilarity(array $queryVector, int $limit, ?\DateTimeImmutable $since = null): array;
+}

--- a/src/Chat/Service/ArticleContextFormatter.php
+++ b/src/Chat/Service/ArticleContextFormatter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Service;
+
+use App\Article\Entity\Article;
+
+final readonly class ArticleContextFormatter implements ArticleContextFormatterInterface
+{
+    public function format(array $articles, array $scores): array
+    {
+        $results = [];
+        foreach ($articles as $article) {
+            $id = $article->getId();
+            if ($id === null) {
+                continue;
+            }
+
+            $results[] = $this->formatArticle($article, $id, $scores[$id] ?? 0.0);
+        }
+
+        usort($results, static fn (array $a, array $b): int => $b['score'] <=> $a['score']);
+
+        return $results;
+    }
+
+    /**
+     * @return array{id: int, title: string, summary: string|null, keywords: list<string>, publishedAt: string|null, url: string, score: float}
+     */
+    private function formatArticle(Article $article, int $id, float $score): array
+    {
+        return [
+            'id' => $id,
+            'title' => $article->getTitle(),
+            'summary' => $article->getSummary(),
+            'keywords' => $article->getKeywords() ?? [],
+            'publishedAt' => $article->getPublishedAt()?->format(\DateTimeInterface::ATOM),
+            'url' => $article->getUrl(),
+            'score' => round($score, 4),
+        ];
+    }
+}

--- a/src/Chat/Service/ArticleContextFormatterInterface.php
+++ b/src/Chat/Service/ArticleContextFormatterInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Service;
+
+use App\Article\Entity\Article;
+
+interface ArticleContextFormatterInterface
+{
+    /**
+     * Format articles as structured data for LLM context.
+     *
+     * @param list<Article> $articles
+     * @param array<int, float> $scores article ID => combined search score
+     *
+     * @return list<array{id: int, title: string, summary: string|null, keywords: list<string>, publishedAt: string|null, url: string, score: float}>
+     */
+    public function format(array $articles, array $scores): array;
+}

--- a/src/Chat/Tool/ArticleSearchTool.php
+++ b/src/Chat/Tool/ArticleSearchTool.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Tool;
+
+use Psr\Log\LoggerInterface;
+
+final readonly class ArticleSearchTool implements ArticleSearchToolInterface
+{
+    private const float KEYWORD_SCORE_BASE = 1.0;
+
+    private const float KEYWORD_SCORE_DECAY = 0.05;
+
+    private const float BOOST_BOTH = 0.2;
+
+    public function __construct(
+        private SearchDependencies $deps,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function search(string $query, ?int $daysBack = null, int $limit = 8): array
+    {
+        $trimmed = trim($query);
+        if ($trimmed === '') {
+            return [];
+        }
+
+        $since = $this->resolveSince($daysBack);
+        $scores = $this->mergeSearchResults($trimmed, $since, $limit);
+
+        if ($scores === []) {
+            $this->logger->info('Hybrid search returned no results for query', [
+                'query' => $trimmed,
+            ]);
+
+            return [];
+        }
+
+        return $this->loadAndFormat($scores, $limit);
+    }
+
+    /**
+     * @return array<int, float> article ID => combined score
+     */
+    private function mergeSearchResults(string $query, ?\DateTimeImmutable $since, int $limit): array
+    {
+        $semanticScores = $this->runSemanticSearch($query, $since, $limit);
+        $keywordScores = $this->runKeywordSearch($query, $limit);
+
+        return $this->combineScores($semanticScores, $keywordScores);
+    }
+
+    /**
+     * @return array<int, float>
+     */
+    private function runSemanticSearch(string $query, ?\DateTimeImmutable $since, int $limit): array
+    {
+        $vector = $this->deps->embedding->embed($query);
+        if ($vector === null) {
+            return [];
+        }
+
+        $results = $this->deps->vectorSearch->findBySimilarity($vector, $limit, $since);
+        $scores = [];
+        foreach ($results as $row) {
+            $scores[$row['id']] = $row['similarity'];
+        }
+
+        return $scores;
+    }
+
+    /**
+     * @return array<int, float>
+     */
+    private function runKeywordSearch(string $query, int $limit): array
+    {
+        $ids = $this->deps->keywordSearch->search($query, null, $limit);
+        $scores = [];
+        foreach ($ids as $position => $id) {
+            $scores[$id] = max(0.0, self::KEYWORD_SCORE_BASE - ($position * self::KEYWORD_SCORE_DECAY));
+        }
+
+        return $scores;
+    }
+
+    /**
+     * @param array<int, float> $semantic
+     * @param array<int, float> $keyword
+     *
+     * @return array<int, float>
+     */
+    private function combineScores(array $semantic, array $keyword): array
+    {
+        $combined = [];
+        $allIds = array_unique([...array_keys($semantic), ...array_keys($keyword)]);
+
+        foreach ($allIds as $id) {
+            $score = ($semantic[$id] ?? 0.0) + ($keyword[$id] ?? 0.0);
+            if (isset($semantic[$id], $keyword[$id])) {
+                $score += self::BOOST_BOTH;
+            }
+            $combined[$id] = $score;
+        }
+
+        arsort($combined);
+
+        return $combined;
+    }
+
+    /**
+     * @param array<int, float> $scores
+     *
+     * @return list<array{id: int, title: string, summary: string|null, keywords: list<string>, publishedAt: string|null, url: string, score: float}>
+     */
+    private function loadAndFormat(array $scores, int $limit): array
+    {
+        $topIds = \array_slice(array_keys($scores), 0, $limit);
+        $articles = $this->deps->articleRepository->findByIds($topIds);
+
+        return $this->deps->formatter->format($articles, $scores);
+    }
+
+    private function resolveSince(?int $daysBack): ?\DateTimeImmutable
+    {
+        if ($daysBack === null || $daysBack <= 0) {
+            return null;
+        }
+
+        return $this->deps->clock->now()->modify(sprintf('-%d days', $daysBack));
+    }
+}

--- a/src/Chat/Tool/ArticleSearchToolInterface.php
+++ b/src/Chat/Tool/ArticleSearchToolInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Tool;
+
+interface ArticleSearchToolInterface
+{
+    /**
+     * Search articles using hybrid semantic + keyword search.
+     *
+     * @return list<array{id: int, title: string, summary: string|null, keywords: list<string>, publishedAt: string|null, url: string, score: float}>
+     */
+    public function search(string $query, ?int $daysBack = null, int $limit = 8): array;
+}

--- a/src/Chat/Tool/SearchDependencies.php
+++ b/src/Chat/Tool/SearchDependencies.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Tool;
+
+use App\Article\Repository\ArticleRepositoryInterface;
+use App\Chat\Repository\VectorSearchRepositoryInterface;
+use App\Chat\Service\ArticleContextFormatterInterface;
+use App\Chat\Service\EmbeddingServiceInterface;
+use App\Shared\Search\Service\ArticleSearchServiceInterface;
+use Psr\Clock\ClockInterface;
+
+/**
+ * Bundles dependencies for ArticleSearchTool to stay within the 5-param constructor limit.
+ */
+final readonly class SearchDependencies
+{
+    public function __construct(
+        public EmbeddingServiceInterface $embedding,
+        public VectorSearchRepositoryInterface $vectorSearch,
+        public ArticleSearchServiceInterface $keywordSearch,
+        public ArticleRepositoryInterface $articleRepository,
+        public ArticleContextFormatterInterface $formatter,
+        public ClockInterface $clock,
+    ) {
+    }
+}

--- a/tests/Unit/Chat/Repository/VectorSearchRepositoryTest.php
+++ b/tests/Unit/Chat/Repository/VectorSearchRepositoryTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Chat\Repository;
+
+use App\Chat\Repository\VectorSearchRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+#[CoversClass(VectorSearchRepository::class)]
+final class VectorSearchRepositoryTest extends TestCase
+{
+    private Connection&MockObject $connection;
+
+    private LoggerInterface&MockObject $logger;
+
+    private VectorSearchRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->repository = new VectorSearchRepository($this->connection, $this->logger);
+    }
+
+    public function testFindBySimilarityEmptyVectorReturnsEmpty(): void
+    {
+        $this->connection->expects(self::never())->method('fetchAllAssociative');
+
+        $result = $this->repository->findBySimilarity([], 10);
+        self::assertSame([], $result);
+    }
+
+    public function testFindBySimilarityBuildsCorrectSqlAndParams(): void
+    {
+        $vector = [0.1, 0.2, 0.3];
+        $capturedSql = '';
+        $capturedParams = [];
+        $capturedTypes = [];
+
+        $this->connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(
+                self::callback(static function (string $sql) use (&$capturedSql): bool {
+                    $capturedSql = $sql;
+
+                    return true;
+                }),
+                self::callback(static function (array $params) use (&$capturedParams): bool {
+                    $capturedParams = $params;
+
+                    return true;
+                }),
+                self::callback(static function (array $types) use (&$capturedTypes): bool {
+                    $capturedTypes = $types;
+
+                    return true;
+                }),
+            )
+            ->willReturn([
+                [
+                    'id' => 1,
+                    'similarity' => '0.95',
+                ],
+                [
+                    'id' => '42',
+                    'similarity' => '0.80',
+                ],
+            ]);
+
+        $results = $this->repository->findBySimilarity($vector, 10);
+
+        // Verify SQL structure
+        self::assertStringStartsWith('SELECT id, 1 - (embedding <=> :query_vector::vector)', $capturedSql);
+        self::assertStringContainsString('FROM article', $capturedSql);
+        self::assertStringContainsString('WHERE embedding IS NOT NULL', $capturedSql);
+        self::assertStringContainsString('ORDER BY embedding <=> :query_vector::vector LIMIT :limit', $capturedSql);
+        self::assertStringNotContainsString('published_at', $capturedSql);
+
+        // Verify params
+        self::assertSame('[0.1,0.2,0.3]', $capturedParams['query_vector']);
+        self::assertSame(10, $capturedParams['limit']);
+        self::assertArrayNotHasKey('since', $capturedParams);
+
+        // Verify types include limit as INTEGER
+        self::assertSame(ParameterType::INTEGER, $capturedTypes['limit']);
+
+        // Verify return values are cast correctly
+        self::assertCount(2, $results);
+        self::assertSame(1, $results[0]['id']);
+        self::assertSame(0.95, $results[0]['similarity']);
+        self::assertSame(42, $results[1]['id']);
+        self::assertSame(0.80, $results[1]['similarity']);
+    }
+
+    public function testFindBySimilarityWithSinceAddsDateFilter(): void
+    {
+        $since = new \DateTimeImmutable('2026-04-01 00:00:00');
+        $capturedSql = '';
+        $capturedParams = [];
+
+        $this->connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(
+                self::callback(static function (string $sql) use (&$capturedSql): bool {
+                    $capturedSql = $sql;
+
+                    return true;
+                }),
+                self::callback(static function (array $params) use (&$capturedParams): bool {
+                    $capturedParams = $params;
+
+                    return true;
+                }),
+                self::anything(),
+            )
+            ->willReturn([]);
+
+        $result = $this->repository->findBySimilarity([0.1], 5, $since);
+
+        self::assertSame([], $result);
+        self::assertStringContainsString('AND published_at >= :since', $capturedSql);
+        self::assertSame('2026-04-01 00:00:00', $capturedParams['since']);
+        self::assertSame('[0.1]', $capturedParams['query_vector']);
+        self::assertSame(5, $capturedParams['limit']);
+    }
+
+    public function testFindBySimilarityLogsAndReturnsEmptyOnException(): void
+    {
+        $this->connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->willThrowException(new \RuntimeException('pgvector not installed'));
+
+        $this->logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'Vector search query failed: {error}',
+                self::callback(static fn (array $ctx): bool => $ctx['error'] === 'pgvector not installed'),
+            );
+
+        $result = $this->repository->findBySimilarity([0.1], 10);
+        self::assertSame([], $result);
+    }
+
+    public function testFindBySimilarityVectorStringFormat(): void
+    {
+        $this->connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(
+                self::anything(),
+                self::callback(static fn (array $p): bool => $p['query_vector'] === '[1.5,2.5]'),
+                self::anything(),
+            )
+            ->willReturn([]);
+
+        $this->repository->findBySimilarity([1.5, 2.5], 5);
+    }
+}

--- a/tests/Unit/Chat/Service/ArticleContextFormatterTest.php
+++ b/tests/Unit/Chat/Service/ArticleContextFormatterTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Chat\Service;
+
+use App\Article\Entity\Article;
+use App\Chat\Service\ArticleContextFormatter;
+use App\Source\Entity\Source;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ArticleContextFormatter::class)]
+final class ArticleContextFormatterTest extends TestCase
+{
+    private ArticleContextFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new ArticleContextFormatter();
+    }
+
+    public function testFormatSortsByScoreDescending(): void
+    {
+        $articles = [
+            $this->createArticle(1, 'Low', 'https://example.com/1'),
+            $this->createArticle(2, 'High', 'https://example.com/2'),
+        ];
+
+        $scores = [
+            1 => 0.5,
+            2 => 0.9,
+        ];
+        $results = $this->formatter->format($articles, $scores);
+
+        self::assertCount(2, $results);
+        self::assertSame(2, $results[0]['id']);
+        self::assertSame(0.9, $results[0]['score']);
+        self::assertSame(1, $results[1]['id']);
+        self::assertSame(0.5, $results[1]['score']);
+    }
+
+    public function testFormatSkipsArticlesWithNullId(): void
+    {
+        $source = $this->createStub(Source::class);
+        $source->method('getName')->willReturn('Source');
+        $article = new Article('Title', 'https://example.com/x', $source, new \DateTimeImmutable());
+
+        $results = $this->formatter->format([$article], []);
+
+        self::assertSame([], $results);
+    }
+
+    public function testFormatUsesDefaultScoreWhenNotInMap(): void
+    {
+        $article = $this->createArticle(1, 'Test', 'https://example.com/1');
+        $results = $this->formatter->format([$article], []);
+
+        self::assertCount(1, $results);
+        self::assertSame(0.0, $results[0]['score']);
+    }
+
+    public function testFormatIncludesAllFields(): void
+    {
+        $article = $this->createArticle(1, 'Title', 'https://example.com/1');
+        $article->setSummary('Summary text');
+        $article->setKeywords(['k1', 'k2']);
+        $article->setPublishedAt(new \DateTimeImmutable('2026-04-09T08:00:00+00:00'));
+
+        $results = $this->formatter->format([$article], [
+            1 => 0.85,
+        ]);
+
+        self::assertCount(1, $results);
+        $r = $results[0];
+        self::assertSame(1, $r['id']);
+        self::assertSame('Title', $r['title']);
+        self::assertSame('Summary text', $r['summary']);
+        self::assertSame(['k1', 'k2'], $r['keywords']);
+        self::assertSame('2026-04-09T08:00:00+00:00', $r['publishedAt']);
+        self::assertSame('https://example.com/1', $r['url']);
+        self::assertSame(0.85, $r['score']);
+    }
+
+    public function testFormatWithNullSummaryKeywordsPublishedAt(): void
+    {
+        $article = $this->createArticle(1, 'Title', 'https://example.com/1');
+
+        $results = $this->formatter->format([$article], [
+            1 => 0.5,
+        ]);
+
+        self::assertNull($results[0]['summary']);
+        self::assertSame([], $results[0]['keywords']);
+        self::assertNull($results[0]['publishedAt']);
+    }
+
+    public function testFormatEmptyArticlesReturnsEmpty(): void
+    {
+        self::assertSame([], $this->formatter->format([], []));
+    }
+
+    public function testFormatRoundsScoreToFourDecimals(): void
+    {
+        $article = $this->createArticle(1, 'T', 'https://example.com/1');
+        $results = $this->formatter->format([$article], [
+            1 => 0.123456789,
+        ]);
+
+        self::assertSame(0.1235, $results[0]['score']);
+    }
+
+    private function createArticle(int $id, string $title, string $url): Article
+    {
+        $source = $this->createStub(Source::class);
+        $source->method('getName')->willReturn('Source');
+        $article = new Article($title, $url, $source, new \DateTimeImmutable('2026-04-09'));
+
+        $reflection = new \ReflectionProperty(Article::class, 'id');
+        $reflection->setValue($article, $id);
+
+        return $article;
+    }
+}

--- a/tests/Unit/Chat/Tool/ArticleSearchToolTest.php
+++ b/tests/Unit/Chat/Tool/ArticleSearchToolTest.php
@@ -1,0 +1,366 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Chat\Tool;
+
+use App\Article\Entity\Article;
+use App\Article\Repository\ArticleRepositoryInterface;
+use App\Chat\Repository\VectorSearchRepositoryInterface;
+use App\Chat\Service\ArticleContextFormatter;
+use App\Chat\Service\EmbeddingServiceInterface;
+use App\Chat\Tool\ArticleSearchTool;
+use App\Chat\Tool\SearchDependencies;
+use App\Shared\Search\Service\ArticleSearchServiceInterface;
+use App\Source\Entity\Source;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\MockClock;
+
+#[CoversClass(ArticleSearchTool::class)]
+#[CoversClass(SearchDependencies::class)]
+final class ArticleSearchToolTest extends TestCase
+{
+    private EmbeddingServiceInterface&MockObject $embedding;
+
+    private VectorSearchRepositoryInterface&MockObject $vectorSearch;
+
+    private ArticleSearchServiceInterface&MockObject $keywordSearch;
+
+    private ArticleRepositoryInterface&MockObject $articleRepository;
+
+    private LoggerInterface&MockObject $logger;
+
+    private MockClock $clock;
+
+    private ArticleSearchTool $tool;
+
+    protected function setUp(): void
+    {
+        $this->embedding = $this->createMock(EmbeddingServiceInterface::class);
+        $this->vectorSearch = $this->createMock(VectorSearchRepositoryInterface::class);
+        $this->keywordSearch = $this->createMock(ArticleSearchServiceInterface::class);
+        $this->articleRepository = $this->createMock(ArticleRepositoryInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->clock = new MockClock(new \DateTimeImmutable('2026-04-10 12:00:00'));
+
+        $deps = new SearchDependencies(
+            $this->embedding,
+            $this->vectorSearch,
+            $this->keywordSearch,
+            $this->articleRepository,
+            new ArticleContextFormatter(),
+            $this->clock,
+        );
+
+        $this->tool = new ArticleSearchTool($deps, $this->logger);
+    }
+
+    public function testSearchEmptyQueryReturnsEmpty(): void
+    {
+        $result = $this->tool->search('');
+        self::assertSame([], $result);
+    }
+
+    public function testSearchWhitespaceOnlyQueryReturnsEmpty(): void
+    {
+        $result = $this->tool->search('   ');
+        self::assertSame([], $result);
+    }
+
+    public function testSearchHybridMergesDedupesAndRanks(): void
+    {
+        $vector = [0.1, 0.2, 0.3];
+        $this->embedding->expects(self::once())
+            ->method('embed')
+            ->with('AI news')
+            ->willReturn($vector);
+
+        $this->vectorSearch->expects(self::once())
+            ->method('findBySimilarity')
+            ->with($vector, 8, null)
+            ->willReturn([
+                [
+                    'id' => 1,
+                    'similarity' => 0.9,
+                ],
+                [
+                    'id' => 2,
+                    'similarity' => 0.7,
+                ],
+            ]);
+
+        $this->keywordSearch->expects(self::once())
+            ->method('search')
+            ->with('AI news', null, 8)
+            ->willReturn([2, 3]);
+
+        $article1 = $this->createArticle(1, 'Article 1', 'https://example.com/1');
+        $article2 = $this->createArticle(2, 'Article 2', 'https://example.com/2');
+        $article3 = $this->createArticle(3, 'Article 3', 'https://example.com/3');
+
+        $this->articleRepository->expects(self::once())
+            ->method('findByIds')
+            ->willReturn([$article1, $article2, $article3]);
+
+        $results = $this->tool->search('AI news');
+
+        self::assertCount(3, $results);
+        // Article 2 found by both: 0.7 (semantic) + 1.0 (keyword pos 0) + 0.2 (boost) = 1.9
+        self::assertSame(2, $results[0]['id']);
+        self::assertSame(1.9, $results[0]['score']);
+        // Article 3: 0.95 (keyword pos 1)
+        self::assertSame(3, $results[1]['id']);
+        self::assertSame(0.95, $results[1]['score']);
+        // Article 1: 0.9 (semantic only)
+        self::assertSame(1, $results[2]['id']);
+        self::assertSame(0.9, $results[2]['score']);
+    }
+
+    public function testSearchFallsBackToKeywordOnlyWhenEmbeddingReturnsNull(): void
+    {
+        $this->embedding->expects(self::once())
+            ->method('embed')
+            ->willReturn(null);
+
+        $this->vectorSearch->expects(self::never())
+            ->method('findBySimilarity');
+
+        $this->keywordSearch->expects(self::once())
+            ->method('search')
+            ->with('test query', null, 8)
+            ->willReturn([5]);
+
+        $article = $this->createArticle(5, 'Keyword Article', 'https://example.com/5');
+        $this->articleRepository->expects(self::once())
+            ->method('findByIds')
+            ->with([5])
+            ->willReturn([$article]);
+
+        $results = $this->tool->search('test query');
+
+        self::assertCount(1, $results);
+        self::assertSame(5, $results[0]['id']);
+        self::assertSame(1.0, $results[0]['score']);
+    }
+
+    public function testSearchWithDaysBackFilterPassesSinceDate(): void
+    {
+        $vector = [0.1];
+        $this->embedding->expects(self::once())
+            ->method('embed')
+            ->willReturn($vector);
+
+        $expectedSince = new \DateTimeImmutable('2026-04-03 12:00:00');
+
+        $this->vectorSearch->expects(self::once())
+            ->method('findBySimilarity')
+            ->with(
+                $vector,
+                8,
+                self::callback(static fn (\DateTimeImmutable $since): bool => $since->format('Y-m-d H:i:s') === $expectedSince->format('Y-m-d H:i:s')),
+            )
+            ->willReturn([]);
+
+        $this->keywordSearch->expects(self::once())
+            ->method('search')
+            ->willReturn([]);
+
+        $this->logger->expects(self::once())
+            ->method('info')
+            ->with('Hybrid search returned no results for query', self::callback(
+                static fn (array $ctx): bool => $ctx['query'] === 'test',
+            ));
+
+        $this->tool->search('test', 7);
+    }
+
+    public function testSearchWithZeroDaysBackDoesNotFilterByDate(): void
+    {
+        $this->embedding->expects(self::once())
+            ->method('embed')
+            ->willReturn([0.1]);
+
+        $this->vectorSearch->expects(self::once())
+            ->method('findBySimilarity')
+            ->with([0.1], 8, null)
+            ->willReturn([]);
+
+        $this->keywordSearch->expects(self::once())
+            ->method('search')
+            ->willReturn([]);
+
+        $this->logger->expects(self::once())
+            ->method('info');
+
+        $this->tool->search('test', 0);
+    }
+
+    public function testSearchWithNegativeDaysBackDoesNotFilterByDate(): void
+    {
+        $this->embedding->expects(self::once())
+            ->method('embed')
+            ->willReturn([0.1]);
+
+        $this->vectorSearch->expects(self::once())
+            ->method('findBySimilarity')
+            ->with([0.1], 8, null)
+            ->willReturn([]);
+
+        $this->keywordSearch->expects(self::once())
+            ->method('search')
+            ->willReturn([]);
+
+        $this->logger->expects(self::once())
+            ->method('info');
+
+        $this->tool->search('test', -1);
+    }
+
+    public function testSearchNoResultsLogsInfo(): void
+    {
+        $this->embedding->expects(self::once())
+            ->method('embed')
+            ->willReturn(null);
+
+        $this->keywordSearch->expects(self::once())
+            ->method('search')
+            ->willReturn([]);
+
+        $this->logger->expects(self::once())
+            ->method('info')
+            ->with(
+                'Hybrid search returned no results for query',
+                self::callback(static fn (array $ctx): bool => $ctx['query'] === 'nothing'),
+            );
+
+        $result = $this->tool->search('nothing');
+        self::assertSame([], $result);
+    }
+
+    public function testSearchRespectsLimit(): void
+    {
+        $this->embedding->expects(self::once())
+            ->method('embed')
+            ->willReturn(null);
+
+        $this->keywordSearch->expects(self::once())
+            ->method('search')
+            ->with('test', null, 3)
+            ->willReturn([1, 2, 3, 4, 5]);
+
+        $articles = [];
+        for ($i = 1; $i <= 5; ++$i) {
+            $articles[] = $this->createArticle($i, "Article {$i}", "https://example.com/{$i}");
+        }
+
+        $this->articleRepository->expects(self::once())
+            ->method('findByIds')
+            ->with([1, 2, 3])
+            ->willReturn(array_slice($articles, 0, 3));
+
+        $results = $this->tool->search('test', null, 3);
+        self::assertCount(3, $results);
+    }
+
+    public function testSearchOutputFormat(): void
+    {
+        $this->embedding->expects(self::once())
+            ->method('embed')
+            ->willReturn(null);
+
+        $this->keywordSearch->expects(self::once())
+            ->method('search')
+            ->willReturn([1]);
+
+        $article = $this->createArticle(1, 'Test Title', 'https://example.com/1');
+        $article->setSummary('Test summary');
+        $article->setKeywords(['keyword1', 'keyword2']);
+        $article->setPublishedAt(new \DateTimeImmutable('2026-04-09T10:00:00+00:00'));
+
+        $this->articleRepository->expects(self::once())
+            ->method('findByIds')
+            ->willReturn([$article]);
+
+        $results = $this->tool->search('test');
+
+        self::assertCount(1, $results);
+        $result = $results[0];
+        self::assertSame(1, $result['id']);
+        self::assertSame('Test Title', $result['title']);
+        self::assertSame('Test summary', $result['summary']);
+        self::assertSame(['keyword1', 'keyword2'], $result['keywords']);
+        self::assertSame('2026-04-09T10:00:00+00:00', $result['publishedAt']);
+        self::assertSame('https://example.com/1', $result['url']);
+        self::assertSame(1.0, $result['score']);
+    }
+
+    public function testSearchArticleWithNullFieldsFormatsGracefully(): void
+    {
+        $this->embedding->expects(self::once())
+            ->method('embed')
+            ->willReturn(null);
+
+        $this->keywordSearch->expects(self::once())
+            ->method('search')
+            ->willReturn([1]);
+
+        $article = $this->createArticle(1, 'Title', 'https://example.com/1');
+        // summary, keywords, publishedAt are all null by default
+
+        $this->articleRepository->expects(self::once())
+            ->method('findByIds')
+            ->willReturn([$article]);
+
+        $results = $this->tool->search('test');
+
+        self::assertCount(1, $results);
+        self::assertNull($results[0]['summary']);
+        self::assertSame([], $results[0]['keywords']);
+        self::assertNull($results[0]['publishedAt']);
+    }
+
+    public function testSearchKeywordScoreDecaysByPosition(): void
+    {
+        $this->embedding->expects(self::once())
+            ->method('embed')
+            ->willReturn(null);
+
+        // 3 results from keyword search
+        $this->keywordSearch->expects(self::once())
+            ->method('search')
+            ->willReturn([10, 20, 30]);
+
+        $articles = [
+            $this->createArticle(10, 'First', 'https://example.com/10'),
+            $this->createArticle(20, 'Second', 'https://example.com/20'),
+            $this->createArticle(30, 'Third', 'https://example.com/30'),
+        ];
+
+        $this->articleRepository->expects(self::once())
+            ->method('findByIds')
+            ->willReturn($articles);
+
+        $results = $this->tool->search('test');
+
+        // Position 0: 1.0, Position 1: 0.95, Position 2: 0.90
+        self::assertSame(1.0, $results[0]['score']);
+        self::assertSame(0.95, $results[1]['score']);
+        self::assertSame(0.9, $results[2]['score']);
+    }
+
+    private function createArticle(int $id, string $title, string $url): Article
+    {
+        $source = $this->createStub(Source::class);
+        $source->method('getName')->willReturn('Test Source');
+
+        $article = new Article($title, $url, $source, new \DateTimeImmutable('2026-04-09'));
+
+        $reflection = new \ReflectionProperty(Article::class, 'id');
+        $reflection->setValue($article, $id);
+
+        return $article;
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `ArticleSearchTool` combining pgvector cosine similarity with existing Loupe keyword search
- Merges/deduplicates results by article ID, ranks by combined score with boost for dual-match articles
- Graceful degradation: keyword-only search when embedding model is unavailable or articles lack embeddings
- `ArticleContextFormatter` formats articles as structured data for LLM context
- `VectorSearchRepository` encapsulates pgvector raw SQL via DBAL Connection

## Files created

| File | Purpose |
|------|---------|
| `src/Chat/Tool/ArticleSearchToolInterface.php` | Public interface for hybrid search |
| `src/Chat/Tool/ArticleSearchTool.php` | Hybrid search implementation |
| `src/Chat/Tool/SearchDependencies.php` | Dependency bundle DTO |
| `src/Chat/Repository/VectorSearchRepositoryInterface.php` | pgvector query interface |
| `src/Chat/Repository/VectorSearchRepository.php` | pgvector DBAL implementation |
| `src/Chat/Service/ArticleContextFormatterInterface.php` | Article formatting interface |
| `src/Chat/Service/ArticleContextFormatter.php` | Formats articles for LLM context |
| `tests/Unit/Chat/Tool/ArticleSearchToolTest.php` | 12 test cases |
| `tests/Unit/Chat/Repository/VectorSearchRepositoryTest.php` | 5 test cases |
| `tests/Unit/Chat/Service/ArticleContextFormatterTest.php` | 7 test cases |

## Scoring algorithm

- **Semantic**: pgvector cosine similarity (0.0-1.0)
- **Keyword**: Position-based decay (1.0 for first, -0.05 per position)
- **Both found**: Sum of scores + 0.2 boost
- **Final**: Sorted descending, top N returned

## Test plan

- [x] `make quality` passes (ECS + PHPStan max + Rector)
- [x] `make test-unit` passes (932 tests, 2583 assertions)
- [x] `make test` passes (all suites)
- [x] `make infection` passes (Covered Code MSI: 90%)
- [x] Empty/whitespace query returns empty
- [x] Hybrid merge deduplicates and ranks correctly
- [x] Graceful degradation when embedding returns null
- [x] Date filtering via daysBack parameter
- [x] Zero/negative daysBack treated as no filter
- [x] Limit parameter respected
- [x] Null article fields handled gracefully
- [x] Keyword score decays by position
- [x] Vector search logs warning on DB error
- [x] Output format includes all required fields

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)