### PR TITLE
feat: dashboard article ranking by sentiment slider (#216)

### DIFF
--- a/src/Article/Repository/ArticleRepository.php
+++ b/src/Article/Repository/ArticleRepository.php
@@ -9,6 +9,7 @@ use App\User\Entity\User;
 use App\User\Entity\UserArticleBookmark;
 use App\User\Entity\UserArticleRead;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -117,15 +118,15 @@ final class ArticleRepository extends ServiceEntityRepository implements Article
     /**
      * @return list<Article>
      */
-    public function findPaginated(?string $categorySlug, ?User $unreadForUser, int $page, int $limit, ?int $sourceId = null, ?User $bookmarkedForUser = null): array
+    public function findPaginated(?string $categorySlug, ?User $unreadForUser, int $page, int $limit, ?int $sourceId = null, ?User $bookmarkedForUser = null, ?int $sentimentSlider = null): array
     {
         $qb = $this->createQueryBuilder('a')
             ->leftJoin('a.category', 'c')
             ->leftJoin('a.source', 's')
-            ->orderBy('CASE WHEN a.publishedAt IS NOT NULL THEN a.publishedAt ELSE a.fetchedAt END', 'DESC')
-            ->addOrderBy('a.score', 'DESC')
             ->setFirstResult(($page - 1) * $limit)
             ->setMaxResults($limit);
+
+        $this->applySentimentOrdering($qb, $sentimentSlider);
 
         if ($categorySlug !== null && $categorySlug !== '') {
             $qb->andWhere('c.slug = :cat')->setParameter('cat', $categorySlug);
@@ -382,5 +383,35 @@ final class ArticleRepository extends ServiceEntityRepository implements Article
             'with_embedding' => (int) $result['with_embedding'],
             'without_embedding' => (int) $result['without_embedding'],
         ];
+    }
+
+    private function applySentimentOrdering(QueryBuilder $qb, ?int $sentimentSlider): void
+    {
+        if ($sentimentSlider === null || $sentimentSlider === 0) {
+            $qb->orderBy('CASE WHEN a.publishedAt IS NOT NULL THEN a.publishedAt ELSE a.fetchedAt END', 'DESC')
+                ->addOrderBy('a.score', 'DESC');
+
+            return;
+        }
+
+        $sliderFactor = $sentimentSlider / 10.0;
+
+        // At ±6-10: filter out opposite sentiment articles (null sentiment always included)
+        if (abs($sentimentSlider) >= 6) {
+            if ($sentimentSlider > 0) {
+                $qb->andWhere('a.sentimentScore IS NULL OR a.sentimentScore >= :sentimentThreshold')
+                    ->setParameter('sentimentThreshold', -0.3);
+            } else {
+                $qb->andWhere('a.sentimentScore IS NULL OR a.sentimentScore <= :sentimentThreshold')
+                    ->setParameter('sentimentThreshold', 0.3);
+            }
+        }
+
+        // Boost matching sentiment via ORDER BY: sentiment_boost = COALESCE(sentiment_score, 0) * sliderFactor
+        $qb->addSelect('(COALESCE(a.sentimentScore, 0) * :sliderFactor) AS HIDDEN sentimentBoost')
+            ->setParameter('sliderFactor', $sliderFactor)
+            ->orderBy('sentimentBoost', 'DESC')
+            ->addOrderBy('CASE WHEN a.publishedAt IS NOT NULL THEN a.publishedAt ELSE a.fetchedAt END', 'DESC')
+            ->addOrderBy('a.score', 'DESC');
     }
 }

--- a/src/Article/Repository/ArticleRepositoryInterface.php
+++ b/src/Article/Repository/ArticleRepositoryInterface.php
@@ -42,7 +42,7 @@ interface ArticleRepositoryInterface
     /**
      * @return list<Article>
      */
-    public function findPaginated(?string $categorySlug, ?User $unreadForUser, int $page, int $limit, ?int $sourceId = null, ?User $bookmarkedForUser = null): array;
+    public function findPaginated(?string $categorySlug, ?User $unreadForUser, int $page, int $limit, ?int $sourceId = null, ?User $bookmarkedForUser = null, ?int $sentimentSlider = null): array;
 
     public function countSince(\DateTimeImmutable $since): int;
 

--- a/src/Shared/Controller/DashboardController.php
+++ b/src/Shared/Controller/DashboardController.php
@@ -8,6 +8,7 @@ use App\Article\Entity\Article;
 use App\Article\Repository\ArticleRepositoryInterface;
 use App\Notification\Repository\NotificationLogRepositoryInterface;
 use App\Shared\Repository\CategoryRepositoryInterface;
+use App\Shared\Service\SettingsServiceInterface;
 use App\Source\Repository\SourceRepositoryInterface;
 use App\User\Entity\User;
 use App\User\Repository\UserArticleBookmarkRepositoryInterface;
@@ -29,6 +30,7 @@ final class DashboardController
         private readonly SourceRepositoryInterface $sourceRepository,
         private readonly CategoryRepositoryInterface $categoryRepository,
         private readonly NotificationLogRepositoryInterface $notificationLogRepository,
+        private readonly SettingsServiceInterface $settingsService,
         private readonly ClockInterface $clock,
     ) {
     }
@@ -52,6 +54,8 @@ final class DashboardController
 
         $user = $this->controller->getUser();
 
+        $sentimentSlider = $this->settingsService->getSentimentSlider();
+
         $articles = $this->articleRepository->findPaginated(
             $category,
             $unreadOnly && $user instanceof User ? $user : null,
@@ -59,6 +63,7 @@ final class DashboardController
             $limit,
             $source,
             $bookmarkedOnly && $user instanceof User ? $user : null,
+            $sentimentSlider !== 0 ? $sentimentSlider : null,
         );
 
         // Build read-state and bookmark-state sets for the current user

--- a/tests/Unit/Shared/Controller/DashboardControllerTest.php
+++ b/tests/Unit/Shared/Controller/DashboardControllerTest.php
@@ -8,6 +8,7 @@ use App\Article\Repository\ArticleRepositoryInterface;
 use App\Notification\Repository\NotificationLogRepositoryInterface;
 use App\Shared\Controller\DashboardController;
 use App\Shared\Repository\CategoryRepositoryInterface;
+use App\Shared\Service\SettingsServiceInterface;
 use App\Source\Repository\SourceRepositoryInterface;
 use App\User\Entity\User;
 use App\User\Repository\UserArticleBookmarkRepositoryInterface;
@@ -71,6 +72,8 @@ final class DashboardControllerTest extends TestCase
         $this->sourceRepository = $this->createMock(SourceRepositoryInterface::class);
         $this->categoryRepository = $this->createMock(CategoryRepositoryInterface::class);
         $this->notificationLogRepository = $this->createMock(NotificationLogRepositoryInterface::class);
+        $settingsService = $this->createStub(SettingsServiceInterface::class);
+        $settingsService->method('getSentimentSlider')->willReturn(0);
         $this->clock = new MockClock(new \DateTimeImmutable('2026-04-06 14:30:00', new \DateTimeZone('UTC')));
 
         $this->controller = new DashboardController(
@@ -81,6 +84,7 @@ final class DashboardControllerTest extends TestCase
             $this->sourceRepository,
             $this->categoryRepository,
             $this->notificationLogRepository,
+            $settingsService,
             $this->clock,
         );
     }


### PR DESCRIPTION
## Summary
- `findPaginated()` gains optional `?int $sentimentSlider` parameter
- Slider 0: no change (zero regression)
- Slider ±1-5: boost matching sentiment articles via computed ORDER BY column
- Slider ±6-10: also filter out opposite sentiment articles (null sentiment always included)
- Formula: `COALESCE(sentiment_score, 0) * sliderFactor` as primary ORDER BY

Closes #216

## Test plan
- [x] Unit tests pass (1054 tests, 3043 assertions)
- [x] PHPStan level max — no errors
- [x] ECS — no errors
- [x] Rector — no changes
- [x] Infection Covered MSI 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)