### PR TITLE
fix: increase max_execution_time for chat streaming endpoint

### DIFF
--- a/src/Chat/Controller/ChatController.php
+++ b/src/Chat/Controller/ChatController.php
@@ -71,6 +71,8 @@ final class ChatController
     #[Route('/chat/stream', name: 'app_chat_stream', methods: ['POST'])]
     public function stream(Request $request): Response
     {
+        set_time_limit(120);
+
         $data = $this->decodeRequest($request);
         if ($data === null) {
             return new JsonResponse([


### PR DESCRIPTION
## Summary

- Chat streaming fails with "Maximum execution time of 30 seconds exceeded" because free model rate limit retries consume the entire PHP time limit before streaming begins
- Adds `set_time_limit(120)` to the streaming endpoint to allow model failover time

Fixes #200

## Test plan

- [ ] Send a chat message when free models are rate-limited
- [ ] Verify status events stream during model retries
- [ ] Verify response arrives even after 30+ seconds of retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)