### PR TITLE
feat: AI sentiment scoring in enrichment pipeline (#213)

### DIFF
--- a/src/Enrichment/Service/AiCombinedEnrichmentService.php
+++ b/src/Enrichment/Service/AiCombinedEnrichmentService.php
@@ -24,6 +24,7 @@ Analyze the following news article and return a JSON object with exactly these f
 - "category": one of [politics, business, tech, science, sports, entertainment, health, world]
 - "summary": 1-2 concise sentences summarizing the key facts
 - "keywords": array of 3-5 key entities (people, organizations, places, topics)
+- "sentiment_score": float from -1.0 (very negative) to +1.0 (very positive), 0.0 = neutral
 
 Title: %s
 Content: %s
@@ -105,8 +106,9 @@ PROMPT;
         $categorySlug = $this->extractCategory($decoded);
         $summary = $this->extractSummary($decoded, $title);
         $keywords = $this->extractKeywords($decoded);
+        $sentimentScore = $this->extractSentiment($decoded);
 
-        $anyFieldFromAi = $categorySlug !== null || $summary !== null || $keywords !== [];
+        $anyFieldFromAi = $categorySlug !== null || $summary !== null || $keywords !== [] || $sentimentScore !== null;
 
         if ($anyFieldFromAi) {
             $this->qualityTracker->recordAcceptance($actualModel);
@@ -131,6 +133,7 @@ PROMPT;
             $keywords,
             $method,
             $anyFieldFromAi ? $actualModel : null,
+            $sentimentScore,
         );
     }
 
@@ -181,6 +184,25 @@ PROMPT;
         }
 
         return $this->keywordFilter->filter($keywords);
+    }
+
+    /**
+     * @param array<string, mixed> $decoded
+     */
+    private function extractSentiment(array $decoded): ?float
+    {
+        if (! isset($decoded['sentiment_score'])) {
+            return null;
+        }
+
+        $value = $decoded['sentiment_score'];
+        if (! is_int($value) && ! is_float($value)) {
+            return null;
+        }
+
+        $score = (float) $value;
+
+        return $this->qualityGate->validateSentiment($score) ? $score : null;
     }
 
     /**

--- a/src/Enrichment/Service/AiQualityGateService.php
+++ b/src/Enrichment/Service/AiQualityGateService.php
@@ -72,6 +72,11 @@ final readonly class AiQualityGateService implements AiQualityGateServiceInterfa
         return $this->categoryRepository->findBySlug($categorySlug) instanceof Category;
     }
 
+    public function validateSentiment(float $score): bool
+    {
+        return $score >= -1.0 && $score <= 1.0;
+    }
+
     private function containsReasoningArtifacts(string $summary): bool
     {
         $lower = mb_strtolower($summary);

--- a/src/Enrichment/Service/AiQualityGateServiceInterface.php
+++ b/src/Enrichment/Service/AiQualityGateServiceInterface.php
@@ -9,4 +9,6 @@ interface AiQualityGateServiceInterface
     public function validateSummary(string $summary, string $title): bool;
 
     public function validateCategorization(string $categorySlug): bool;
+
+    public function validateSentiment(float $score): bool;
 }

--- a/src/Enrichment/Service/ArticleEnrichmentService.php
+++ b/src/Enrichment/Service/ArticleEnrichmentService.php
@@ -29,6 +29,7 @@ final readonly class ArticleEnrichmentService implements ArticleEnrichmentServic
         $this->applyCategory($article, $result, $source);
         $this->applySummaryAndMethod($article, $result);
         $this->applyKeywords($article, $result);
+        $this->applySentiment($article, $result);
 
         $this->articleTranslation->applyTranslations($article, $source);
         $article->setScore($this->scoring->score($article));
@@ -62,6 +63,13 @@ final readonly class ArticleEnrichmentService implements ArticleEnrichmentServic
     {
         if ($result->keywords !== []) {
             $article->setKeywords($result->keywords);
+        }
+    }
+
+    private function applySentiment(Article $article, CombinedEnrichmentResult $result): void
+    {
+        if ($result->sentimentScore !== null) {
+            $article->setSentimentScore($result->sentimentScore);
         }
     }
 }

--- a/src/Enrichment/ValueObject/CombinedEnrichmentResult.php
+++ b/src/Enrichment/ValueObject/CombinedEnrichmentResult.php
@@ -17,6 +17,7 @@ final readonly class CombinedEnrichmentResult
         public array $keywords,
         public EnrichmentMethod $method,
         public ?string $modelUsed = null,
+        public ?float $sentimentScore = null,
     ) {
     }
 }

--- a/tests/Unit/Enrichment/Service/AiCombinedEnrichmentServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiCombinedEnrichmentServiceTest.php
@@ -849,6 +849,90 @@ final class AiCombinedEnrichmentServiceTest extends TestCase
         $service->enrich('Title', 'Content');
     }
 
+    public function testExtractsSentimentScoreFromAiResponse(): void
+    {
+        $json = json_encode([
+            'category' => 'tech',
+            'summary' => 'Google announced a new AI model for developers.',
+            'keywords' => ['Google', 'AI'],
+            'sentiment_score' => 0.75,
+        ], JSON_THROW_ON_ERROR);
+
+        $platform = new InMemoryPlatform($json);
+        $service = $this->createService($platform);
+
+        $result = $service->enrich('Google AI announcement', 'New AI model for developers');
+
+        self::assertSame(0.75, $result->sentimentScore);
+    }
+
+    public function testSentimentScoreNullWhenMissing(): void
+    {
+        $json = json_encode([
+            'category' => 'tech',
+            'summary' => 'Google announced a new AI model for developers.',
+            'keywords' => ['Google', 'AI'],
+        ], JSON_THROW_ON_ERROR);
+
+        $platform = new InMemoryPlatform($json);
+        $service = $this->createService($platform);
+
+        $result = $service->enrich('Google AI announcement', 'New AI model for developers');
+
+        self::assertNull($result->sentimentScore);
+    }
+
+    public function testSentimentScoreNullWhenOutOfRange(): void
+    {
+        $json = json_encode([
+            'category' => 'tech',
+            'summary' => 'Google announced a new AI model for developers.',
+            'keywords' => ['Google', 'AI'],
+            'sentiment_score' => 5.0,
+        ], JSON_THROW_ON_ERROR);
+
+        $platform = new InMemoryPlatform($json);
+        $service = $this->createService($platform);
+
+        $result = $service->enrich('Google AI announcement', 'New AI model for developers');
+
+        self::assertNull($result->sentimentScore);
+    }
+
+    public function testSentimentScoreNullWhenNotNumeric(): void
+    {
+        $json = json_encode([
+            'category' => 'tech',
+            'summary' => 'Google announced a new AI model for developers.',
+            'keywords' => ['Google', 'AI'],
+            'sentiment_score' => 'positive',
+        ], JSON_THROW_ON_ERROR);
+
+        $platform = new InMemoryPlatform($json);
+        $service = $this->createService($platform);
+
+        $result = $service->enrich('Google AI announcement', 'New AI model for developers');
+
+        self::assertNull($result->sentimentScore);
+    }
+
+    public function testNegativeSentimentScoreExtracted(): void
+    {
+        $json = json_encode([
+            'category' => 'politics',
+            'summary' => 'The government announced new sanctions against multiple countries.',
+            'keywords' => ['sanctions', 'government'],
+            'sentiment_score' => -0.8,
+        ], JSON_THROW_ON_ERROR);
+
+        $platform = new InMemoryPlatform($json);
+        $service = $this->createService($platform);
+
+        $result = $service->enrich('Sanctions Announcement', 'The government announced new sanctions');
+
+        self::assertSame(-0.8, $result->sentimentScore);
+    }
+
     private function createService(
         PlatformInterface $platform,
         ?ModelQualityTrackerInterface $tracker = null,
@@ -873,6 +957,9 @@ final class AiCombinedEnrichmentServiceTest extends TestCase
         );
         $qualityGate->method('validateSummary')->willReturnCallback(
             static fn (string $summary): bool => mb_strlen($summary) >= 20 && mb_strlen($summary) <= 500,
+        );
+        $qualityGate->method('validateSentiment')->willReturnCallback(
+            static fn (float $score): bool => $score >= -1.0 && $score <= 1.0,
         );
 
         return new AiCombinedEnrichmentService(
@@ -906,6 +993,9 @@ final class AiCombinedEnrichmentServiceTest extends TestCase
         );
         $qualityGate->method('validateSummary')->willReturnCallback(
             static fn (string $summary): bool => mb_strlen($summary) >= 20 && mb_strlen($summary) <= 500,
+        );
+        $qualityGate->method('validateSentiment')->willReturnCallback(
+            static fn (float $score): bool => $score >= -1.0 && $score <= 1.0,
         );
 
         return new AiCombinedEnrichmentService(

--- a/tests/Unit/Enrichment/Service/AiQualityGateServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiQualityGateServiceTest.php
@@ -284,6 +284,27 @@ final class AiQualityGateServiceTest extends TestCase
         ));
     }
 
+    public function testValidSentimentPasses(): void
+    {
+        self::assertTrue($this->gate->validateSentiment(0.5));
+        self::assertTrue($this->gate->validateSentiment(-0.5));
+        self::assertTrue($this->gate->validateSentiment(0.0));
+    }
+
+    public function testSentimentBoundariesPass(): void
+    {
+        self::assertTrue($this->gate->validateSentiment(-1.0));
+        self::assertTrue($this->gate->validateSentiment(1.0));
+    }
+
+    public function testSentimentOutOfRangeFails(): void
+    {
+        self::assertFalse($this->gate->validateSentiment(-1.01));
+        self::assertFalse($this->gate->validateSentiment(1.01));
+        self::assertFalse($this->gate->validateSentiment(5.0));
+        self::assertFalse($this->gate->validateSentiment(-5.0));
+    }
+
     public function testCleanSummaryStillPasses(): void
     {
         self::assertTrue($this->gate->validateSummary(

--- a/tests/Unit/Enrichment/Service/ArticleEnrichmentServiceTest.php
+++ b/tests/Unit/Enrichment/Service/ArticleEnrichmentServiceTest.php
@@ -32,6 +32,7 @@ final class ArticleEnrichmentServiceTest extends TestCase
             ['Google', 'AI'],
             EnrichmentMethod::Ai,
             'model-1',
+            0.65,
         );
 
         $combined = $this->createStub(CombinedEnrichmentServiceInterface::class);
@@ -60,6 +61,7 @@ final class ArticleEnrichmentServiceTest extends TestCase
         self::assertSame('A summary of the article.', $article->getSummary());
         self::assertSame(['Google', 'AI'], $article->getKeywords());
         self::assertSame(0.42, $article->getScore());
+        self::assertSame(0.65, $article->getSentimentScore());
     }
 
     public function testFallsBackToSourceCategoryWhenSlugNotFound(): void
@@ -128,6 +130,39 @@ final class ArticleEnrichmentServiceTest extends TestCase
 
         self::assertSame(EnrichmentMethod::Ai, $article->getEnrichmentMethod());
         self::assertSame('actual-model-id', $article->getAiModelUsed());
+    }
+
+    public function testSentimentScoreNotPersistedWhenNull(): void
+    {
+        $combinedResult = new CombinedEnrichmentResult(
+            'tech',
+            null,
+            [],
+            EnrichmentMethod::RuleBased,
+        );
+
+        $combined = $this->createStub(CombinedEnrichmentServiceInterface::class);
+        $combined->method('enrich')->willReturn($combinedResult);
+
+        $translation = $this->createStub(ArticleTranslationServiceInterface::class);
+        $scoring = $this->createStub(ScoringServiceInterface::class);
+        $scoring->method('score')->willReturn(0.0);
+
+        $category = new Category('Technology', 'tech', 1, '#000');
+        $categoryRepo = $this->createStub(CategoryRepositoryInterface::class);
+        $categoryRepo->method('findBySlug')->willReturn($category);
+
+        $source = $this->createStub(Source::class);
+        $source->method('getCategory')->willReturn($category);
+
+        $service = new ArticleEnrichmentService($combined, $translation, $scoring, $categoryRepo);
+
+        $article = $this->createArticle('Title', 'https://example.com/article');
+        $item = new FeedItem('Title', 'https://example.com/article', null, null, null);
+
+        $service->enrich($article, $item, $source);
+
+        self::assertNull($article->getSentimentScore());
     }
 
     private function createArticle(string $title, string $url): Article

--- a/tests/Unit/Enrichment/ValueObject/CombinedEnrichmentResultTest.php
+++ b/tests/Unit/Enrichment/ValueObject/CombinedEnrichmentResultTest.php
@@ -20,6 +20,7 @@ final class CombinedEnrichmentResultTest extends TestCase
             ['Google', 'AI'],
             EnrichmentMethod::Ai,
             'model-1',
+            0.75,
         );
 
         self::assertSame('tech', $result->categorySlug);
@@ -27,6 +28,7 @@ final class CombinedEnrichmentResultTest extends TestCase
         self::assertSame(['Google', 'AI'], $result->keywords);
         self::assertSame(EnrichmentMethod::Ai, $result->method);
         self::assertSame('model-1', $result->modelUsed);
+        self::assertSame(0.75, $result->sentimentScore);
     }
 
     public function testConstructsWithNullFields(): void
@@ -43,5 +45,6 @@ final class CombinedEnrichmentResultTest extends TestCase
         self::assertSame([], $result->keywords);
         self::assertSame(EnrichmentMethod::RuleBased, $result->method);
         self::assertNull($result->modelUsed);
+        self::assertNull($result->sentimentScore);
     }
 }


### PR DESCRIPTION
## Summary
- Extends AI enrichment prompt to extract `sentiment_score` (-1.0 to +1.0) at zero extra API cost
- Quality gate validates sentiment range; invalid values silently dropped (partial fallback)
- `ArticleEnrichmentService` persists sentiment to Article entity
- 8 new tests: sentiment extraction, null/missing/invalid/negative handling, quality gate validation

Closes #213

## Test plan
- [x] Unit tests pass (1036 tests, 2991 assertions)
- [x] PHPStan level max — no errors
- [x] ECS — no errors
- [x] Rector — no changes
- [x] Infection Covered MSI 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)