### PR TITLE
feat: add sentiment_score column to Article entity (#212)

### DIFF
--- a/migrations/Version20260411190000.php
+++ b/migrations/Version20260411190000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260411190000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add sentiment_score column to article entity';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE article ADD sentiment_score DOUBLE PRECISION DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_article_sentiment_score ON article (sentiment_score)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_article_sentiment_score');
+        $this->addSql('ALTER TABLE article DROP sentiment_score');
+    }
+}

--- a/src/Article/Entity/Article.php
+++ b/src/Article/Entity/Article.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(name: 'idx_article_fingerprint', columns: ['fingerprint'])]
 #[ORM\Index(name: 'idx_article_published_at', columns: ['published_at'])]
 #[ORM\Index(name: 'idx_article_url', columns: ['url'])]
+#[ORM\Index(name: 'idx_article_sentiment_score', columns: ['sentiment_score'])]
 class Article
 {
     #[ORM\Id]
@@ -45,6 +46,9 @@ class Article
 
     #[ORM\Column(type: Types::FLOAT, nullable: true)]
     private ?float $score = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true)]
+    private ?float $sentimentScore = null;
 
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(nullable: false)]
@@ -181,6 +185,20 @@ class Article
         }
 
         $this->score = $score;
+    }
+
+    public function getSentimentScore(): ?float
+    {
+        return $this->sentimentScore;
+    }
+
+    public function setSentimentScore(?float $sentimentScore): void
+    {
+        if ($sentimentScore !== null && ($sentimentScore < -1.0 || $sentimentScore > 1.0)) {
+            throw new \InvalidArgumentException(sprintf('Sentiment score must be between -1.0 and 1.0, got %f', $sentimentScore));
+        }
+
+        $this->sentimentScore = $sentimentScore;
     }
 
     public function getSource(): Source

--- a/src/Article/Repository/ArticleRepository.php
+++ b/src/Article/Repository/ArticleRepository.php
@@ -345,6 +345,17 @@ final class ArticleRepository extends ServiceEntityRepository implements Article
             ->getSingleColumnResult();
     }
 
+    public function findWithoutSentiment(int $limit): array
+    {
+        /** @var list<Article> */
+        return $this->createQueryBuilder('a')
+            ->where('a.sentimentScore IS NULL')
+            ->orderBy('a.publishedAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
     public function getEmbeddingStats(): array
     {
         $conn = $this->getEntityManager()->getConnection();

--- a/src/Article/Repository/ArticleRepositoryInterface.php
+++ b/src/Article/Repository/ArticleRepositoryInterface.php
@@ -88,4 +88,9 @@ interface ArticleRepositoryInterface
      * @return list<int>
      */
     public function findIdsWithoutEmbeddings(int $limit): array;
+
+    /**
+     * @return list<Article>
+     */
+    public function findWithoutSentiment(int $limit): array;
 }

--- a/tests/Unit/Article/Entity/ArticleTest.php
+++ b/tests/Unit/Article/Entity/ArticleTest.php
@@ -178,6 +178,79 @@ final class ArticleTest extends TestCase
         self::assertSame(EnrichmentStatus::Pending, $article->getEnrichmentStatus());
     }
 
+    public function testSetSentimentScoreValidRange(): void
+    {
+        $article = $this->createArticle();
+
+        $article->setSentimentScore(0.75);
+        self::assertSame(0.75, $article->getSentimentScore());
+    }
+
+    public function testSetSentimentScoreAcceptsNull(): void
+    {
+        $article = $this->createArticle();
+
+        $article->setSentimentScore(null);
+        self::assertNull($article->getSentimentScore());
+    }
+
+    public function testSetSentimentScoreAcceptsNegative(): void
+    {
+        $article = $this->createArticle();
+
+        $article->setSentimentScore(-0.5);
+        self::assertSame(-0.5, $article->getSentimentScore());
+    }
+
+    public function testSetSentimentScoreAcceptsBoundaryNegativeOne(): void
+    {
+        $article = $this->createArticle();
+
+        $article->setSentimentScore(-1.0);
+        self::assertSame(-1.0, $article->getSentimentScore());
+    }
+
+    public function testSetSentimentScoreAcceptsBoundaryPositiveOne(): void
+    {
+        $article = $this->createArticle();
+
+        $article->setSentimentScore(1.0);
+        self::assertSame(1.0, $article->getSentimentScore());
+    }
+
+    public function testSetSentimentScoreAcceptsBoundaryZero(): void
+    {
+        $article = $this->createArticle();
+
+        $article->setSentimentScore(0.0);
+        self::assertSame(0.0, $article->getSentimentScore());
+    }
+
+    public function testSetSentimentScoreRejectsAboveOne(): void
+    {
+        $article = $this->createArticle();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Sentiment score must be between -1.0 and 1.0');
+        $article->setSentimentScore(1.01);
+    }
+
+    public function testSetSentimentScoreRejectsBelowNegativeOne(): void
+    {
+        $article = $this->createArticle();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Sentiment score must be between -1.0 and 1.0');
+        $article->setSentimentScore(-1.01);
+    }
+
+    public function testConstructorDefaultsSentimentScoreToNull(): void
+    {
+        $article = $this->createArticle();
+
+        self::assertNull($article->getSentimentScore());
+    }
+
     public function testSetFingerprint(): void
     {
         $article = $this->createArticle();


### PR DESCRIPTION
## Summary
- Adds nullable `sentiment_score` float column (-1.0 to +1.0) to Article entity with range validation
- Doctrine migration adds column + index (`idx_article_sentiment_score`)
- `ArticleRepositoryInterface` gains `findWithoutSentiment(int $limit): list<Article>` for backfill use
- 9 unit tests for setter validation, null handling, and boundary values

Closes #212

## Test plan
- [x] Unit tests pass (1027 tests, 2973 assertions)
- [x] Integration tests pass (24 tests)
- [x] PHPStan level max — no errors
- [x] ECS — no errors
- [x] Rector — no changes
- [x] Infection MSI 90% / Covered MSI 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)