### PR TITLE
feat: rule-based sentiment scoring fallback (#214)

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -35,8 +35,10 @@ use App\Enrichment\Service\KeywordExtractionServiceInterface;
 use App\Enrichment\Service\RuleBasedCategorizationService;
 use App\Enrichment\Service\RuleBasedEnrichmentService;
 use App\Enrichment\Service\RuleBasedKeywordExtractionService;
+use App\Enrichment\Service\RuleBasedSentimentScoringService;
 use App\Enrichment\Service\RuleBasedSummarizationService;
 use App\Enrichment\Service\RuleBasedTranslationService;
+use App\Enrichment\Service\SentimentScoringServiceInterface;
 use App\Enrichment\Service\SummarizationServiceInterface;
 use App\Enrichment\Service\TranslationServiceInterface;
 use App\Notification\Command\LoadAlertRulesCommand;
@@ -242,6 +244,9 @@ return static function (ContainerConfigurator $container): void {
 
     // Chat stream publisher: publishes chat tokens to Mercure
     $services->alias(ChatStreamPublisherInterface::class, ChatStreamPublisher::class);
+
+    // SentimentScoringServiceInterface → RuleBasedSentimentScoringService
+    $services->alias(SentimentScoringServiceInterface::class, RuleBasedSentimentScoringService::class);
 
     // RuleBasedEnrichmentService: explicitly bind rule-based implementations (not AI decorators)
     $services->set(RuleBasedEnrichmentService::class)

--- a/src/Enrichment/Service/AiCombinedEnrichmentService.php
+++ b/src/Enrichment/Service/AiCombinedEnrichmentService.php
@@ -37,6 +37,7 @@ PROMPT;
         private CategorizationServiceInterface $categorizationFallback,
         private SummarizationServiceInterface $summarizationFallback,
         private KeywordExtractionServiceInterface $keywordExtractionFallback,
+        private SentimentScoringServiceInterface $sentimentFallback,
         private AiQualityGateServiceInterface $qualityGate,
         private ModelQualityTrackerInterface $qualityTracker,
         private AiTextCleanupServiceInterface $textCleanup,
@@ -124,6 +125,7 @@ PROMPT;
         if ($keywords === []) {
             $keywords = $this->keywordExtractionFallback->extract($title, $contentText);
         }
+        $sentimentScore ??= $this->sentimentFallback->score($title, $contentText);
 
         $method = $anyFieldFromAi ? EnrichmentMethod::Ai : EnrichmentMethod::RuleBased;
 
@@ -236,6 +238,7 @@ PROMPT;
             ? $this->summarizationFallback->summarize($contentText, $title)
             : null;
         $keywords = $this->keywordExtractionFallback->extract($title, $contentText);
+        $sentimentScore = $this->sentimentFallback->score($title, $contentText);
 
         $method = $catResult->method === EnrichmentMethod::Ai
             || ($sumResult instanceof EnrichmentResult && $sumResult->method === EnrichmentMethod::Ai)
@@ -250,6 +253,7 @@ PROMPT;
             $keywords,
             $method,
             $modelUsed,
+            $sentimentScore,
         );
     }
 }

--- a/src/Enrichment/Service/RuleBasedEnrichmentService.php
+++ b/src/Enrichment/Service/RuleBasedEnrichmentService.php
@@ -18,6 +18,7 @@ final readonly class RuleBasedEnrichmentService implements RuleBasedEnrichmentSe
         private CategorizationServiceInterface $categorization,
         private SummarizationServiceInterface $summarization,
         private KeywordExtractionServiceInterface $keywordExtraction,
+        private SentimentScoringServiceInterface $sentimentScoring,
         private ScoringServiceInterface $scoring,
         private CategoryRepositoryInterface $categoryRepository,
     ) {
@@ -28,6 +29,7 @@ final readonly class RuleBasedEnrichmentService implements RuleBasedEnrichmentSe
         $this->applyCategory($article, $item, $source);
         $this->applySummary($article, $item);
         $this->applyKeywords($article, $item);
+        $this->applySentiment($article, $item);
 
         $article->setEnrichmentMethod(EnrichmentMethod::RuleBased);
         $article->setScore($this->scoring->score($article));
@@ -68,6 +70,15 @@ final readonly class RuleBasedEnrichmentService implements RuleBasedEnrichmentSe
 
         if ($keywords !== []) {
             $article->setKeywords($keywords);
+        }
+    }
+
+    private function applySentiment(Article $article, FeedItem $item): void
+    {
+        $score = $this->sentimentScoring->score($item->title, $item->contentText);
+
+        if ($score !== null) {
+            $article->setSentimentScore($score);
         }
     }
 }

--- a/src/Enrichment/Service/RuleBasedSentimentScoringService.php
+++ b/src/Enrichment/Service/RuleBasedSentimentScoringService.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enrichment\Service;
+
+final readonly class RuleBasedSentimentScoringService implements SentimentScoringServiceInterface
+{
+    private const float MAX_SCORE = 0.8;
+
+    private const int TITLE_WEIGHT = 2;
+
+    private const array POSITIVE_KEYWORDS = [
+        'breakthrough', 'success', 'win', 'growth', 'improve', 'gain', 'boost',
+        'advance', 'achieve', 'celebrate', 'thrive', 'prosper', 'benefit', 'progress',
+        'innovation', 'optimism', 'recovery', 'upgrade', 'milestone', 'soar',
+        'record high', 'surge', 'positive', 'hope', 'opportunity', 'triumph',
+        'solution', 'award', 'praise', 'hero',
+    ];
+
+    private const array NEGATIVE_KEYWORDS = [
+        'crisis', 'crash', 'fail', 'loss', 'decline', 'drop', 'threat', 'attack',
+        'disaster', 'collapse', 'scandal', 'fraud', 'death', 'kill', 'war',
+        'recession', 'layoff', 'bankrupt', 'shutdown', 'breach', 'exploit',
+        'record low', 'plunge', 'negative', 'fear', 'danger', 'tragedy',
+        'devastation', 'victim', 'condemn', 'riot',
+    ];
+
+    public function score(string $title, ?string $contentText): ?float
+    {
+        $titleLower = mb_strtolower($title);
+        $contentLower = $contentText !== null ? mb_strtolower($contentText) : '';
+
+        $positiveCount = $this->countMatches($titleLower, self::POSITIVE_KEYWORDS) * self::TITLE_WEIGHT
+            + $this->countMatches($contentLower, self::POSITIVE_KEYWORDS);
+
+        $negativeCount = $this->countMatches($titleLower, self::NEGATIVE_KEYWORDS) * self::TITLE_WEIGHT
+            + $this->countMatches($contentLower, self::NEGATIVE_KEYWORDS);
+
+        $total = $positiveCount + $negativeCount;
+
+        if ($total === 0) {
+            return null;
+        }
+
+        $raw = ($positiveCount - $negativeCount) / $total;
+
+        return max(-self::MAX_SCORE, min(self::MAX_SCORE, $raw));
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    private function countMatches(string $text, array $keywords): int
+    {
+        $count = 0;
+
+        foreach ($keywords as $keyword) {
+            if (str_contains($text, $keyword)) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/src/Enrichment/Service/SentimentScoringServiceInterface.php
+++ b/src/Enrichment/Service/SentimentScoringServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enrichment\Service;
+
+interface SentimentScoringServiceInterface
+{
+    public function score(string $title, ?string $contentText): ?float;
+}

--- a/tests/Integration/Enrichment/BatchEnrichmentPipelineTest.php
+++ b/tests/Integration/Enrichment/BatchEnrichmentPipelineTest.php
@@ -15,6 +15,7 @@ use App\Enrichment\Service\ArticleTranslationService;
 use App\Enrichment\Service\CategorizationServiceInterface;
 use App\Enrichment\Service\KeywordExtractionServiceInterface;
 use App\Enrichment\Service\KeywordFilterService;
+use App\Enrichment\Service\SentimentScoringServiceInterface;
 use App\Enrichment\Service\SummarizationServiceInterface;
 use App\Enrichment\Service\TranslationServiceInterface;
 use App\Enrichment\ValueObject\BatchTranslationResult;
@@ -85,11 +86,15 @@ final class BatchEnrichmentPipelineTest extends TestCase
         $keywordFallback = $this->createMock(KeywordExtractionServiceInterface::class);
         $keywordFallback->expects(self::never())->method('extract');
 
+        $sentimentFallback = $this->createStub(SentimentScoringServiceInterface::class);
+        $sentimentFallback->method('score')->willReturn(null);
+
         $combinedEnrichment = new AiCombinedEnrichmentService(
             $platform,
             $categorizationFallback,
             $summarizationFallback,
             $keywordFallback,
+            $sentimentFallback,
             $qualityGate,
             $qualityTracker,
             $textCleanup,
@@ -195,11 +200,15 @@ final class BatchEnrichmentPipelineTest extends TestCase
         $keywordFallback = $this->createStub(KeywordExtractionServiceInterface::class);
         $keywordFallback->method('extract')->willReturn([]);
 
+        $sentimentFallback = $this->createStub(SentimentScoringServiceInterface::class);
+        $sentimentFallback->method('score')->willReturn(null);
+
         $combinedEnrichment = new AiCombinedEnrichmentService(
             $platform,
             $categorizationFallback,
             $summarizationFallback,
             $keywordFallback,
+            $sentimentFallback,
             $qualityGate,
             $qualityTracker,
             $textCleanup,

--- a/tests/Unit/Enrichment/Service/AiCombinedEnrichmentServiceTest.php
+++ b/tests/Unit/Enrichment/Service/AiCombinedEnrichmentServiceTest.php
@@ -10,6 +10,7 @@ use App\Enrichment\Service\AiTextCleanupService;
 use App\Enrichment\Service\CategorizationServiceInterface;
 use App\Enrichment\Service\KeywordExtractionServiceInterface;
 use App\Enrichment\Service\KeywordFilterService;
+use App\Enrichment\Service\SentimentScoringServiceInterface;
 use App\Enrichment\Service\SummarizationServiceInterface;
 use App\Enrichment\ValueObject\CombinedEnrichmentResult;
 use App\Enrichment\ValueObject\EnrichmentResult;
@@ -962,11 +963,15 @@ final class AiCombinedEnrichmentServiceTest extends TestCase
             static fn (float $score): bool => $score >= -1.0 && $score <= 1.0,
         );
 
+        $sentimentFallback = $this->createStub(SentimentScoringServiceInterface::class);
+        $sentimentFallback->method('score')->willReturn(null);
+
         return new AiCombinedEnrichmentService(
             $platform,
             $categorization,
             $summarization,
             $keywordExtraction,
+            $sentimentFallback,
             $qualityGate,
             $tracker ?? $this->createStub(ModelQualityTrackerInterface::class),
             new AiTextCleanupService(),
@@ -998,11 +1003,15 @@ final class AiCombinedEnrichmentServiceTest extends TestCase
             static fn (float $score): bool => $score >= -1.0 && $score <= 1.0,
         );
 
+        $sentimentFallback = $this->createStub(SentimentScoringServiceInterface::class);
+        $sentimentFallback->method('score')->willReturn(null);
+
         return new AiCombinedEnrichmentService(
             $platform,
             $categorization,
             $summarization,
             $keywordExtraction,
+            $sentimentFallback,
             $qualityGate,
             $this->createStub(ModelQualityTrackerInterface::class),
             new AiTextCleanupService(),

--- a/tests/Unit/Enrichment/Service/RuleBasedEnrichmentServiceTest.php
+++ b/tests/Unit/Enrichment/Service/RuleBasedEnrichmentServiceTest.php
@@ -9,6 +9,7 @@ use App\Article\Service\ScoringServiceInterface;
 use App\Enrichment\Service\CategorizationServiceInterface;
 use App\Enrichment\Service\KeywordExtractionServiceInterface;
 use App\Enrichment\Service\RuleBasedEnrichmentService;
+use App\Enrichment\Service\SentimentScoringServiceInterface;
 use App\Enrichment\Service\SummarizationServiceInterface;
 use App\Enrichment\ValueObject\EnrichmentResult;
 use App\Shared\Entity\Category;
@@ -53,7 +54,10 @@ final class RuleBasedEnrichmentServiceTest extends TestCase
         $scoring = $this->createStub(ScoringServiceInterface::class);
         $scoring->method('score')->willReturn(0.5);
 
-        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $scoring, $categoryRepo);
+        $sentimentScoring = $this->createStub(SentimentScoringServiceInterface::class);
+        $sentimentScoring->method('score')->willReturn(null);
+
+        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $sentimentScoring, $scoring, $categoryRepo);
         $service->enrich($article, $item, $source);
 
         self::assertSame($category, $article->getCategory());
@@ -84,7 +88,10 @@ final class RuleBasedEnrichmentServiceTest extends TestCase
         $scoring = $this->createStub(ScoringServiceInterface::class);
         $scoring->method('score')->willReturn(0.3);
 
-        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $scoring, $categoryRepo);
+        $sentimentScoring = $this->createStub(SentimentScoringServiceInterface::class);
+        $sentimentScoring->method('score')->willReturn(null);
+
+        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $sentimentScoring, $scoring, $categoryRepo);
         $service->enrich($article, $item, $source);
 
         self::assertSame($sourceCategory, $article->getCategory());
@@ -114,7 +121,10 @@ final class RuleBasedEnrichmentServiceTest extends TestCase
         $scoring = $this->createStub(ScoringServiceInterface::class);
         $scoring->method('score')->willReturn(0.6);
 
-        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $scoring, $categoryRepo);
+        $sentimentScoring = $this->createStub(SentimentScoringServiceInterface::class);
+        $sentimentScoring->method('score')->willReturn(null);
+
+        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $sentimentScoring, $scoring, $categoryRepo);
         $service->enrich($article, $item, $source);
 
         self::assertSame('Generated summary.', $article->getSummary());
@@ -141,7 +151,10 @@ final class RuleBasedEnrichmentServiceTest extends TestCase
         $scoring = $this->createStub(ScoringServiceInterface::class);
         $scoring->method('score')->willReturn(0.4);
 
-        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $scoring, $categoryRepo);
+        $sentimentScoring = $this->createStub(SentimentScoringServiceInterface::class);
+        $sentimentScoring->method('score')->willReturn(null);
+
+        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $sentimentScoring, $scoring, $categoryRepo);
         $service->enrich($article, $item, $source);
 
         self::assertNull($article->getSummary());
@@ -171,7 +184,10 @@ final class RuleBasedEnrichmentServiceTest extends TestCase
         $scoring = $this->createStub(ScoringServiceInterface::class);
         $scoring->method('score')->willReturn(0.7);
 
-        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $scoring, $categoryRepo);
+        $sentimentScoring = $this->createStub(SentimentScoringServiceInterface::class);
+        $sentimentScoring->method('score')->willReturn(null);
+
+        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $sentimentScoring, $scoring, $categoryRepo);
         $service->enrich($article, $item, $source);
 
         self::assertSame(['Google', 'AI'], $article->getKeywords());
@@ -200,7 +216,10 @@ final class RuleBasedEnrichmentServiceTest extends TestCase
         $scoring = $this->createStub(ScoringServiceInterface::class);
         $scoring->method('score')->willReturn(0.3);
 
-        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $scoring, $categoryRepo);
+        $sentimentScoring = $this->createStub(SentimentScoringServiceInterface::class);
+        $sentimentScoring->method('score')->willReturn(null);
+
+        $service = new RuleBasedEnrichmentService($categorization, $summarization, $keywords, $sentimentScoring, $scoring, $categoryRepo);
         $service->enrich($article, $item, $source);
 
         self::assertNull($article->getKeywords());

--- a/tests/Unit/Enrichment/Service/RuleBasedSentimentScoringServiceTest.php
+++ b/tests/Unit/Enrichment/Service/RuleBasedSentimentScoringServiceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Enrichment\Service;
+
+use App\Enrichment\Service\RuleBasedSentimentScoringService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RuleBasedSentimentScoringService::class)]
+final class RuleBasedSentimentScoringServiceTest extends TestCase
+{
+    private RuleBasedSentimentScoringService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new RuleBasedSentimentScoringService();
+    }
+
+    public function testPositiveHeadlineReturnsPositiveScore(): void
+    {
+        $score = $this->service->score('Major breakthrough in cancer research', null);
+
+        self::assertNotNull($score);
+        self::assertGreaterThan(0.0, $score);
+    }
+
+    public function testNegativeHeadlineReturnsNegativeScore(): void
+    {
+        $score = $this->service->score('Economic crisis deepens as markets crash', null);
+
+        self::assertNotNull($score);
+        self::assertLessThan(0.0, $score);
+    }
+
+    public function testNeutralHeadlineReturnsNull(): void
+    {
+        $score = $this->service->score('City council meets Tuesday afternoon', null);
+
+        self::assertNull($score);
+    }
+
+    public function testTitleWeightedHigherThanContent(): void
+    {
+        // "breakthrough" in title (weight 2) vs "crisis" in content (weight 1)
+        $score = $this->service->score('Breakthrough in science', 'There was a crisis in the past');
+
+        self::assertNotNull($score);
+        self::assertGreaterThan(0.0, $score);
+    }
+
+    public function testScoreCappedAtPositive08(): void
+    {
+        $score = $this->service->score(
+            'Success! Win! Growth! Breakthrough! Achievement!',
+            'Amazing progress and innovation with optimism and recovery',
+        );
+
+        self::assertNotNull($score);
+        self::assertLessThanOrEqual(0.8, $score);
+    }
+
+    public function testScoreCappedAtNegative08(): void
+    {
+        $score = $this->service->score(
+            'Crisis! Crash! Disaster! War! Death!',
+            'Collapse and scandal with fraud and recession and layoff',
+        );
+
+        self::assertNotNull($score);
+        self::assertGreaterThanOrEqual(-0.8, $score);
+    }
+
+    public function testMixedSentimentReturnsBalancedScore(): void
+    {
+        $score = $this->service->score(
+            'Market crash followed by rapid recovery',
+            null,
+        );
+
+        self::assertNotNull($score);
+        // Both positive and negative keywords found, result depends on balance
+        self::assertGreaterThanOrEqual(-0.8, $score);
+        self::assertLessThanOrEqual(0.8, $score);
+    }
+
+    public function testContentTextAddsSentiment(): void
+    {
+        $titleOnly = $this->service->score('News update', null);
+        $withContent = $this->service->score('News update', 'There was a major breakthrough today');
+
+        self::assertNull($titleOnly);
+        self::assertNotNull($withContent);
+        self::assertGreaterThan(0.0, $withContent);
+    }
+
+    public function testCaseInsensitiveMatching(): void
+    {
+        $score = $this->service->score('MAJOR BREAKTHROUGH IN SCIENCE', null);
+
+        self::assertNotNull($score);
+        self::assertGreaterThan(0.0, $score);
+    }
+}


### PR DESCRIPTION
## Summary
- New `RuleBasedSentimentScoringService` with ~30 positive + ~30 negative keyword lists
- Title weighted 2x, scores normalized and capped at ±0.8 (reserves ±0.9-1.0 for AI)
- Returns null when no sentiment keywords found (neutral articles unaffected)
- Integrated into `RuleBasedEnrichmentService` and as partial fallback in `AiCombinedEnrichmentService`
- 9 new tests for the sentiment service, updated existing tests for new constructor params

Closes #214

## Test plan
- [x] Unit tests pass (1045 tests, 3014 assertions)
- [x] PHPStan level max — no errors
- [x] ECS — no errors
- [x] Rector — no changes
- [x] Infection Covered MSI 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)