### PR TITLE
feat(ai): quality tracking for chat and embedding models (#191)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ src/
 - **Alert fixtures**: YAML-based alert rule definitions, loadable via `app:load-alert-rules`
 - **Keyword-first**: Alert rules always run keyword matching first; AI evaluation only on keyword matches (~10-20 calls/day)
 - **Auto-reindex**: Doctrine listener indexes articles on persist/update; daily full reindex via maintenance scheduler
-- **Model stats**: `app:ai-stats` command shows model quality metrics
+- **Model quality tracking**: `ModelQualityTracker` records accept/reject per model across three categories (`enrichment`, `chat`, `embedding`). Chat and embedding services auto-instrument. `app:ai-model-stats` and `/stats/ai` show per-category quality tables.
 - **Blocked models**: `OPENROUTER_BLOCKED_MODELS` env var (comma-separated) for persistent manual overrides
 
 ## Key Environment Variables

--- a/migrations/Version20260410230000.php
+++ b/migrations/Version20260410230000.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260410230000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add category column to model_quality_stat for chat/embedding quality tracking';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE model_quality_stat ADD category VARCHAR(32) NOT NULL DEFAULT 'enrichment'");
+        $this->addSql('DROP INDEX IF EXISTS UNIQ_model_quality_stat_model_id');
+        $this->addSql('ALTER TABLE model_quality_stat DROP CONSTRAINT IF EXISTS UNIQ_model_quality_stat_model_id');
+
+        // Remove old unique constraint on model_id alone (name varies by Doctrine version)
+        $this->addSql(<<<'SQL'
+            DO $$
+            DECLARE
+                constraint_name TEXT;
+            BEGIN
+                SELECT conname INTO constraint_name
+                FROM pg_constraint
+                WHERE conrelid = 'model_quality_stat'::regclass
+                  AND contype = 'u'
+                  AND array_length(conkey, 1) = 1;
+                IF constraint_name IS NOT NULL THEN
+                    EXECUTE 'ALTER TABLE model_quality_stat DROP CONSTRAINT ' || constraint_name;
+                END IF;
+            END $$
+        SQL);
+
+        $this->addSql('CREATE UNIQUE INDEX uniq_model_category ON model_quality_stat (model_id, category)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS uniq_model_category');
+        $this->addSql('ALTER TABLE model_quality_stat DROP COLUMN category');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_model_quality_stat_model_id ON model_quality_stat (model_id)');
+    }
+}

--- a/src/Chat/Service/ArticleChatService.php
+++ b/src/Chat/Service/ArticleChatService.php
@@ -8,7 +8,9 @@ use App\Chat\Store\ConversationMessageStoreInterface;
 use App\Chat\ValueObject\ChatResponse;
 use App\Shared\AI\Platform\ModelFailoverPlatform;
 use App\Shared\AI\Service\ModelDiscoveryServiceInterface;
+use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\AI\ValueObject\ModelId;
+use App\Shared\AI\ValueObject\ModelQualityCategory;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\InputProcessor\SystemPromptInputProcessor;
@@ -27,6 +29,7 @@ final readonly class ArticleChatService implements ArticleChatServiceInterface
         private PlatformInterface $innerPlatform,
         private ModelDiscoveryServiceInterface $modelDiscovery,
         private ToolboxInterface $toolbox,
+        private ModelQualityTrackerInterface $qualityTracker,
         private LoggerInterface $logger,
     ) {
     }
@@ -37,17 +40,9 @@ final readonly class ArticleChatService implements ArticleChatServiceInterface
         $history = $this->store->load();
 
         $messages = $this->buildPromptMessages($history, $userMessage);
-        $agent = $this->buildAgent();
-        $result = $agent->call($messages);
+        [$agent, $modelId] = $this->buildAgent();
 
-        $content = $result->getContent();
-        $answer = \is_string($content) ? $content : '';
-
-        $history->add(Message::ofUser($userMessage));
-        $history->add(Message::ofAssistant($answer));
-        $this->store->save($history);
-
-        return new ChatResponse($answer, $this->extractCitedArticleIds($answer), $conversationId);
+        return $this->executeChat($agent, $messages, $history, $userMessage, $conversationId, $modelId);
     }
 
     public function getHistory(string $conversationId): MessageBag
@@ -55,6 +50,37 @@ final readonly class ArticleChatService implements ArticleChatServiceInterface
         $this->store->setConversationId($conversationId);
 
         return $this->store->load();
+    }
+
+    private function executeChat(
+        Agent $agent,
+        MessageBag $messages,
+        MessageBag $history,
+        string $userMessage,
+        string $conversationId,
+        string $modelId,
+    ): ChatResponse {
+        try {
+            $result = $agent->call($messages);
+            $content = $result->getContent();
+            $answer = \is_string($content) ? $content : '';
+
+            $this->qualityTracker->recordAcceptance($modelId, ModelQualityCategory::Chat);
+        } catch (\Throwable $e) {
+            $this->qualityTracker->recordRejection($modelId, ModelQualityCategory::Chat);
+            $this->logger->error('Chat call failed for model {model}: {error}', [
+                'model' => $modelId,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+
+        $history->add(Message::ofUser($userMessage));
+        $history->add(Message::ofAssistant($answer));
+        $this->store->save($history);
+
+        return new ChatResponse($answer, $this->extractCitedArticleIds($answer), $conversationId);
     }
 
     private function buildPromptMessages(MessageBag $history, string $userMessage): MessageBag
@@ -65,20 +91,25 @@ final readonly class ArticleChatService implements ArticleChatServiceInterface
         return $messages;
     }
 
-    private function buildAgent(): Agent
+    /**
+     * @return array{0: Agent, 1: string}
+     */
+    private function buildAgent(): array
     {
         [$platform, $model] = $this->buildPlatformAndModel();
 
         $agentProcessor = new AgentProcessor($this->toolbox);
         $systemPrompt = new SystemPromptInputProcessor($this->getSystemPrompt(), $this->toolbox);
 
-        return new Agent(
+        $agent = new Agent(
             $platform,
             $model,
             [$systemPrompt, $agentProcessor],
             [$agentProcessor],
             'article_chat',
         );
+
+        return [$agent, $model];
     }
 
     /**

--- a/src/Chat/Service/EmbeddingService.php
+++ b/src/Chat/Service/EmbeddingService.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Chat\Service;
 
 use App\Shared\AI\Service\ModelDiscoveryServiceInterface;
+use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\AI\ValueObject\ModelId;
+use App\Shared\AI\ValueObject\ModelQualityCategory;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -14,6 +16,7 @@ final readonly class EmbeddingService implements EmbeddingServiceInterface
     public function __construct(
         private HttpClientInterface $httpClient,
         private ModelDiscoveryServiceInterface $modelDiscovery,
+        private ModelQualityTrackerInterface $qualityTracker,
         private LoggerInterface $logger,
     ) {
     }
@@ -64,13 +67,12 @@ final readonly class EmbeddingService implements EmbeddingServiceInterface
 
             $embedding = $data['data'][0]['embedding'] ?? null;
             if (! \is_array($embedding) || $embedding === []) {
-                $this->logger->warning('Empty embedding response from {model}', [
-                    'model' => $model->value,
-                ]);
+                $this->recordFailure($model->value, 'Empty embedding response');
 
                 return null;
             }
 
+            $this->qualityTracker->recordAcceptance($model->value, ModelQualityCategory::Embedding);
             $this->logger->debug('Generated embedding via {model} ({dimensions}d)', [
                 'model' => $model->value,
                 'dimensions' => \count($embedding),
@@ -78,12 +80,18 @@ final readonly class EmbeddingService implements EmbeddingServiceInterface
 
             return $embedding;
         } catch (\Throwable $e) {
-            $this->logger->warning('Embedding request failed for {model}: {error}', [
-                'model' => $model->value,
-                'error' => $e->getMessage(),
-            ]);
+            $this->recordFailure($model->value, $e->getMessage());
 
             return null;
         }
+    }
+
+    private function recordFailure(string $modelId, string $reason): void
+    {
+        $this->qualityTracker->recordRejection($modelId, ModelQualityCategory::Embedding);
+        $this->logger->warning('Embedding request failed for {model}: {error}', [
+            'model' => $modelId,
+            'error' => $reason,
+        ]);
     }
 }

--- a/src/Chat/Service/StreamingChatService.php
+++ b/src/Chat/Service/StreamingChatService.php
@@ -8,6 +8,8 @@ use App\Chat\Store\ConversationMessageStoreInterface;
 use App\Chat\Tool\ArticleSearchToolInterface;
 use App\Chat\ValueObject\AnswerCollector;
 use App\Chat\ValueObject\StreamContext;
+use App\Shared\AI\Service\ModelQualityTrackerInterface;
+use App\Shared\AI\ValueObject\ModelQualityCategory;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
@@ -22,6 +24,7 @@ final readonly class StreamingChatService implements StreamingChatServiceInterfa
         private PlatformInterface $platform,
         private ArticleSearchToolInterface $searchTool,
         private ChatModelResolverInterface $modelResolver,
+        private ModelQualityTrackerInterface $qualityTracker,
         private LoggerInterface $logger,
     ) {
     }
@@ -77,15 +80,17 @@ final readonly class StreamingChatService implements StreamingChatServiceInterfa
     private function streamFromPlatform(MessageBag $messages, StreamContext $ctx): \Generator
     {
         $collector = new AnswerCollector();
+        $model = $this->modelResolver->resolveModel();
 
         try {
-            $model = $this->modelResolver->resolveModel();
             $result = $this->platform->invoke($model, $messages, [
                 'stream' => true,
             ]);
 
             yield from $this->yieldTokens($result->getResult(), $collector);
+            $this->qualityTracker->recordAcceptance($model, ModelQualityCategory::Chat);
         } catch (\Throwable $e) {
+            $this->qualityTracker->recordRejection($model, ModelQualityCategory::Chat);
             $this->logger->error('Streaming chat failed: {error}', [
                 'error' => $e->getMessage(),
             ]);

--- a/src/Shared/AI/Command/AiModelStatsCommand.php
+++ b/src/Shared/AI/Command/AiModelStatsCommand.php
@@ -8,6 +8,8 @@ use App\Shared\AI\Service\ModelDiscoveryServiceInterface;
 use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\AI\ValueObject\ModelId;
 use App\Shared\AI\ValueObject\ModelIdCollection;
+use App\Shared\AI\ValueObject\ModelQualityCategory;
+use App\Shared\AI\ValueObject\ModelQualityStatsMap;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,7 +33,10 @@ final class AiModelStatsCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $this->showQualityStats($io);
+        $this->showCategoryStats($io, 'Enrichment', ModelQualityCategory::Enrichment);
+        $this->showCategoryStats($io, 'Chat', ModelQualityCategory::Chat);
+        $this->showCategoryStats($io, 'Embedding', ModelQualityCategory::Embedding);
+
         $this->showModelPool($io, 'free', $this->modelDiscovery->discoverFreeModels());
         $this->showModelPool($io, 'tool-calling', $this->modelDiscovery->discoverToolCallingModels());
         $this->showModelPool($io, 'embedding', $this->modelDiscovery->discoverEmbeddingModels());
@@ -39,15 +44,23 @@ final class AiModelStatsCommand extends Command
         return Command::SUCCESS;
     }
 
-    private function showQualityStats(SymfonyStyle $io): void
+    private function showCategoryStats(SymfonyStyle $io, string $title, ModelQualityCategory $category): void
     {
-        $stats = $this->qualityTracker->getAllStats();
+        $stats = $this->qualityTracker->getStatsByCategory($category);
+
+        $io->section($title . ' Model Quality');
+
         if ($stats->isEmpty()) {
-            $io->info('No model quality data yet.');
+            $io->text('No data yet.');
 
             return;
         }
 
+        $this->renderStatsTable($io, $stats);
+    }
+
+    private function renderStatsTable(SymfonyStyle $io, ModelQualityStatsMap $stats): void
+    {
         $rows = [];
         foreach ($stats as $modelId => $data) {
             $rows[] = [

--- a/src/Shared/AI/Entity/ModelQualityStat.php
+++ b/src/Shared/AI/Entity/ModelQualityStat.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'model_quality_stat')]
+#[ORM\UniqueConstraint(name: 'uniq_model_category', columns: ['model_id', 'category'])]
 class ModelQualityStat
 {
     #[ORM\Id]
@@ -16,8 +17,13 @@ class ModelQualityStat
     #[ORM\Column]
     private ?int $id = null;
 
-    #[ORM\Column(length: 255, unique: true)]
+    #[ORM\Column(length: 255)]
     private string $modelId;
+
+    #[ORM\Column(length: 32, options: [
+        'default' => 'enrichment',
+    ])]
+    private string $category;
 
     #[ORM\Column(type: Types::INTEGER, options: [
         'default' => 0,
@@ -32,10 +38,14 @@ class ModelQualityStat
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     private \DateTimeImmutable $updatedAt;
 
-    public function __construct(string $modelId, \DateTimeImmutable $updatedAt)
-    {
+    public function __construct(
+        string $modelId,
+        \DateTimeImmutable $updatedAt,
+        string $category = 'enrichment',
+    ) {
         $this->modelId = $modelId;
         $this->updatedAt = $updatedAt;
+        $this->category = $category;
     }
 
     public function getId(): ?int
@@ -46,6 +56,11 @@ class ModelQualityStat
     public function getModelId(): string
     {
         return $this->modelId;
+    }
+
+    public function getCategory(): string
+    {
+        return $this->category;
     }
 
     public function getAccepted(): int

--- a/src/Shared/AI/Repository/ModelQualityStatRepository.php
+++ b/src/Shared/AI/Repository/ModelQualityStatRepository.php
@@ -22,6 +22,15 @@ final class ModelQualityStatRepository extends ServiceEntityRepository implement
     {
         return $this->findOneBy([
             'modelId' => $modelId,
+            'category' => 'enrichment',
+        ]);
+    }
+
+    public function findByModelIdAndCategory(string $modelId, string $category): ?ModelQualityStat
+    {
+        return $this->findOneBy([
+            'modelId' => $modelId,
+            'category' => $category,
         ]);
     }
 
@@ -32,6 +41,17 @@ final class ModelQualityStatRepository extends ServiceEntityRepository implement
     {
         /** @var list<ModelQualityStat> */
         return parent::findAll();
+    }
+
+    /**
+     * @return list<ModelQualityStat>
+     */
+    public function findByCategory(string $category): array
+    {
+        /** @var list<ModelQualityStat> */
+        return $this->findBy([
+            'category' => $category,
+        ]);
     }
 
     public function save(ModelQualityStat $stat, bool $flush = false): void

--- a/src/Shared/AI/Repository/ModelQualityStatRepositoryInterface.php
+++ b/src/Shared/AI/Repository/ModelQualityStatRepositoryInterface.php
@@ -10,10 +10,17 @@ interface ModelQualityStatRepositoryInterface
 {
     public function findByModelId(string $modelId): ?ModelQualityStat;
 
+    public function findByModelIdAndCategory(string $modelId, string $category): ?ModelQualityStat;
+
     /**
      * @return list<ModelQualityStat>
      */
     public function findAll(): array;
+
+    /**
+     * @return list<ModelQualityStat>
+     */
+    public function findByCategory(string $category): array;
 
     public function save(ModelQualityStat $stat, bool $flush = false): void;
 

--- a/src/Shared/AI/Service/ModelQualityTracker.php
+++ b/src/Shared/AI/Service/ModelQualityTracker.php
@@ -6,6 +6,7 @@ namespace App\Shared\AI\Service;
 
 use App\Shared\AI\Entity\ModelQualityStat;
 use App\Shared\AI\Repository\ModelQualityStatRepositoryInterface;
+use App\Shared\AI\ValueObject\ModelQualityCategory;
 use App\Shared\AI\ValueObject\ModelQualityStats;
 use App\Shared\AI\ValueObject\ModelQualityStatsMap;
 use Psr\Clock\ClockInterface;
@@ -18,30 +19,26 @@ final class ModelQualityTracker implements ModelQualityTrackerInterface
     ) {
     }
 
-    public function recordAcceptance(string $modelId): void
+    public function recordAcceptance(string $modelId, ModelQualityCategory $category = ModelQualityCategory::Enrichment): void
     {
-        $stat = $this->findOrCreate($modelId);
+        $stat = $this->findOrCreate($modelId, $category);
         $stat->incrementAccepted($this->clock->now());
         $this->repository->save($stat, true);
     }
 
-    public function recordRejection(string $modelId): void
+    public function recordRejection(string $modelId, ModelQualityCategory $category = ModelQualityCategory::Enrichment): void
     {
-        $stat = $this->findOrCreate($modelId);
+        $stat = $this->findOrCreate($modelId, $category);
         $stat->incrementRejected($this->clock->now());
         $this->repository->save($stat, true);
     }
 
-    public function getStats(string $modelId): ModelQualityStats
+    public function getStats(string $modelId, ModelQualityCategory $category = ModelQualityCategory::Enrichment): ModelQualityStats
     {
-        $stat = $this->repository->findByModelId($modelId);
+        $stat = $this->repository->findByModelIdAndCategory($modelId, $category->value);
 
         if (! $stat instanceof ModelQualityStat) {
-            return new ModelQualityStats(
-                accepted: 0,
-                rejected: 0,
-                acceptanceRate: 0.0,
-            );
+            return new ModelQualityStats(accepted: 0, rejected: 0, acceptanceRate: 0.0);
         }
 
         return $this->toValueObject($stat);
@@ -52,16 +49,28 @@ final class ModelQualityTracker implements ModelQualityTrackerInterface
         $stats = [];
 
         foreach ($this->repository->findAll() as $stat) {
+            $key = $stat->getCategory() . ':' . $stat->getModelId();
+            $stats[$key] = $this->toValueObject($stat);
+        }
+
+        return new ModelQualityStatsMap($stats);
+    }
+
+    public function getStatsByCategory(ModelQualityCategory $category): ModelQualityStatsMap
+    {
+        $stats = [];
+
+        foreach ($this->repository->findByCategory($category->value) as $stat) {
             $stats[$stat->getModelId()] = $this->toValueObject($stat);
         }
 
         return new ModelQualityStatsMap($stats);
     }
 
-    private function findOrCreate(string $modelId): ModelQualityStat
+    private function findOrCreate(string $modelId, ModelQualityCategory $category): ModelQualityStat
     {
-        return $this->repository->findByModelId($modelId)
-            ?? new ModelQualityStat($modelId, $this->clock->now());
+        return $this->repository->findByModelIdAndCategory($modelId, $category->value)
+            ?? new ModelQualityStat($modelId, $this->clock->now(), $category->value);
     }
 
     private function toValueObject(ModelQualityStat $stat): ModelQualityStats

--- a/src/Shared/AI/Service/ModelQualityTrackerInterface.php
+++ b/src/Shared/AI/Service/ModelQualityTrackerInterface.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace App\Shared\AI\Service;
 
+use App\Shared\AI\ValueObject\ModelQualityCategory;
 use App\Shared\AI\ValueObject\ModelQualityStats;
 use App\Shared\AI\ValueObject\ModelQualityStatsMap;
 
 interface ModelQualityTrackerInterface
 {
-    public function recordAcceptance(string $modelId): void;
+    public function recordAcceptance(string $modelId, ModelQualityCategory $category = ModelQualityCategory::Enrichment): void;
 
-    public function recordRejection(string $modelId): void;
+    public function recordRejection(string $modelId, ModelQualityCategory $category = ModelQualityCategory::Enrichment): void;
 
-    public function getStats(string $modelId): ModelQualityStats;
+    public function getStats(string $modelId, ModelQualityCategory $category = ModelQualityCategory::Enrichment): ModelQualityStats;
 
     public function getAllStats(): ModelQualityStatsMap;
+
+    public function getStatsByCategory(ModelQualityCategory $category): ModelQualityStatsMap;
 }

--- a/src/Shared/AI/ValueObject/ModelQualityCategory.php
+++ b/src/Shared/AI/ValueObject/ModelQualityCategory.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\AI\ValueObject;
+
+enum ModelQualityCategory: string
+{
+    case Enrichment = 'enrichment';
+    case Chat = 'chat';
+    case Embedding = 'embedding';
+}

--- a/src/Shared/Controller/AiStatsController.php
+++ b/src/Shared/Controller/AiStatsController.php
@@ -6,6 +6,7 @@ namespace App\Shared\Controller;
 
 use App\Shared\AI\Service\ModelDiscoveryServiceInterface;
 use App\Shared\AI\Service\ModelQualityTrackerInterface;
+use App\Shared\AI\ValueObject\ModelQualityCategory;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -31,7 +32,9 @@ final class AiStatsController
             : [];
 
         return $this->controller->render('stats/ai.html.twig', [
-            'stats' => $this->qualityTracker->getAllStats(),
+            'enrichmentStats' => $this->qualityTracker->getStatsByCategory(ModelQualityCategory::Enrichment),
+            'chatStats' => $this->qualityTracker->getStatsByCategory(ModelQualityCategory::Chat),
+            'embeddingStats' => $this->qualityTracker->getStatsByCategory(ModelQualityCategory::Embedding),
             'freeModels' => $this->modelDiscovery->discoverFreeModels(),
             'primaryModel' => self::PRIMARY_MODEL,
             'blockedModels' => $blockedList,

--- a/templates/stats/ai.html.twig
+++ b/templates/stats/ai.html.twig
@@ -34,37 +34,9 @@
         </div>
     </div>
 
-    {% if stats is empty %}
-        <div class="alert alert-info mb-6">No model quality data yet. Stats populate after AI enrichment runs.</div>
-    {% else %}
-        <div class="overflow-x-auto mb-8">
-            <table class="table table-zebra">
-                <thead>
-                    <tr>
-                        <th>Model</th>
-                        <th>Accepted</th>
-                        <th>Rejected</th>
-                        <th>Rate</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for model, data in stats %}
-                        <tr>
-                            <td class="font-mono text-sm">{{ model }}</td>
-                            <td>{{ data.accepted }}</td>
-                            <td>{{ data.rejected }}</td>
-                            <td>
-                                <div class="flex items-center gap-2">
-                                    <progress class="progress {{ data.acceptanceRate > 0.7 ? 'progress-success' : (data.acceptanceRate > 0.4 ? 'progress-warning' : 'progress-error') }} w-20" value="{{ (data.acceptanceRate * 100)|round }}" max="100"></progress>
-                                    <span class="text-sm">{{ (data.acceptanceRate * 100)|round(1) }}%</span>
-                                </div>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    {% endif %}
+    {{ _self.stats_table('Enrichment', enrichmentStats) }}
+    {{ _self.stats_table('Chat', chatStats) }}
+    {{ _self.stats_table('Embedding', embeddingStats) }}
 
     <h2 class="text-xl font-bold mb-4">Available Free Models ({{ freeModels|length }})</h2>
     {% if freeModels is empty %}
@@ -76,4 +48,39 @@
             {% endfor %}
         </div>
     {% endif %}
+
+    {% macro stats_table(title, stats) %}
+        <h2 class="text-xl font-bold mb-4">{{ title }} Model Quality</h2>
+        {% if stats is empty %}
+            <div class="alert alert-info mb-6">No {{ title|lower }} model quality data yet.</div>
+        {% else %}
+            <div class="overflow-x-auto mb-8">
+                <table class="table table-zebra">
+                    <thead>
+                        <tr>
+                            <th>Model</th>
+                            <th>Accepted</th>
+                            <th>Rejected</th>
+                            <th>Rate</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for model, data in stats %}
+                            <tr>
+                                <td class="font-mono text-sm">{{ model }}</td>
+                                <td>{{ data.accepted }}</td>
+                                <td>{{ data.rejected }}</td>
+                                <td>
+                                    <div class="flex items-center gap-2">
+                                        <progress class="progress {{ data.acceptanceRate > 0.7 ? 'progress-success' : (data.acceptanceRate > 0.4 ? 'progress-warning' : 'progress-error') }} w-20" value="{{ (data.acceptanceRate * 100)|round }}" max="100"></progress>
+                                        <span class="text-sm">{{ (data.acceptanceRate * 100)|round(1) }}%</span>
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endif %}
+    {% endmacro %}
 {% endblock %}

--- a/tests/Unit/Chat/Service/ArticleChatServiceTest.php
+++ b/tests/Unit/Chat/Service/ArticleChatServiceTest.php
@@ -9,8 +9,10 @@ use App\Chat\Store\ConversationMessageStoreInterface;
 use App\Chat\ValueObject\ChatResponse;
 use App\Shared\AI\Platform\ModelFailoverPlatform;
 use App\Shared\AI\Service\ModelDiscoveryServiceInterface;
+use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\AI\ValueObject\ModelId;
 use App\Shared\AI\ValueObject\ModelIdCollection;
+use App\Shared\AI\ValueObject\ModelQualityCategory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +32,7 @@ use Symfony\AI\Platform\ResultConverterInterface;
 #[UsesClass(ModelFailoverPlatform::class)]
 #[UsesClass(ModelIdCollection::class)]
 #[UsesClass(ModelId::class)]
+#[UsesClass(ModelQualityCategory::class)]
 final class ArticleChatServiceTest extends TestCase
 {
     public function testChatReturnsResponseWithAnswer(): void
@@ -40,7 +43,7 @@ final class ArticleChatServiceTest extends TestCase
         $store->expects(self::once())->method('save')
             ->with(self::callback(static function (MessageBag $bag): bool {
                 $messages = $bag->getMessages();
-                // Must contain both user message and assistant reply
+
                 return \count($messages) >= 2;
             }));
 
@@ -48,9 +51,13 @@ final class ArticleChatServiceTest extends TestCase
         $discovery = $this->createToolCallingDiscovery(['model-a']);
         $toolbox = $this->createEmptyToolbox();
 
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::once())->method('recordAcceptance')
+            ->with('model-a', ModelQualityCategory::Chat);
+
         $logger = $this->createMock(LoggerInterface::class);
 
-        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $logger);
+        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $tracker, $logger);
         $response = $service->chat('What happened today?', 'conv-1');
 
         self::assertSame('This is the answer.', $response->answer);
@@ -68,10 +75,11 @@ final class ArticleChatServiceTest extends TestCase
         $platform = $this->createPlatformReturning($answer);
         $discovery = $this->createToolCallingDiscovery(['model-a']);
         $toolbox = $this->createEmptyToolbox();
+        $tracker = $this->createStub(ModelQualityTrackerInterface::class);
 
         $logger = $this->createStub(LoggerInterface::class);
 
-        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $logger);
+        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $tracker, $logger);
         $response = $service->chat('Tell me about AI', 'conv-2');
 
         self::assertSame([42, 99], $response->citedArticleIds);
@@ -87,8 +95,9 @@ final class ArticleChatServiceTest extends TestCase
         $platform = $this->createPlatformReturning($answer);
         $discovery = $this->createToolCallingDiscovery(['model-a']);
         $toolbox = $this->createEmptyToolbox();
+        $tracker = $this->createStub(ModelQualityTrackerInterface::class);
 
-        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $this->createStub(LoggerInterface::class));
+        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $tracker, $this->createStub(LoggerInterface::class));
         $response = $service->chat('query', 'conv-x');
 
         self::assertSame([7], $response->citedArticleIds);
@@ -104,11 +113,15 @@ final class ArticleChatServiceTest extends TestCase
         $discovery = $this->createToolCallingDiscovery([]);
         $toolbox = $this->createEmptyToolbox();
 
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::once())->method('recordAcceptance')
+            ->with('openrouter/free', ModelQualityCategory::Chat);
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('warning')
             ->with(self::stringContains('No tool-calling models'));
 
-        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $logger);
+        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $tracker, $logger);
         $response = $service->chat('Hello', 'conv-3');
 
         self::assertSame('Fallback answer.', $response->answer);
@@ -124,9 +137,10 @@ final class ArticleChatServiceTest extends TestCase
         $platform = $this->createStub(PlatformInterface::class);
         $discovery = $this->createStub(ModelDiscoveryServiceInterface::class);
         $toolbox = $this->createEmptyToolbox();
+        $tracker = $this->createStub(ModelQualityTrackerInterface::class);
         $logger = $this->createStub(LoggerInterface::class);
 
-        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $logger);
+        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $tracker, $logger);
         $result = $service->getHistory('conv-5');
 
         self::assertSame($expectedBag, $result);
@@ -141,10 +155,11 @@ final class ArticleChatServiceTest extends TestCase
         $platform = $this->createPlatformReturning('No articles found.');
         $discovery = $this->createToolCallingDiscovery(['model-a']);
         $toolbox = $this->createEmptyToolbox();
+        $tracker = $this->createStub(ModelQualityTrackerInterface::class);
 
         $logger = $this->createStub(LoggerInterface::class);
 
-        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $logger);
+        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $tracker, $logger);
         $response = $service->chat('random question', 'conv-6');
 
         self::assertSame([], $response->citedArticleIds);
@@ -159,10 +174,11 @@ final class ArticleChatServiceTest extends TestCase
         $platform = $this->createPlatformReturning('Multi-model answer.');
         $discovery = $this->createToolCallingDiscovery(['model-a', 'model-b', 'model-c']);
         $toolbox = $this->createEmptyToolbox();
+        $tracker = $this->createStub(ModelQualityTrackerInterface::class);
 
         $logger = $this->createStub(LoggerInterface::class);
 
-        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $logger);
+        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $tracker, $logger);
         $response = $service->chat('Hello', 'conv-7');
 
         self::assertSame('Multi-model answer.', $response->answer);
@@ -193,8 +209,9 @@ final class ArticleChatServiceTest extends TestCase
         $platform = $this->createPlatformReturning('Reply text.');
         $discovery = $this->createToolCallingDiscovery(['model-a']);
         $toolbox = $this->createEmptyToolbox();
+        $tracker = $this->createStub(ModelQualityTrackerInterface::class);
 
-        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $this->createStub(LoggerInterface::class));
+        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $tracker, $this->createStub(LoggerInterface::class));
         $service->chat('User message', 'conv-save');
     }
 
@@ -222,6 +239,7 @@ final class ArticleChatServiceTest extends TestCase
                     if (! $input instanceof MessageBag) {
                         return false;
                     }
+
                     return array_any($input->getMessages(), fn (object $msg): bool => $msg instanceof UserMessage);
                 }),
             )
@@ -229,8 +247,9 @@ final class ArticleChatServiceTest extends TestCase
 
         $discovery = $this->createToolCallingDiscovery(['model-a']);
         $toolbox = $this->createEmptyToolbox();
+        $tracker = $this->createStub(ModelQualityTrackerInterface::class);
 
-        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $this->createStub(LoggerInterface::class));
+        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $tracker, $this->createStub(LoggerInterface::class));
         $response = $service->chat('My question', 'conv-msg');
 
         self::assertSame('Answer.', $response->answer);
@@ -245,12 +264,42 @@ final class ArticleChatServiceTest extends TestCase
         $platform = $this->createPlatformReturning('');
         $discovery = $this->createToolCallingDiscovery(['model-a']);
         $toolbox = $this->createEmptyToolbox();
+        $tracker = $this->createStub(ModelQualityTrackerInterface::class);
 
-        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $this->createStub(LoggerInterface::class));
+        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $tracker, $this->createStub(LoggerInterface::class));
         $response = $service->chat('question', 'conv-8');
 
         self::assertSame('', $response->answer);
         self::assertSame([], $response->citedArticleIds);
+    }
+
+    public function testChatRecordsRejectionOnFailure(): void
+    {
+        $store = $this->createMock(ConversationMessageStoreInterface::class);
+        $store->method('load')->willReturn(new MessageBag());
+
+        $platform = $this->createStub(PlatformInterface::class);
+        $platform->method('invoke')->willThrowException(new \RuntimeException('API down'));
+
+        $discovery = $this->createToolCallingDiscovery(['model-a']);
+        $toolbox = $this->createEmptyToolbox();
+
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::once())->method('recordRejection')
+            ->with('model-a', ModelQualityCategory::Chat);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('error')
+            ->with(
+                self::stringContains('Chat call failed'),
+                self::callback(static fn (array $ctx): bool => $ctx['model'] === 'model-a' && $ctx['error'] === 'API down'),
+            );
+
+        $service = new ArticleChatService($store, $platform, $discovery, $toolbox, $tracker, $logger);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('API down');
+        $service->chat('Hello', 'conv-fail');
     }
 
     /**

--- a/tests/Unit/Chat/Service/EmbeddingServiceTest.php
+++ b/tests/Unit/Chat/Service/EmbeddingServiceTest.php
@@ -6,8 +6,10 @@ namespace App\Tests\Unit\Chat\Service;
 
 use App\Chat\Service\EmbeddingService;
 use App\Shared\AI\Service\ModelDiscoveryServiceInterface;
+use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\AI\ValueObject\ModelId;
 use App\Shared\AI\ValueObject\ModelIdCollection;
+use App\Shared\AI\ValueObject\ModelQualityCategory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
@@ -18,6 +20,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 #[CoversClass(EmbeddingService::class)]
 #[UsesClass(ModelId::class)]
 #[UsesClass(ModelIdCollection::class)]
+#[UsesClass(ModelQualityCategory::class)]
 final class EmbeddingServiceTest extends TestCase
 {
     public function testEmbedReturnsVectorOnSuccess(): void
@@ -34,6 +37,10 @@ final class EmbeddingServiceTest extends TestCase
             new ModelIdCollection([new ModelId('test-model')]),
         );
 
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::once())->method('recordAcceptance')
+            ->with('test-model', ModelQualityCategory::Embedding);
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('debug')
             ->with(
@@ -41,7 +48,7 @@ final class EmbeddingServiceTest extends TestCase
                 self::callback(static fn (array $ctx): bool => $ctx['model'] === 'test-model' && $ctx['dimensions'] === 3),
             );
 
-        $service = new EmbeddingService($httpClient, $discovery, $logger);
+        $service = new EmbeddingService($httpClient, $discovery, $tracker, $logger);
         $result = $service->embed('test text');
 
         self::assertSame($expectedEmbedding, $result);
@@ -51,10 +58,14 @@ final class EmbeddingServiceTest extends TestCase
     {
         $httpClient = new MockHttpClient();
         $discovery = $this->createStub(ModelDiscoveryServiceInterface::class);
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::never())->method('recordAcceptance');
+        $tracker->expects(self::never())->method('recordRejection');
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::never())->method('warning');
 
-        $service = new EmbeddingService($httpClient, $discovery, $logger);
+        $service = new EmbeddingService($httpClient, $discovery, $tracker, $logger);
 
         self::assertNull($service->embed(''));
     }
@@ -63,10 +74,14 @@ final class EmbeddingServiceTest extends TestCase
     {
         $httpClient = new MockHttpClient();
         $discovery = $this->createStub(ModelDiscoveryServiceInterface::class);
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::never())->method('recordAcceptance');
+        $tracker->expects(self::never())->method('recordRejection');
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::never())->method('warning');
 
-        $service = new EmbeddingService($httpClient, $discovery, $logger);
+        $service = new EmbeddingService($httpClient, $discovery, $tracker, $logger);
 
         self::assertNull($service->embed('   '));
     }
@@ -77,11 +92,15 @@ final class EmbeddingServiceTest extends TestCase
         $discovery = $this->createStub(ModelDiscoveryServiceInterface::class);
         $discovery->method('discoverEmbeddingModels')->willReturn(new ModelIdCollection());
 
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::never())->method('recordAcceptance');
+        $tracker->expects(self::never())->method('recordRejection');
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('warning')
             ->with('No embedding models available');
 
-        $service = new EmbeddingService($httpClient, $discovery, $logger);
+        $service = new EmbeddingService($httpClient, $discovery, $tracker, $logger);
 
         self::assertNull($service->embed('some text'));
     }
@@ -106,6 +125,12 @@ final class EmbeddingServiceTest extends TestCase
             new ModelIdCollection([new ModelId('failing-model'), new ModelId('working-model')]),
         );
 
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::once())->method('recordRejection')
+            ->with('failing-model', ModelQualityCategory::Embedding);
+        $tracker->expects(self::once())->method('recordAcceptance')
+            ->with('working-model', ModelQualityCategory::Embedding);
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('warning')
             ->with(
@@ -118,7 +143,7 @@ final class EmbeddingServiceTest extends TestCase
                 self::callback(static fn (array $ctx): bool => $ctx['model'] === 'working-model' && $ctx['dimensions'] === 2),
             );
 
-        $service = new EmbeddingService($httpClient, $discovery, $logger);
+        $service = new EmbeddingService($httpClient, $discovery, $tracker, $logger);
         $result = $service->embed('test text');
 
         self::assertSame($expectedEmbedding, $result);
@@ -141,11 +166,14 @@ final class EmbeddingServiceTest extends TestCase
             new ModelIdCollection([new ModelId('model-1'), new ModelId('model-2')]),
         );
 
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::exactly(2))->method('recordRejection');
+
         $logger = $this->createMock(LoggerInterface::class);
-        // Two failure warnings + one "all failed" warning
+        // Two per-model failure warnings + one "all failed" warning
         $logger->expects(self::exactly(3))->method('warning');
 
-        $service = new EmbeddingService($httpClient, $discovery, $logger);
+        $service = new EmbeddingService($httpClient, $discovery, $tracker, $logger);
 
         self::assertNull($service->embed('test text'));
     }
@@ -163,6 +191,10 @@ final class EmbeddingServiceTest extends TestCase
             new ModelIdCollection([new ModelId('test-model')]),
         );
 
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::once())->method('recordRejection')
+            ->with('test-model', ModelQualityCategory::Embedding);
+
         /** @var list<string> $warningMessages */
         $warningMessages = [];
         $logger = $this->createMock(LoggerInterface::class);
@@ -171,10 +203,10 @@ final class EmbeddingServiceTest extends TestCase
                 $warningMessages[] = $message;
             });
 
-        $service = new EmbeddingService($httpClient, $discovery, $logger);
+        $service = new EmbeddingService($httpClient, $discovery, $tracker, $logger);
 
         self::assertNull($service->embed('test text'));
-        self::assertStringContainsString('Empty embedding response', $warningMessages[0]);
+        self::assertStringContainsString('Embedding request failed', $warningMessages[0]);
         self::assertStringContainsString('All embedding models failed', $warningMessages[1]);
     }
 
@@ -189,10 +221,14 @@ final class EmbeddingServiceTest extends TestCase
             new ModelIdCollection([new ModelId('test-model')]),
         );
 
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::once())->method('recordRejection')
+            ->with('test-model', ModelQualityCategory::Embedding);
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::atLeastOnce())->method('warning');
 
-        $service = new EmbeddingService($httpClient, $discovery, $logger);
+        $service = new EmbeddingService($httpClient, $discovery, $tracker, $logger);
 
         self::assertNull($service->embed('test text'));
     }

--- a/tests/Unit/Chat/Service/StreamingChatServiceTest.php
+++ b/tests/Unit/Chat/Service/StreamingChatServiceTest.php
@@ -8,6 +8,8 @@ use App\Chat\Service\ChatModelResolverInterface;
 use App\Chat\Service\StreamingChatService;
 use App\Chat\Store\ConversationMessageStoreInterface;
 use App\Chat\Tool\ArticleSearchToolInterface;
+use App\Shared\AI\Service\ModelQualityTrackerInterface;
+use App\Shared\AI\ValueObject\ModelQualityCategory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -65,7 +67,11 @@ final class StreamingChatServiceTest extends TestCase
         $resolver = $this->createMock(ChatModelResolverInterface::class);
         $resolver->expects(self::once())->method('resolveModel')->willReturn('test/model');
 
-        $service = $this->buildService($store, $platform, $searchTool, $resolver);
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::once())->method('recordAcceptance')
+            ->with('test/model', ModelQualityCategory::Chat);
+
+        $service = $this->buildService($store, $platform, $searchTool, $resolver, $tracker);
         $chunks = iterator_to_array($service->stream('What happened?', 'conv-1'), false);
 
         self::assertCount(3, $chunks);
@@ -112,6 +118,10 @@ final class StreamingChatServiceTest extends TestCase
         $platform = $this->createStub(PlatformInterface::class);
         $platform->method('invoke')->willThrowException(new \RuntimeException('API down'));
 
+        $tracker = $this->createMock(ModelQualityTrackerInterface::class);
+        $tracker->expects(self::once())->method('recordRejection')
+            ->with('test/model', ModelQualityCategory::Chat);
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('error')
             ->with(
@@ -119,7 +129,7 @@ final class StreamingChatServiceTest extends TestCase
                 self::callback(static fn (array $ctx): bool => $ctx['error'] === 'API down'),
             );
 
-        $service = $this->buildService($store, $platform, $searchTool, logger: $logger);
+        $service = $this->buildService($store, $platform, $searchTool, tracker: $tracker, logger: $logger);
         $chunks = iterator_to_array($service->stream('Hello', 'conv-3'), false);
 
         self::assertCount(1, $chunks);
@@ -371,6 +381,7 @@ final class StreamingChatServiceTest extends TestCase
         PlatformInterface $platform,
         ArticleSearchToolInterface $searchTool,
         ?ChatModelResolverInterface $resolver = null,
+        ?ModelQualityTrackerInterface $tracker = null,
         ?LoggerInterface $logger = null,
     ): StreamingChatService {
         return new StreamingChatService(
@@ -378,6 +389,7 @@ final class StreamingChatServiceTest extends TestCase
             $platform,
             $searchTool,
             $resolver ?? $this->defaultResolver(),
+            $tracker ?? $this->createStub(ModelQualityTrackerInterface::class),
             $logger ?? $this->createStub(LoggerInterface::class),
         );
     }

--- a/tests/Unit/Shared/AI/Service/InMemoryModelQualityStatRepository.php
+++ b/tests/Unit/Shared/AI/Service/InMemoryModelQualityStatRepository.php
@@ -18,7 +18,14 @@ final class InMemoryModelQualityStatRepository implements ModelQualityStatReposi
 
     public function findByModelId(string $modelId): ?ModelQualityStat
     {
-        return $this->stats[$modelId] ?? null;
+        return $this->findByModelIdAndCategory($modelId, 'enrichment');
+    }
+
+    public function findByModelIdAndCategory(string $modelId, string $category): ?ModelQualityStat
+    {
+        $key = $category . ':' . $modelId;
+
+        return $this->stats[$key] ?? null;
     }
 
     /**
@@ -29,9 +36,21 @@ final class InMemoryModelQualityStatRepository implements ModelQualityStatReposi
         return array_values($this->stats);
     }
 
+    /**
+     * @return list<ModelQualityStat>
+     */
+    public function findByCategory(string $category): array
+    {
+        return array_values(array_filter(
+            $this->stats,
+            static fn (ModelQualityStat $stat): bool => $stat->getCategory() === $category,
+        ));
+    }
+
     public function save(ModelQualityStat $stat, bool $flush = false): void
     {
-        $this->stats[$stat->getModelId()] = $stat;
+        $key = $stat->getCategory() . ':' . $stat->getModelId();
+        $this->stats[$key] = $stat;
         $this->saveCount++;
     }
 

--- a/tests/Unit/Shared/AI/Service/ModelQualityTrackerTest.php
+++ b/tests/Unit/Shared/AI/Service/ModelQualityTrackerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Shared\AI\Service;
 
 use App\Shared\AI\Entity\ModelQualityStat;
 use App\Shared\AI\Service\ModelQualityTracker;
+use App\Shared\AI\ValueObject\ModelQualityCategory;
 use App\Shared\AI\ValueObject\ModelQualityStats;
 use App\Shared\AI\ValueObject\ModelQualityStatsMap;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -17,6 +18,7 @@ use Symfony\Component\Clock\MockClock;
 #[UsesClass(ModelQualityStat::class)]
 #[UsesClass(ModelQualityStats::class)]
 #[UsesClass(ModelQualityStatsMap::class)]
+#[UsesClass(ModelQualityCategory::class)]
 final class ModelQualityTrackerTest extends TestCase
 {
     private ModelQualityTracker $tracker;
@@ -62,8 +64,6 @@ final class ModelQualityTrackerTest extends TestCase
         $all = $this->tracker->getAllStats();
 
         self::assertCount(2, $all);
-        self::assertTrue($all->containsKey('model-x'));
-        self::assertTrue($all->containsKey('model-y'));
         self::assertContainsOnlyInstancesOf(ModelQualityStats::class, $all->toArray());
     }
 
@@ -95,7 +95,7 @@ final class ModelQualityTrackerTest extends TestCase
         $this->tracker->recordAcceptance('model-d');
         $this->tracker->recordAcceptance('model-d');
 
-        $all = $this->tracker->getAllStats();
+        $all = $this->tracker->getStatsByCategory(ModelQualityCategory::Enrichment);
 
         self::assertCount(1, $all);
         $stats = $all->get('model-d');
@@ -137,5 +137,118 @@ final class ModelQualityTrackerTest extends TestCase
         $this->tracker->recordRejection('model-b');
 
         self::assertSame(2, $this->repository->getSaveCount());
+    }
+
+    public function testRecordAcceptanceWithChatCategory(): void
+    {
+        $this->tracker->recordAcceptance('chat-model', ModelQualityCategory::Chat);
+        $this->tracker->recordAcceptance('chat-model', ModelQualityCategory::Chat);
+        $this->tracker->recordRejection('chat-model', ModelQualityCategory::Chat);
+
+        $stats = $this->tracker->getStats('chat-model', ModelQualityCategory::Chat);
+
+        self::assertSame(2, $stats->accepted);
+        self::assertSame(1, $stats->rejected);
+        self::assertEqualsWithDelta(0.6667, $stats->acceptanceRate, 0.001);
+    }
+
+    public function testRecordRejectionWithEmbeddingCategory(): void
+    {
+        $this->tracker->recordRejection('embed-model', ModelQualityCategory::Embedding);
+
+        $stats = $this->tracker->getStats('embed-model', ModelQualityCategory::Embedding);
+
+        self::assertSame(0, $stats->accepted);
+        self::assertSame(1, $stats->rejected);
+        self::assertSame(0.0, $stats->acceptanceRate);
+    }
+
+    public function testCategoriesAreIndependent(): void
+    {
+        $this->tracker->recordAcceptance('shared-model', ModelQualityCategory::Enrichment);
+        $this->tracker->recordRejection('shared-model', ModelQualityCategory::Chat);
+        $this->tracker->recordAcceptance('shared-model', ModelQualityCategory::Embedding);
+
+        $enrichment = $this->tracker->getStats('shared-model', ModelQualityCategory::Enrichment);
+        $chat = $this->tracker->getStats('shared-model', ModelQualityCategory::Chat);
+        $embedding = $this->tracker->getStats('shared-model', ModelQualityCategory::Embedding);
+
+        self::assertSame(1, $enrichment->accepted);
+        self::assertSame(0, $enrichment->rejected);
+        self::assertSame(1.0, $enrichment->acceptanceRate);
+
+        self::assertSame(0, $chat->accepted);
+        self::assertSame(1, $chat->rejected);
+        self::assertSame(0.0, $chat->acceptanceRate);
+
+        self::assertSame(1, $embedding->accepted);
+        self::assertSame(0, $embedding->rejected);
+        self::assertSame(1.0, $embedding->acceptanceRate);
+    }
+
+    public function testGetStatsByCategoryReturnsOnlyMatchingCategory(): void
+    {
+        $this->tracker->recordAcceptance('model-a', ModelQualityCategory::Enrichment);
+        $this->tracker->recordAcceptance('model-b', ModelQualityCategory::Chat);
+        $this->tracker->recordAcceptance('model-c', ModelQualityCategory::Embedding);
+
+        $chatStats = $this->tracker->getStatsByCategory(ModelQualityCategory::Chat);
+
+        self::assertCount(1, $chatStats);
+        self::assertTrue($chatStats->containsKey('model-b'));
+    }
+
+    public function testGetStatsByCategoryEmptyWhenNoMatchingRecords(): void
+    {
+        $this->tracker->recordAcceptance('model-a', ModelQualityCategory::Enrichment);
+
+        $chatStats = $this->tracker->getStatsByCategory(ModelQualityCategory::Chat);
+
+        self::assertCount(0, $chatStats);
+    }
+
+    public function testGetAllStatsIncludesAllCategories(): void
+    {
+        $this->tracker->recordAcceptance('model-a', ModelQualityCategory::Enrichment);
+        $this->tracker->recordAcceptance('model-b', ModelQualityCategory::Chat);
+        $this->tracker->recordAcceptance('model-c', ModelQualityCategory::Embedding);
+
+        $all = $this->tracker->getAllStats();
+
+        self::assertCount(3, $all);
+        self::assertTrue($all->containsKey('enrichment:model-a'));
+        self::assertTrue($all->containsKey('chat:model-b'));
+        self::assertTrue($all->containsKey('embedding:model-c'));
+    }
+
+    public function testDefaultCategoryIsEnrichment(): void
+    {
+        $this->tracker->recordAcceptance('model-x');
+
+        $enrichmentStats = $this->tracker->getStatsByCategory(ModelQualityCategory::Enrichment);
+        $chatStats = $this->tracker->getStatsByCategory(ModelQualityCategory::Chat);
+
+        self::assertCount(1, $enrichmentStats);
+        self::assertCount(0, $chatStats);
+    }
+
+    public function testGetStatsDefaultCategoryIsEnrichment(): void
+    {
+        $this->tracker->recordAcceptance('model-x');
+
+        $stats = $this->tracker->getStats('model-x');
+
+        self::assertSame(1, $stats->accepted);
+    }
+
+    public function testGetStatsForNonExistentCategoryReturnsZero(): void
+    {
+        $this->tracker->recordAcceptance('model-x', ModelQualityCategory::Enrichment);
+
+        $stats = $this->tracker->getStats('model-x', ModelQualityCategory::Chat);
+
+        self::assertSame(0, $stats->accepted);
+        self::assertSame(0, $stats->rejected);
+        self::assertSame(0.0, $stats->acceptanceRate);
     }
 }


### PR DESCRIPTION
## Summary

- Extend `ModelQualityTracker` to support three categories: `enrichment`, `chat`, `embedding` via new `ModelQualityCategory` enum
- Add `category` column to `model_quality_stat` entity with composite unique constraint `(model_id, category)`
- Instrument `ArticleChatService`, `StreamingChatService`, and `EmbeddingService` to auto-record accept/reject events
- Update `AiModelStatsCommand` and `/stats/ai` to display per-category quality tables
- Full backward compatibility: existing callers without category parameter default to `enrichment`

Closes #191

## Test plan

- [x] `make quality` passes (ECS + PHPStan max + Rector)
- [x] `make test-unit` passes (989 tests, 2808 assertions)
- [x] `make infection` passes (90% covered MSI, 100% mutation code coverage)
- [x] Migration applied successfully
- [ ] Verify `/stats/ai` page renders enrichment, chat, and embedding sections
- [ ] Verify `app:ai-model-stats` CLI shows three category sections

Generated with [Claude Code](https://claude.com/claude-code)