### PR TITLE
feat: OpenAI-compatible AI provider (vLLM) configurable in Settings UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ OPENROUTER_API_KEY=
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 OPENROUTER_BLOCKED_MODELS=
 
+# AI provider defaults (overridable in Settings UI)
+AI_PROVIDER=openrouter
+AI_OPENAI_BASE_URL=
+AI_OPENAI_API_KEY=
+AI_OPENAI_MODEL=
+
 # Notifications (install desired transport package)
 # Pushover: pushover://USER_KEY:APP_TOKEN@default
 # Slack: slack://TOKEN@default?channel=CHANNEL

--- a/config/services.php
+++ b/config/services.php
@@ -46,6 +46,8 @@ use App\Notification\Service\AiAlertEvaluationService;
 use App\Notification\Service\NotificationDispatchService;
 use App\Shared\AI\Command\AiSmokeTestCommand;
 use App\Shared\AI\Platform\ModelFailoverPlatform;
+use App\Shared\AI\Platform\OpenAiCompatiblePlatform;
+use App\Shared\AI\Platform\SettingsRoutedPlatform;
 use App\Shared\AI\Service\ModelDiscoveryService;
 use App\Shared\Controller\AiStatsController;
 use App\Shared\Controller\SettingsController;
@@ -153,45 +155,51 @@ return static function (ContainerConfigurator $container): void {
         ->arg('$queueAccelerateThreshold', '%env(int:QUEUE_ACCELERATE_THRESHOLD)%')
         ->arg('$queueSkipFreeThreshold', '%env(int:QUEUE_SKIP_FREE_THRESHOLD)%');
 
-    // All AI services use the failover-wrapped platform
+    $services->set('ai.platform.openai_compatible', OpenAiCompatiblePlatform::class);
+
+    $services->set('ai.platform.settings_routed', SettingsRoutedPlatform::class)
+        ->arg('$openRouterFailover', service('ai.platform.openrouter.failover'))
+        ->arg('$openAiCompatiblePlatform', service('ai.platform.openai_compatible'));
+
+    // All AI services use the settings-routed platform (OpenRouter or OpenAI-compatible API)
     $services->set(AiCategorizationService::class)
         ->arg('$ruleBasedFallback', service(RuleBasedCategorizationService::class))
-        ->arg('$platform', service('ai.platform.openrouter.failover'));
+        ->arg('$platform', service('ai.platform.settings_routed'));
 
     $services->set(AiSummarizationService::class)
         ->arg('$ruleBasedFallback', service(RuleBasedSummarizationService::class))
-        ->arg('$platform', service('ai.platform.openrouter.failover'));
+        ->arg('$platform', service('ai.platform.settings_routed'));
 
     $services->set(AiTranslationService::class)
         ->arg('$ruleBasedFallback', service(RuleBasedTranslationService::class))
-        ->arg('$platform', service('ai.platform.openrouter.failover'));
+        ->arg('$platform', service('ai.platform.settings_routed'));
 
     $services->set(AiKeywordExtractionService::class)
         ->arg('$ruleBasedFallback', service(RuleBasedKeywordExtractionService::class))
-        ->arg('$platform', service('ai.platform.openrouter.failover'));
+        ->arg('$platform', service('ai.platform.settings_routed'));
 
     $services->set(AiCombinedEnrichmentService::class)
         ->arg('$categorizationFallback', service(AiCategorizationService::class))
         ->arg('$summarizationFallback', service(AiSummarizationService::class))
         ->arg('$keywordExtractionFallback', service(AiKeywordExtractionService::class))
-        ->arg('$platform', service('ai.platform.openrouter.failover'));
+        ->arg('$platform', service('ai.platform.settings_routed'));
 
     $services->set(AiBatchTranslationService::class)
         ->arg('$translationFallback', service(AiTranslationService::class))
-        ->arg('$platform', service('ai.platform.openrouter.failover'));
+        ->arg('$platform', service('ai.platform.settings_routed'));
 
     $services->set(AiDeduplicationService::class)
         ->arg('$ruleBasedFallback', service(DeduplicationService::class))
-        ->arg('$platform', service('ai.platform.openrouter.failover'));
+        ->arg('$platform', service('ai.platform.settings_routed'));
 
     $services->set(AiAlertEvaluationService::class)
-        ->arg('$platform', service('ai.platform.openrouter.failover'));
+        ->arg('$platform', service('ai.platform.settings_routed'));
 
     $services->set(DigestSummaryService::class)
-        ->arg('$platform', service('ai.platform.openrouter.failover'));
+        ->arg('$platform', service('ai.platform.settings_routed'));
 
     $services->set(AiSmokeTestCommand::class)
-        ->arg('$platform', service('ai.platform.openrouter.failover'));
+        ->arg('$platform', service('ai.platform.settings_routed'));
 
     // Wire admin email for LoadAlertRulesCommand
     $services->set(LoadAlertRulesCommand::class)
@@ -222,7 +230,13 @@ return static function (ContainerConfigurator $container): void {
         ->arg('$displayLanguages', '%env(string:DISPLAY_LANGUAGES)%')
         ->arg('$fetchDefaultInterval', '%env(int:FETCH_DEFAULT_INTERVAL_MINUTES)%')
         ->arg('$retentionArticles', '%env(int:RETENTION_ARTICLES)%')
-        ->arg('$retentionLogs', '%env(int:RETENTION_LOGS)%');
+        ->arg('$retentionLogs', '%env(int:RETENTION_LOGS)%')
+        ->arg('$defaultAiProvider', '%env(default:ai_provider_default:AI_PROVIDER)%')
+        ->arg('$defaultAiOpenAiBaseUrl', '%env(default::AI_OPENAI_BASE_URL)%')
+        ->arg('$defaultAiOpenAiApiKey', '%env(default::AI_OPENAI_API_KEY)%')
+        ->arg('$defaultAiOpenAiModel', '%env(default::AI_OPENAI_MODEL)%');
+
+    $container->parameters()->set('ai_provider_default', 'openrouter');
 
     $services->alias(SettingsServiceInterface::class, SettingsService::class);
 
@@ -263,7 +277,7 @@ return static function (ContainerConfigurator $container): void {
 
     // Chat: ArticleChatService uses inner OpenRouter platform for tool-calling agent
     $services->set(ArticleChatService::class)
-        ->arg('$innerPlatform', service('ai.platform.openrouter'))
+        ->arg('$innerPlatform', service('ai.platform.settings_routed'))
         ->arg('$toolbox', service('chat.toolbox'));
 
     $services->alias(ArticleChatServiceInterface::class, ArticleChatService::class);

--- a/config/services.php
+++ b/config/services.php
@@ -295,7 +295,7 @@ return static function (ContainerConfigurator $container): void {
 
     // Chat: streaming service uses platform directly (bypasses Agent for real SSE streaming)
     $services->set(StreamingChatService::class)
-        ->arg('$platform', service('ai.platform.openrouter'));
+        ->arg('$platform', service('ai.platform.settings_routed'));
 
     $services->alias(StreamingChatServiceInterface::class, StreamingChatService::class);
 

--- a/config/services.php
+++ b/config/services.php
@@ -240,21 +240,23 @@ return static function (ContainerConfigurator $container): void {
     $container->parameters()->set('ai_openai_base_url_default', '');
     $container->parameters()->set('ai_openai_api_key_default', '');
     $container->parameters()->set('ai_openai_model_default', '');
+    $container->parameters()->set('openrouter_api_key_default', '');
+    $container->parameters()->set('notifier_dsn_default', 'null://null');
 
     $services->alias(SettingsServiceInterface::class, SettingsService::class);
 
     // Wire env vars for SettingsController
     $services->set(SettingsController::class)
-        ->arg('$openrouterApiKey', '%env(default::OPENROUTER_API_KEY)%')
-        ->arg('$notifierDsn', '%env(default::NOTIFIER_CHATTER_DSN)%');
+        ->arg('$openrouterApiKey', '%env(default:openrouter_api_key_default:OPENROUTER_API_KEY)%')
+        ->arg('$notifierDsn', '%env(default:notifier_dsn_default:NOTIFIER_CHATTER_DSN)%');
 
     // Wire notifier DSN for TestNotificationController (to detect null transport)
     $services->set(TestNotificationController::class)
-        ->arg('$notifierDsn', '%env(default::NOTIFIER_CHATTER_DSN)%');
+        ->arg('$notifierDsn', '%env(default:notifier_dsn_default:NOTIFIER_CHATTER_DSN)%');
 
     // Wire notifier DSN for NotificationDispatchService (to detect null transport)
     $services->set(NotificationDispatchService::class)
-        ->arg('$notifierDsn', '%env(default::NOTIFIER_CHATTER_DSN)%');
+        ->arg('$notifierDsn', '%env(default:notifier_dsn_default:NOTIFIER_CHATTER_DSN)%');
 
     // Mercure publisher: real implementation when Hub is available
     $services->alias(MercurePublisherServiceInterface::class, MercurePublisherService::class);

--- a/config/services.php
+++ b/config/services.php
@@ -232,11 +232,14 @@ return static function (ContainerConfigurator $container): void {
         ->arg('$retentionArticles', '%env(int:RETENTION_ARTICLES)%')
         ->arg('$retentionLogs', '%env(int:RETENTION_LOGS)%')
         ->arg('$defaultAiProvider', '%env(default:ai_provider_default:AI_PROVIDER)%')
-        ->arg('$defaultAiOpenAiBaseUrl', '%env(default::AI_OPENAI_BASE_URL)%')
-        ->arg('$defaultAiOpenAiApiKey', '%env(default::AI_OPENAI_API_KEY)%')
-        ->arg('$defaultAiOpenAiModel', '%env(default::AI_OPENAI_MODEL)%');
+        ->arg('$defaultAiOpenAiBaseUrl', '%env(default:ai_openai_base_url_default:AI_OPENAI_BASE_URL)%')
+        ->arg('$defaultAiOpenAiApiKey', '%env(default:ai_openai_api_key_default:AI_OPENAI_API_KEY)%')
+        ->arg('$defaultAiOpenAiModel', '%env(default:ai_openai_model_default:AI_OPENAI_MODEL)%');
 
     $container->parameters()->set('ai_provider_default', 'openrouter');
+    $container->parameters()->set('ai_openai_base_url_default', '');
+    $container->parameters()->set('ai_openai_api_key_default', '');
+    $container->parameters()->set('ai_openai_model_default', '');
 
     $services->alias(SettingsServiceInterface::class, SettingsService::class);
 

--- a/src/Chat/Service/ArticleChatService.php
+++ b/src/Chat/Service/ArticleChatService.php
@@ -12,6 +12,7 @@ use App\Shared\AI\Service\ModelQualityTrackerInterface;
 use App\Shared\AI\ValueObject\ModelId;
 use App\Shared\AI\ValueObject\ModelQualityCategory;
 use App\Shared\Service\SettingsServiceInterface;
+use App\Shared\ValueObject\AiProvider;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Agent\Agent;
 use Symfony\AI\Agent\InputProcessor\SystemPromptInputProcessor;
@@ -119,6 +120,14 @@ final readonly class ArticleChatService implements ArticleChatServiceInterface
      */
     private function buildPlatformAndModel(): array
     {
+        if ($this->settingsService->getAiProvider() === AiProvider::OpenAi
+            && $this->settingsService->isOpenAiConfigured()) {
+            $model = $this->settingsService->getOpenAiModel();
+            \assert($model !== '');
+
+            return [$this->innerPlatform, $model];
+        }
+
         $models = $this->modelDiscovery->discoverToolCallingModels();
         $modelIds = array_map(
             static fn (ModelId $m): string => $m->value,

--- a/src/Chat/Service/ChatModelResolver.php
+++ b/src/Chat/Service/ChatModelResolver.php
@@ -6,6 +6,8 @@ namespace App\Chat\Service;
 
 use App\Shared\AI\Service\ModelDiscoveryServiceInterface;
 use App\Shared\AI\ValueObject\ModelId;
+use App\Shared\Service\SettingsServiceInterface;
+use App\Shared\ValueObject\AiProvider;
 
 final readonly class ChatModelResolver implements ChatModelResolverInterface
 {
@@ -13,6 +15,7 @@ final readonly class ChatModelResolver implements ChatModelResolverInterface
 
     public function __construct(
         private ModelDiscoveryServiceInterface $modelDiscovery,
+        private SettingsServiceInterface $settings,
         private string $paidFallbackModel = '',
     ) {
     }
@@ -29,6 +32,13 @@ final readonly class ChatModelResolver implements ChatModelResolverInterface
      */
     public function resolveModelChain(): array
     {
+        if ($this->settings->getAiProvider() === AiProvider::OpenAi && $this->settings->isOpenAiConfigured()) {
+            $model = $this->settings->getOpenAiModel();
+            \assert($model !== '');
+
+            return [$model];
+        }
+
         $models = $this->modelDiscovery->discoverToolCallingModels();
 
         /** @var list<non-empty-string> $modelIds */

--- a/src/Chat/Service/StreamingChatService.php
+++ b/src/Chat/Service/StreamingChatService.php
@@ -83,8 +83,8 @@ final readonly class StreamingChatService implements StreamingChatServiceInterfa
 
     private function streamFromPlatform(MessageBag $messages, StreamContext $ctx): void
     {
-        $collector = new AnswerCollector();
         $modelChain = $this->modelResolver->resolveModelChain();
+        $lastError = null;
 
         foreach ($modelChain as $index => $model) {
             $this->publisher->publishStatus(
@@ -93,30 +93,93 @@ final readonly class StreamingChatService implements StreamingChatServiceInterfa
             );
 
             try {
-                $result = $this->platform->invoke($model, $messages, [
-                    'stream' => true,
-                ]);
-
-                foreach ($result->asStream() as $chunk) {
-                    if (\is_string($chunk)) {
-                        $collector->append($chunk);
-                        $this->publisher->publishToken($ctx->conversationId, $chunk);
-                    }
+                if ($this->attemptModel($model, $messages, $ctx)) {
+                    return;
                 }
-
-                $this->qualityTracker->recordAcceptance($model, ModelQualityCategory::Chat);
-                $this->persistConversation($ctx, $collector->getText());
-
-                $this->publisher->publishDone($ctx->conversationId, $ctx->articles);
-
-                return;
             } catch (\Throwable $e) {
-                $this->qualityTracker->recordRejection($model, ModelQualityCategory::Chat);
+                $lastError = $e;
                 $this->logModelFailure($model, $e, $index === \count($modelChain) - 1);
             }
         }
 
-        $this->publisher->publishError($ctx->conversationId, 'Failed to generate response');
+        $this->publisher->publishError($ctx->conversationId, $this->formatStreamError($lastError));
+    }
+
+    /**
+     * @param non-empty-string $model
+     */
+    private function attemptModel(string $model, MessageBag $messages, StreamContext $ctx): bool
+    {
+        foreach ([true, false] as $stream) {
+            $attemptCollector = new AnswerCollector();
+
+            try {
+                $this->invokeModel($model, $messages, $ctx, $attemptCollector, $stream);
+                $this->qualityTracker->recordAcceptance($model, ModelQualityCategory::Chat);
+                $this->persistConversation($ctx, $attemptCollector->getText());
+                $this->publisher->publishDone($ctx->conversationId, $ctx->articles);
+
+                return true;
+            } catch (\Throwable $e) {
+                if ($stream) {
+                    $this->logger->info('Chat streaming failed for {model}, retrying without stream: {error}', [
+                        'model' => $model,
+                        'error' => $e->getMessage(),
+                    ]);
+
+                    continue;
+                }
+
+                $this->qualityTracker->recordRejection($model, ModelQualityCategory::Chat);
+
+                throw $e;
+            }
+        }
+
+        return false;
+    }
+
+    private function formatStreamError(?\Throwable $lastError): string
+    {
+        $message = 'Failed to generate response';
+        if ($lastError instanceof \Throwable && $lastError->getMessage() !== '') {
+            $message .= ': ' . mb_substr($lastError->getMessage(), 0, 200);
+        }
+
+        return $message;
+    }
+
+    /**
+     * @param non-empty-string $model
+     */
+    private function invokeModel(
+        string $model,
+        MessageBag $messages,
+        StreamContext $ctx,
+        AnswerCollector $collector,
+        bool $stream,
+    ): void {
+        $options = $stream ? [
+            'stream' => true,
+        ] : [];
+        $result = $this->platform->invoke($model, $messages, $options);
+
+        if ($stream) {
+            foreach ($result->asStream() as $chunk) {
+                if (\is_string($chunk)) {
+                    $collector->append($chunk);
+                    $this->publisher->publishToken($ctx->conversationId, $chunk);
+                }
+            }
+
+            return;
+        }
+
+        $text = $result->asText();
+        if ($text !== '') {
+            $collector->append($text);
+            $this->publisher->publishToken($ctx->conversationId, $text);
+        }
     }
 
     private function logModelFailure(string $model, \Throwable $e, bool $isLast): void

--- a/src/Shared/AI/Platform/OpenAiCompatiblePlatform.php
+++ b/src/Shared/AI/Platform/OpenAiCompatiblePlatform.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\AI\Platform;
+
+use App\Shared\Service\SettingsServiceInterface;
+use Symfony\AI\Platform\Bridge\Generic\CompletionsModel;
+use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
+use Symfony\AI\Platform\Bridge\OpenRouter\ModelCatalog;
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\Platform;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+
+/**
+ * OpenAI-compatible API platform (vLLM, OpenAI, LocalAI, etc.) configured via Settings.
+ */
+final class OpenAiCompatiblePlatform implements PlatformInterface
+{
+    private ?Platform $platform = null;
+
+    private string $configHash = '';
+
+    public function __construct(
+        private readonly SettingsServiceInterface $settings,
+    ) {
+    }
+
+    public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult
+    {
+        if (! $this->settings->isOpenAiConfigured()) {
+            throw new \RuntimeException('OpenAI-compatible provider is not configured (base URL, API key, and model required).');
+        }
+
+        $platform = $this->resolvePlatform();
+        $configuredModel = $this->settings->getOpenAiModel();
+
+        if ($configuredModel === '') {
+            throw new \RuntimeException('OpenAI-compatible provider model is not configured.');
+        }
+
+        return $platform->invoke($configuredModel, $input, $options);
+    }
+
+    public function getModelCatalog(): ModelCatalogInterface
+    {
+        return $this->resolvePlatform()->getModelCatalog();
+    }
+
+    private function resolvePlatform(): Platform
+    {
+        $baseUrl = $this->normalizeBaseUrl($this->settings->getOpenAiBaseUrl());
+        $apiKey = $this->settings->getOpenAiApiKey();
+        $model = $this->settings->getOpenAiModel();
+        $hash = $baseUrl.'|'.$apiKey.'|'.$model;
+
+        if ($this->platform instanceof Platform && $this->configHash === $hash) {
+            return $this->platform;
+        }
+
+        $catalog = new ModelCatalog([
+            $model => [
+                'class' => CompletionsModel::class,
+                'capabilities' => [
+                    Capability::INPUT_TEXT,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                ],
+            ],
+        ]);
+
+        $this->platform = GenericPlatformFactory::create(
+            baseUrl: $baseUrl,
+            apiKey: $apiKey,
+            modelCatalog: $catalog,
+            supportsEmbeddings: false,
+        );
+        $this->configHash = $hash;
+
+        return $this->platform;
+    }
+
+    private function normalizeBaseUrl(string $url): string
+    {
+        $normalized = rtrim(trim($url), '/');
+
+        if (str_ends_with($normalized, '/v1')) {
+            $normalized = substr($normalized, 0, -3);
+        }
+
+        return rtrim($normalized, '/');
+    }
+}

--- a/src/Shared/AI/Platform/OpenAiCompatiblePlatform.php
+++ b/src/Shared/AI/Platform/OpenAiCompatiblePlatform.php
@@ -54,7 +54,7 @@ final class OpenAiCompatiblePlatform implements PlatformInterface
         $baseUrl = $this->normalizeBaseUrl($this->settings->getOpenAiBaseUrl());
         $apiKey = $this->settings->getOpenAiApiKey();
         $model = $this->settings->getOpenAiModel();
-        $hash = $baseUrl.'|'.$apiKey.'|'.$model;
+        $hash = $baseUrl . '|' . $apiKey . '|' . $model;
 
         if ($this->platform instanceof Platform && $this->configHash === $hash) {
             return $this->platform;
@@ -84,12 +84,6 @@ final class OpenAiCompatiblePlatform implements PlatformInterface
 
     private function normalizeBaseUrl(string $url): string
     {
-        $normalized = rtrim(trim($url), '/');
-
-        if (str_ends_with($normalized, '/v1')) {
-            $normalized = substr($normalized, 0, -3);
-        }
-
-        return rtrim($normalized, '/');
+        return OpenAiCompatibleUrlNormalizer::normalize($url);
     }
 }

--- a/src/Shared/AI/Platform/OpenAiCompatibleUrlNormalizer.php
+++ b/src/Shared/AI/Platform/OpenAiCompatibleUrlNormalizer.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\AI\Platform;
+
+final class OpenAiCompatibleUrlNormalizer
+{
+    public static function normalize(string $url): string
+    {
+        $normalized = rtrim(trim($url), '/');
+
+        if (str_ends_with($normalized, '/v1')) {
+            $normalized = substr($normalized, 0, -3);
+        }
+
+        return rtrim($normalized, '/');
+    }
+}

--- a/src/Shared/AI/Platform/SettingsRoutedPlatform.php
+++ b/src/Shared/AI/Platform/SettingsRoutedPlatform.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\AI\Platform;
+
+use App\Shared\Service\SettingsServiceInterface;
+use App\Shared\ValueObject\AiProvider;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\PlatformInterface;
+use Symfony\AI\Platform\Result\DeferredResult;
+
+/**
+ * Routes AI invocations to OpenRouter failover or an OpenAI-compatible endpoint based on Settings.
+ */
+final readonly class SettingsRoutedPlatform implements PlatformInterface
+{
+    public function __construct(
+        private SettingsServiceInterface $settings,
+        private PlatformInterface $openRouterFailover,
+        private PlatformInterface $openAiCompatiblePlatform,
+    ) {
+    }
+
+    public function invoke(string $model, array|string|object $input, array $options = []): DeferredResult
+    {
+        if ($this->settings->getAiProvider() === AiProvider::OpenAi && $this->settings->isOpenAiConfigured()) {
+            return $this->openAiCompatiblePlatform->invoke($model, $input, $options);
+        }
+
+        return $this->openRouterFailover->invoke($model, $input, $options);
+    }
+
+    public function getModelCatalog(): ModelCatalogInterface
+    {
+        if ($this->settings->getAiProvider() === AiProvider::OpenAi && $this->settings->isOpenAiConfigured()) {
+            return $this->openAiCompatiblePlatform->getModelCatalog();
+        }
+
+        return $this->openRouterFailover->getModelCatalog();
+    }
+}

--- a/src/Shared/AI/Service/AiConnectionTestService.php
+++ b/src/Shared/AI/Service/AiConnectionTestService.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\AI\Service;
+
+use App\Shared\AI\Platform\OpenAiCompatibleUrlNormalizer;
+use Symfony\AI\Platform\Bridge\Generic\CompletionsModel;
+use Symfony\AI\Platform\Bridge\Generic\PlatformFactory as GenericPlatformFactory;
+use Symfony\AI\Platform\Bridge\OpenRouter\ModelCatalog;
+use Symfony\AI\Platform\Capability;
+use Symfony\AI\Platform\Message\Message;
+use Symfony\AI\Platform\Message\MessageBag;
+
+final class AiConnectionTestService implements AiConnectionTestServiceInterface
+{
+    public function testOpenAiCompatible(string $baseUrl, string $model, string $apiKey): string
+    {
+        $baseUrl = OpenAiCompatibleUrlNormalizer::normalize($baseUrl);
+        $model = trim($model);
+        $apiKey = trim($apiKey);
+
+        if ($baseUrl === '') {
+            throw new \InvalidArgumentException('Base URL is required.');
+        }
+
+        if ($model === '') {
+            throw new \InvalidArgumentException('Model is required.');
+        }
+
+        if ($apiKey === '') {
+            throw new \InvalidArgumentException('API key is required.');
+        }
+
+        $catalog = new ModelCatalog([
+            $model => [
+                'class' => CompletionsModel::class,
+                'capabilities' => [
+                    Capability::INPUT_TEXT,
+                    Capability::OUTPUT_TEXT,
+                    Capability::OUTPUT_STREAMING,
+                ],
+            ],
+        ]);
+
+        $platform = GenericPlatformFactory::create(
+            baseUrl: $baseUrl,
+            apiKey: $apiKey,
+            modelCatalog: $catalog,
+            supportsEmbeddings: false,
+        );
+
+        try {
+            $messageBag = new MessageBag(Message::ofUser('Respond with exactly one word: hello'));
+            $result = $platform->invoke($model, $messageBag);
+
+            return trim($result->asText());
+        } catch (\Throwable $e) {
+            throw new \RuntimeException($e->getMessage(), 0, $e);
+        }
+    }
+}

--- a/src/Shared/AI/Service/AiConnectionTestServiceInterface.php
+++ b/src/Shared/AI/Service/AiConnectionTestServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\AI\Service;
+
+interface AiConnectionTestServiceInterface
+{
+    /**
+     * Sends a minimal prompt to verify OpenAI-compatible API connectivity.
+     *
+     * @throws \InvalidArgumentException when required fields are missing
+     * @throws \RuntimeException when the API call fails
+     */
+    public function testOpenAiCompatible(string $baseUrl, string $model, string $apiKey): string;
+}

--- a/src/Shared/Controller/SettingsController.php
+++ b/src/Shared/Controller/SettingsController.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Shared\Controller;
 
+use App\Shared\Service\SettingsService;
 use App\Shared\Service\SettingsServiceInterface;
+use App\Shared\ValueObject\AiProvider;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -12,6 +14,16 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class SettingsController
 {
+    /**
+     * @var list<string>
+     */
+    private const array AI_SETTING_KEYS = [
+        SettingsService::KEY_AI_PROVIDER,
+        SettingsService::KEY_AI_OPENAI_BASE_URL,
+        SettingsService::KEY_AI_OPENAI_MODEL,
+        SettingsService::KEY_AI_OPENAI_API_KEY,
+    ];
+
     public function __construct(
         private readonly ControllerHelper $controller,
         private readonly SettingsServiceInterface $settingsService,
@@ -24,7 +36,8 @@ final class SettingsController
     public function index(): Response
     {
         return $this->controller->render('settings/index.html.twig', [
-            'hasOpenrouterKey' => $this->openrouterApiKey !== '',
+            'aiConfigured' => $this->settingsService->isAiConfigured($this->openrouterApiKey),
+            'openAiApiKeyConfigured' => $this->settingsService->hasOpenAiApiKey(),
             'hasNotifierDsn' => $this->notifierDsn !== '' && $this->notifierDsn !== 'null://null',
             'settings' => $this->settingsService->getAll(),
         ]);
@@ -39,9 +52,21 @@ final class SettingsController
             return new Response('Invalid CSRF token.', Response::HTTP_FORBIDDEN);
         }
 
+        $aiError = $this->saveAiProviderSettings($request);
+        if ($aiError !== null) {
+            return new Response(
+                sprintf('<span class="text-error">%s</span>', htmlspecialchars($aiError, ENT_QUOTES)),
+                Response::HTTP_UNPROCESSABLE_ENTITY,
+            );
+        }
+
         $allSettings = $this->settingsService->getAll();
 
         foreach (array_keys($allSettings) as $key) {
+            if (\in_array($key, self::AI_SETTING_KEYS, true)) {
+                continue;
+            }
+
             $value = $request->request->getString($key);
 
             if ($value !== '') {
@@ -56,5 +81,45 @@ final class SettingsController
         }
 
         return $this->controller->redirectToRoute('app_settings');
+    }
+
+    private function saveAiProviderSettings(Request $request): ?string
+    {
+        $providerValue = $request->request->getString('ai_provider');
+        $provider = AiProvider::fromString($providerValue);
+        $this->settingsService->set(SettingsService::KEY_AI_PROVIDER, $provider->value);
+
+        if ($provider !== AiProvider::OpenAi) {
+            return null;
+        }
+
+        $baseUrl = trim($request->request->getString('ai_openai_base_url'));
+        $model = trim($request->request->getString('ai_openai_model'));
+        $apiKey = $request->request->getString('ai_openai_api_key');
+
+        if ($baseUrl === '') {
+            $baseUrl = $this->settingsService->getOpenAiBaseUrl();
+        }
+
+        if ($model === '') {
+            $model = $this->settingsService->getOpenAiModel();
+        }
+
+        if ($baseUrl === '' || $model === '') {
+            return 'OpenAI-compatible provider requires Base URL and Model.';
+        }
+
+        if ($apiKey === '' && ! $this->settingsService->hasOpenAiApiKey()) {
+            return 'OpenAI-compatible provider requires an API key.';
+        }
+
+        $this->settingsService->set(SettingsService::KEY_AI_OPENAI_BASE_URL, $baseUrl);
+        $this->settingsService->set(SettingsService::KEY_AI_OPENAI_MODEL, $model);
+
+        if ($apiKey !== '') {
+            $this->settingsService->set(SettingsService::KEY_AI_OPENAI_API_KEY, $apiKey);
+        }
+
+        return null;
     }
 }

--- a/src/Shared/Controller/SettingsController.php
+++ b/src/Shared/Controller/SettingsController.php
@@ -49,17 +49,21 @@ final class SettingsController
         $token = $request->request->getString('_csrf_token');
 
         if (! $this->controller->isCsrfTokenValid('settings_save', $token)) {
-            return new Response('Invalid CSRF token.', Response::HTTP_FORBIDDEN);
+            return $this->saveErrorResponse($request, 'Invalid CSRF token.', Response::HTTP_FORBIDDEN);
         }
 
         $aiError = $this->saveAiProviderSettings($request);
         if ($aiError !== null) {
-            return new Response(
-                sprintf('<span class="text-error">%s</span>', htmlspecialchars($aiError, ENT_QUOTES)),
-                Response::HTTP_UNPROCESSABLE_ENTITY,
-            );
+            return $this->saveErrorResponse($request, $aiError, Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
+        $this->saveGeneralSettings($request);
+
+        return $this->saveSuccessResponse($request);
+    }
+
+    private function saveGeneralSettings(Request $request): void
+    {
         $allSettings = $this->settingsService->getAll();
 
         foreach (array_keys($allSettings) as $key) {
@@ -73,14 +77,56 @@ final class SettingsController
                 $this->settingsService->set($key, $value);
             }
         }
+    }
 
-        if ($request->headers->has('HX-Request')) {
+    private function saveSuccessResponse(Request $request): Response
+    {
+        if ($this->isHtmxRequest($request)) {
             return new Response(
-                '<span class="text-success">Settings saved.</span>',
+                $this->buildSaveFeedbackResponse('success', 'Settings saved successfully.'),
             );
         }
 
+        $this->controller->addFlash('success', 'Settings saved successfully.');
+
         return $this->controller->redirectToRoute('app_settings');
+    }
+
+    private function saveErrorResponse(Request $request, string $message, int $statusCode): Response
+    {
+        if ($this->isHtmxRequest($request)) {
+            return new Response(
+                $this->buildSaveFeedbackResponse('error', $message),
+                $statusCode,
+            );
+        }
+
+        return new Response(
+            sprintf('<span class="text-error">%s</span>', htmlspecialchars($message, ENT_QUOTES)),
+            $statusCode,
+        );
+    }
+
+    private function isHtmxRequest(Request $request): bool
+    {
+        return $request->headers->has('HX-Request');
+    }
+
+    private function buildSaveFeedbackResponse(string $level, string $message): string
+    {
+        $alertClass = $level === 'success' ? 'alert-success' : 'alert-error';
+        $badgeClass = $level === 'success' ? 'badge-success' : 'badge-error';
+        $badgeLabel = $level === 'success' ? 'Saved' : 'Save failed';
+        $escapedMessage = htmlspecialchars($message, ENT_QUOTES);
+
+        return sprintf(
+            '<div id="settings-save-feedback" hx-swap-oob="innerHTML" class="alert %s shadow-sm max-w-lg"><span>%s</span></div>'
+            . '<span class="badge %s badge-sm">%s</span>',
+            $alertClass,
+            $escapedMessage,
+            $badgeClass,
+            $badgeLabel,
+        );
     }
 
     private function saveAiProviderSettings(Request $request): ?string

--- a/src/Shared/Controller/TestAiConnectionController.php
+++ b/src/Shared/Controller/TestAiConnectionController.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Controller;
+
+use App\Shared\AI\Service\AiConnectionTestServiceInterface;
+use App\Shared\Service\SettingsServiceInterface;
+use App\User\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class TestAiConnectionController
+{
+    public function __construct(
+        private readonly ControllerHelper $controller,
+        private readonly AiConnectionTestServiceInterface $connectionTestService,
+        private readonly SettingsServiceInterface $settingsService,
+        private readonly UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    #[Route('/settings/test-ai-connection', name: 'app_settings_test_ai_connection', methods: ['POST'])]
+    public function __invoke(Request $request): Response
+    {
+        $user = $this->controller->getUser();
+        if (! $user instanceof User) {
+            return new RedirectResponse($this->urlGenerator->generate('app_login'));
+        }
+
+        $isHtmx = $request->headers->has('HX-Request');
+
+        $token = $request->headers->get('X-CSRF-Token')
+            ?? $request->request->getString('_token');
+        if (! $this->controller->isCsrfTokenValid('test_ai_connection', $token)) {
+            return $this->respond($isHtmx, 'error', 'Invalid CSRF token.', Response::HTTP_FORBIDDEN);
+        }
+
+        $credentials = $this->resolveCredentials($request);
+        if ($credentials['error'] !== null) {
+            return $this->respond($isHtmx, 'warning', $credentials['error']);
+        }
+
+        return $this->testConnection($isHtmx, $credentials['baseUrl'], $credentials['model'], $credentials['apiKey']);
+    }
+
+    /**
+     * @return array{baseUrl: string, model: string, apiKey: string, error: ?string}
+     */
+    private function resolveCredentials(Request $request): array
+    {
+        $baseUrl = trim($request->request->getString('ai_openai_base_url'));
+        $model = trim($request->request->getString('ai_openai_model'));
+        $apiKey = $request->request->getString('ai_openai_api_key');
+
+        if ($baseUrl === '') {
+            $baseUrl = $this->settingsService->getOpenAiBaseUrl();
+        }
+
+        if ($model === '') {
+            $model = $this->settingsService->getOpenAiModel();
+        }
+
+        if ($apiKey === '') {
+            $apiKey = $this->settingsService->getOpenAiApiKey();
+        }
+
+        if ($baseUrl === '' || $model === '') {
+            return ['baseUrl' => '', 'model' => '', 'apiKey' => '', 'error' => 'Base URL and model are required.'];
+        }
+
+        if ($apiKey === '') {
+            return ['baseUrl' => '', 'model' => '', 'apiKey' => '', 'error' => 'API key is required.'];
+        }
+
+        return ['baseUrl' => $baseUrl, 'model' => $model, 'apiKey' => $apiKey, 'error' => null];
+    }
+
+    private function testConnection(bool $isHtmx, string $baseUrl, string $model, string $apiKey): Response
+    {
+        try {
+            $responseText = $this->connectionTestService->testOpenAiCompatible($baseUrl, $model, $apiKey);
+        } catch (\InvalidArgumentException $e) {
+            return $this->respond($isHtmx, 'warning', $e->getMessage());
+        } catch (\Throwable) {
+            return $this->respond($isHtmx, 'error', 'Connection failed');
+        }
+
+        $preview = mb_strlen($responseText) > 80
+            ? mb_substr($responseText, 0, 77) . '...'
+            : $responseText;
+
+        return $this->respond($isHtmx, 'success', sprintf('Connected — model replied: "%s"', $preview));
+    }
+
+    private function respond(bool $isHtmx, string $level, string $message, int $statusCode = Response::HTTP_OK): Response
+    {
+        if ($isHtmx) {
+            $badgeClass = match ($level) {
+                'success' => 'badge-success',
+                'warning' => 'badge-warning',
+                default => 'badge-error',
+            };
+
+            return new Response(
+                sprintf('<span class="badge %s badge-sm">%s</span>', $badgeClass, htmlspecialchars($message, ENT_QUOTES)),
+                $statusCode,
+            );
+        }
+
+        $this->controller->addFlash($level, $message);
+
+        return new RedirectResponse($this->urlGenerator->generate('app_settings'));
+    }
+}

--- a/src/Shared/Service/SettingsService.php
+++ b/src/Shared/Service/SettingsService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Shared\Service;
 
+use App\Shared\ValueObject\AiProvider;
+
 use App\Shared\Entity\Setting;
 use App\Shared\Repository\SettingRepositoryInterface;
 
@@ -19,6 +21,14 @@ final readonly class SettingsService implements SettingsServiceInterface
 
     public const string KEY_SENTIMENT_SLIDER = 'sentiment_slider';
 
+    public const string KEY_AI_PROVIDER = 'ai_provider';
+
+    public const string KEY_AI_OPENAI_BASE_URL = 'ai_openai_base_url';
+
+    public const string KEY_AI_OPENAI_API_KEY = 'ai_openai_api_key';
+
+    public const string KEY_AI_OPENAI_MODEL = 'ai_openai_model';
+
     /**
      * @var array<string, string>
      */
@@ -30,14 +40,27 @@ final readonly class SettingsService implements SettingsServiceInterface
         int $fetchDefaultInterval,
         int $retentionArticles,
         int $retentionLogs,
+        string $defaultAiProvider = 'openrouter',
+        string $defaultAiOpenAiBaseUrl = '',
+        string $defaultAiOpenAiApiKey = '',
+        string $defaultAiOpenAiModel = '',
     ) {
-        $this->defaults = [
+        $defaults = [
             self::KEY_DISPLAY_LANGUAGES => $displayLanguages,
             self::KEY_FETCH_DEFAULT_INTERVAL => (string) $fetchDefaultInterval,
             self::KEY_RETENTION_ARTICLES => (string) $retentionArticles,
             self::KEY_RETENTION_LOGS => (string) $retentionLogs,
             self::KEY_SENTIMENT_SLIDER => '0',
+            self::KEY_AI_PROVIDER => $defaultAiProvider,
+            self::KEY_AI_OPENAI_BASE_URL => $defaultAiOpenAiBaseUrl,
+            self::KEY_AI_OPENAI_MODEL => $defaultAiOpenAiModel,
         ];
+
+        if ($defaultAiOpenAiApiKey !== '') {
+            $defaults[self::KEY_AI_OPENAI_API_KEY] = $defaultAiOpenAiApiKey;
+        }
+
+        $this->defaults = $defaults;
     }
 
     public function get(string $key): string
@@ -49,6 +72,11 @@ final readonly class SettingsService implements SettingsServiceInterface
         }
 
         return $this->defaults[$key] ?? '';
+    }
+
+    public function hasDefault(string $key): bool
+    {
+        return \array_key_exists($key, $this->defaults);
     }
 
     public function set(string $key, string $value): void
@@ -84,6 +112,13 @@ final readonly class SettingsService implements SettingsServiceInterface
             ];
         }
 
+        if (isset($dbSettings[self::KEY_AI_OPENAI_API_KEY])) {
+            $result[self::KEY_AI_OPENAI_API_KEY] = [
+                'value' => '',
+                'isOverridden' => true,
+            ];
+        }
+
         return $result;
     }
 
@@ -110,5 +145,51 @@ final readonly class SettingsService implements SettingsServiceInterface
     public function getSentimentSlider(): int
     {
         return (int) $this->get(self::KEY_SENTIMENT_SLIDER);
+    }
+
+    public function getAiProvider(): AiProvider
+    {
+        return AiProvider::fromString($this->get(self::KEY_AI_PROVIDER));
+    }
+
+    public function getOpenAiBaseUrl(): string
+    {
+        return trim($this->get(self::KEY_AI_OPENAI_BASE_URL));
+    }
+
+    public function getOpenAiModel(): string
+    {
+        return trim($this->get(self::KEY_AI_OPENAI_MODEL));
+    }
+
+    public function getOpenAiApiKey(): string
+    {
+        $setting = $this->settingRepository->findByKey(self::KEY_AI_OPENAI_API_KEY);
+
+        if ($setting instanceof Setting) {
+            return $setting->getValue();
+        }
+
+        return $this->defaults[self::KEY_AI_OPENAI_API_KEY] ?? '';
+    }
+
+    public function hasOpenAiApiKey(): bool
+    {
+        return $this->getOpenAiApiKey() !== '';
+    }
+
+    public function isOpenAiConfigured(): bool
+    {
+        return $this->getOpenAiBaseUrl() !== ''
+            && $this->getOpenAiModel() !== ''
+            && $this->hasOpenAiApiKey();
+    }
+
+    public function isAiConfigured(string $openrouterApiKey): bool
+    {
+        return match ($this->getAiProvider()) {
+            AiProvider::OpenAi => $this->isOpenAiConfigured(),
+            AiProvider::OpenRouter => $openrouterApiKey !== '',
+        };
     }
 }

--- a/src/Shared/Service/SettingsService.php
+++ b/src/Shared/Service/SettingsService.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace App\Shared\Service;
 
-use App\Shared\ValueObject\AiProvider;
-
 use App\Shared\Entity\Setting;
 use App\Shared\Repository\SettingRepositoryInterface;
+use App\Shared\ValueObject\AiProvider;
 
 final readonly class SettingsService implements SettingsServiceInterface
 {

--- a/src/Shared/Service/SettingsServiceInterface.php
+++ b/src/Shared/Service/SettingsServiceInterface.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App\Shared\Service;
 
+use App\Shared\ValueObject\AiProvider;
+
 interface SettingsServiceInterface
 {
     public function get(string $key): string;
+
+    public function hasDefault(string $key): bool;
 
     public function set(string $key, string $value): void;
 
@@ -24,4 +28,18 @@ interface SettingsServiceInterface
     public function getRetentionLogs(): int;
 
     public function getSentimentSlider(): int;
+
+    public function getAiProvider(): AiProvider;
+
+    public function getOpenAiBaseUrl(): string;
+
+    public function getOpenAiModel(): string;
+
+    public function getOpenAiApiKey(): string;
+
+    public function hasOpenAiApiKey(): bool;
+
+    public function isOpenAiConfigured(): bool;
+
+    public function isAiConfigured(string $openrouterApiKey): bool;
 }

--- a/src/Shared/ValueObject/AiProvider.php
+++ b/src/Shared/ValueObject/AiProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\ValueObject;
+
+enum AiProvider: string
+{
+    case OpenRouter = 'openrouter';
+    case OpenAi = 'openai';
+
+    public static function fromString(string $value): self
+    {
+        return self::tryFrom($value) ?? self::OpenRouter;
+    }
+}

--- a/templates/chat/index.html.twig
+++ b/templates/chat/index.html.twig
@@ -203,6 +203,28 @@
         }
     }
 
+    function generateConversationId() {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+            return crypto.randomUUID().replace(/-/g, '');
+        }
+
+        const bytes = new Uint8Array(16);
+        if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+            crypto.getRandomValues(bytes);
+        } else {
+            for (let i = 0; i < 16; i++) {
+                bytes[i] = Math.floor(Math.random() * 256);
+            }
+        }
+
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+        return Array.from(bytes, function(b) {
+            return b.toString(16).padStart(2, '0');
+        }).join('');
+    }
+
     async function sendMessage(message) {
         createBubble('user', message);
         setLoading(true);
@@ -210,7 +232,7 @@
 
         // Generate conversationId client-side if needed
         if (!conversationId) {
-            conversationId = crypto.randomUUID().replace(/-/g, '');
+            conversationId = generateConversationId();
         }
 
         // 1. Subscribe to Mercure topic FIRST (before POST, so we don't miss early events)
@@ -318,7 +340,7 @@
     input.addEventListener('keydown', function(e) {
         if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
-            form.dispatchEvent(new Event('submit'));
+            form.requestSubmit();
         }
     });
 

--- a/templates/settings/index.html.twig
+++ b/templates/settings/index.html.twig
@@ -6,18 +6,6 @@
     <div class="grid gap-4 max-w-lg">
         <div class="card bg-base-100 shadow-sm">
             <div class="card-body">
-                <h3 class="card-title text-base">OpenRouter AI</h3>
-                {% if hasOpenrouterKey %}
-                    <span class="badge badge-success">Configured</span>
-                {% else %}
-                    <span class="badge badge-warning">Not configured</span>
-                    <p class="text-sm text-base-content/50">Set OPENROUTER_API_KEY in .env.local for AI features.</p>
-                {% endif %}
-            </div>
-        </div>
-
-        <div class="card bg-base-100 shadow-sm">
-            <div class="card-body">
                 <h3 class="card-title text-base">Notifications</h3>
                 {% if hasNotifierDsn %}
                     <span class="badge badge-success">Configured</span>
@@ -46,8 +34,86 @@
               hx-swap="innerHTML"
         >
             <div class="card-body">
-                <h3 class="card-title text-base">Display Settings</h3>
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('settings_save') }}">
+
+                <h3 class="card-title text-base">AI Provider</h3>
+
+                {% if aiConfigured %}
+                    <span class="badge badge-success mb-2">Configured</span>
+                {% else %}
+                    <span class="badge badge-warning mb-2">Not configured</span>
+                {% endif %}
+
+                <div class="form-control">
+                    <label class="label" for="setting-ai-provider">
+                        <span class="label-text">Provider</span>
+                        {% if settings.ai_provider.isOverridden %}
+                            <span class="badge badge-info badge-xs">overridden</span>
+                        {% else %}
+                            <span class="badge badge-ghost badge-xs">default</span>
+                        {% endif %}
+                    </label>
+                    <select id="setting-ai-provider" name="ai_provider" class="select select-bordered select-sm"
+                            onchange="document.getElementById('ai-openai-fields').hidden = this.value !== 'openai'">
+                        <option value="openrouter" {{ settings.ai_provider.value == 'openrouter' ? 'selected' : '' }}>OpenRouter (cloud)</option>
+                        <option value="openai" {{ settings.ai_provider.value == 'openai' ? 'selected' : '' }}>OpenAI-compatible API (vLLM, OpenAI, …)</option>
+                    </select>
+                </div>
+
+                <div id="ai-openai-fields" class="grid gap-3 mt-2" {% if settings.ai_provider.value != 'openai' %}hidden{% endif %}>
+                    <div class="form-control">
+                        <label class="label" for="setting-ai-openai-base-url">
+                            <span class="label-text">Base URL</span>
+                            {% if settings.ai_openai_base_url.isOverridden %}
+                                <span class="badge badge-info badge-xs">overridden</span>
+                            {% endif %}
+                        </label>
+                        <input type="url" id="setting-ai-openai-base-url" name="ai_openai_base_url"
+                               value="{{ settings.ai_openai_base_url.value }}"
+                               class="input input-bordered input-sm"
+                               placeholder="http://192.168.30.121:8000/v1">
+                        <label class="label">
+                            <span class="label-text-alt text-base-content/50">OpenAI-compatible endpoint (with or without /v1)</span>
+                        </label>
+                    </div>
+
+                    <div class="form-control">
+                        <label class="label" for="setting-ai-openai-model">
+                            <span class="label-text">Model</span>
+                            {% if settings.ai_openai_model.isOverridden %}
+                                <span class="badge badge-info badge-xs">overridden</span>
+                            {% endif %}
+                        </label>
+                        <input type="text" id="setting-ai-openai-model" name="ai_openai_model"
+                               value="{{ settings.ai_openai_model.value }}"
+                               class="input input-bordered input-sm"
+                               placeholder="your-model-id">
+                        <label class="label">
+                            <span class="label-text-alt text-base-content/50">Model ID as returned by GET /v1/models</span>
+                        </label>
+                    </div>
+
+                    <div class="form-control">
+                        <label class="label" for="setting-ai-openai-api-key">
+                            <span class="label-text">API Key</span>
+                            {% if openAiApiKeyConfigured %}
+                                <span class="badge badge-success badge-xs">set</span>
+                            {% endif %}
+                        </label>
+                        <input type="password" id="setting-ai-openai-api-key" name="ai_openai_api_key"
+                               class="input input-bordered input-sm"
+                               autocomplete="new-password"
+                               placeholder="{% if openAiApiKeyConfigured %}Leave blank to keep current key{% else %}Required{% endif %}">
+                    </div>
+                </div>
+
+                <p class="text-sm text-base-content/50 mt-1">
+                    OpenRouter uses <code class="text-xs">OPENROUTER_API_KEY</code> from <code class="text-xs">.env.local</code> when selected.
+                </p>
+
+                <hr class="my-4 border-base-300">
+
+                <h3 class="card-title text-base">Display Settings</h3>
 
                 <div class="form-control">
                     <label class="label" for="setting-display-languages">

--- a/templates/settings/index.html.twig
+++ b/templates/settings/index.html.twig
@@ -3,6 +3,8 @@
 {% block body %}
     <h1 class="text-2xl font-bold mb-6">Settings</h1>
 
+    <div id="settings-save-feedback" aria-live="polite"></div>
+
     <div class="grid gap-4 max-w-lg">
         <div class="card bg-base-100 shadow-sm">
             <div class="card-body">
@@ -32,6 +34,7 @@
               hx-post="{{ path('app_settings_save') }}"
               hx-target="#save-result"
               hx-swap="innerHTML"
+              hx-indicator="#save-spinner"
         >
             <div class="card-body">
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('settings_save') }}">
@@ -104,6 +107,21 @@
                                class="input input-bordered input-sm"
                                autocomplete="new-password"
                                placeholder="{% if openAiApiKeyConfigured %}Leave blank to keep current key{% else %}Required{% endif %}">
+                    </div>
+
+                    <div class="flex items-center gap-2">
+                        <button
+                            type="button"
+                            class="btn btn-sm btn-outline"
+                            hx-post="{{ path('app_settings_test_ai_connection') }}"
+                            hx-include="#ai-openai-fields"
+                            hx-headers='{"X-CSRF-Token": "{{ csrf_token('test_ai_connection') }}"}'
+                            hx-target="#test-ai-connection-result"
+                            hx-swap="innerHTML"
+                        >
+                            Test Connection
+                        </button>
+                        <span id="test-ai-connection-result"></span>
                     </div>
                 </div>
 
@@ -188,7 +206,10 @@
                 </div>
 
                 <div class="card-actions mt-2 flex items-center gap-2">
-                    <button type="submit" class="btn btn-primary btn-sm">Save Settings</button>
+                    <button type="submit" class="btn btn-primary btn-sm">
+                        Save Settings
+                        <span id="save-spinner" class="htmx-indicator loading loading-spinner loading-xs"></span>
+                    </button>
                     <span id="save-result"></span>
                 </div>
             </div>

--- a/tests/Unit/Chat/Service/ChatModelResolverTest.php
+++ b/tests/Unit/Chat/Service/ChatModelResolverTest.php
@@ -8,12 +8,23 @@ use App\Chat\Service\ChatModelResolver;
 use App\Shared\AI\Service\ModelDiscoveryServiceInterface;
 use App\Shared\AI\ValueObject\ModelId;
 use App\Shared\AI\ValueObject\ModelIdCollection;
+use App\Shared\Service\SettingsServiceInterface;
+use App\Shared\ValueObject\AiProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ChatModelResolver::class)]
 final class ChatModelResolverTest extends TestCase
 {
+    private function createOpenRouterSettings(): SettingsServiceInterface
+    {
+        $settings = $this->createStub(SettingsServiceInterface::class);
+        $settings->method('getAiProvider')->willReturn(AiProvider::OpenRouter);
+        $settings->method('isOpenAiConfigured')->willReturn(false);
+
+        return $settings;
+    }
+
     public function testResolveModelReturnsFirstDiscoveredModel(): void
     {
         $discovery = $this->createMock(ModelDiscoveryServiceInterface::class);
@@ -23,7 +34,9 @@ final class ChatModelResolverTest extends TestCase
                 new ModelId('openai/gpt-4o-mini'),
             ]));
 
-        $resolver = new ChatModelResolver($discovery);
+        $settings = $this->createOpenRouterSettings();
+
+        $resolver = new ChatModelResolver($discovery, $settings);
 
         self::assertSame('google/gemini-flash', $resolver->resolveModel());
     }
@@ -34,7 +47,9 @@ final class ChatModelResolverTest extends TestCase
         $discovery->expects(self::once())->method('discoverToolCallingModels')
             ->willReturn(new ModelIdCollection([]));
 
-        $resolver = new ChatModelResolver($discovery);
+        $settings = $this->createOpenRouterSettings();
+
+        $resolver = new ChatModelResolver($discovery, $settings);
 
         self::assertSame('openrouter/free', $resolver->resolveModel());
     }
@@ -49,7 +64,9 @@ final class ChatModelResolverTest extends TestCase
                 new ModelId('meta/llama-3'),
             ]));
 
-        $resolver = new ChatModelResolver($discovery);
+        $settings = $this->createOpenRouterSettings();
+
+        $resolver = new ChatModelResolver($discovery, $settings);
 
         self::assertSame(
             ['google/gemini-flash', 'openai/gpt-4o-mini', 'meta/llama-3'],
@@ -63,8 +80,26 @@ final class ChatModelResolverTest extends TestCase
         $discovery->expects(self::once())->method('discoverToolCallingModels')
             ->willReturn(new ModelIdCollection([]));
 
-        $resolver = new ChatModelResolver($discovery);
+        $settings = $this->createOpenRouterSettings();
+
+        $resolver = new ChatModelResolver($discovery, $settings);
 
         self::assertSame(['openrouter/free'], $resolver->resolveModelChain());
+    }
+
+    public function testResolveModelChainUsesConfiguredOpenAiModel(): void
+    {
+        $discovery = $this->createMock(ModelDiscoveryServiceInterface::class);
+        $discovery->expects(self::never())->method('discoverToolCallingModels');
+
+        $settings = $this->createMock(SettingsServiceInterface::class);
+        $settings->method('getAiProvider')->willReturn(AiProvider::OpenAi);
+        $settings->method('isOpenAiConfigured')->willReturn(true);
+        $settings->method('getOpenAiModel')->willReturn('qwen-local');
+
+        $resolver = new ChatModelResolver($discovery, $settings);
+
+        self::assertSame(['qwen-local'], $resolver->resolveModelChain());
+        self::assertSame('qwen-local', $resolver->resolveModel());
     }
 }

--- a/tests/Unit/Chat/Service/StreamingChatServiceTest.php
+++ b/tests/Unit/Chat/Service/StreamingChatServiceTest.php
@@ -152,6 +152,8 @@ final class StreamingChatServiceTest extends TestCase
             ->with('test/model', ModelQualityCategory::Chat);
 
         $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('info')
+            ->with(self::stringContains('retrying without stream'));
         $logger->expects(self::once())->method('error')
             ->with(
                 self::stringContains('all models exhausted'),
@@ -164,7 +166,7 @@ final class StreamingChatServiceTest extends TestCase
         $publisher->expects(self::never())->method('publishToken');
         $publisher->expects(self::never())->method('publishDone');
         $publisher->expects(self::once())->method('publishError')
-            ->with('conv-3', 'Failed to generate response');
+            ->with('conv-3', 'Failed to generate response: API down');
 
         $service = $this->buildService($store, $platform, $searchTool, tracker: $tracker, logger: $logger, publisher: $publisher);
         $service->stream('Hello', 'conv-3');
@@ -180,8 +182,9 @@ final class StreamingChatServiceTest extends TestCase
         $searchTool->method('search')->willReturn([]);
 
         $platform = $this->createMock(PlatformInterface::class);
-        $platform->expects(self::exactly(2))->method('invoke')
+        $platform->expects(self::exactly(3))->method('invoke')
             ->willReturnOnConsecutiveCalls(
+                self::throwException(new \RuntimeException('Rate limited')),
                 self::throwException(new \RuntimeException('Rate limited')),
                 $this->createDeferredForText(new TextResult('Fallback response')),
             );
@@ -196,15 +199,10 @@ final class StreamingChatServiceTest extends TestCase
             ->with('model/second', ModelQualityCategory::Chat);
 
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects(self::once())->method('info')
-            ->with(
-                self::stringContains('failed, trying next'),
-                self::callback(static fn (array $ctx): bool => $ctx['model'] === 'model/first'
-                    && $ctx['error'] === 'Rate limited'),
-            );
+        $logger->expects(self::exactly(2))->method('info');
 
         $publisher = $this->createMock(ChatStreamPublisherInterface::class);
-        // 2 from stream() + 2 from streamFromPlatform() (one per model attempt)
+        // 2 from stream() + 2 from streamFromPlatform() (stream fail + non-stream fail on first, success on second)
         $publisher->expects(self::exactly(4))->method('publishStatus');
         $publisher->expects(self::once())->method('publishToken')
             ->with('conv-failover', 'Fallback response');
@@ -233,7 +231,7 @@ final class StreamingChatServiceTest extends TestCase
         $tracker->expects(self::exactly(3))->method('recordRejection');
 
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects(self::exactly(2))->method('info');
+        $logger->expects(self::exactly(5))->method('info');
         $logger->expects(self::once())->method('error')
             ->with(
                 self::stringContains('all models exhausted'),
@@ -241,10 +239,10 @@ final class StreamingChatServiceTest extends TestCase
             );
 
         $publisher = $this->createMock(ChatStreamPublisherInterface::class);
-        // 2 from stream() + 3 from streamFromPlatform() (one per model)
+        // 2 from stream() + 3 models × 1 status each
         $publisher->expects(self::exactly(5))->method('publishStatus');
         $publisher->expects(self::once())->method('publishError')
-            ->with('conv-exhaust', 'Failed to generate response');
+            ->with('conv-exhaust', 'Failed to generate response: All broken');
 
         $service = $this->buildService($store, $platform, $searchTool, $resolver, $tracker, $logger, publisher: $publisher);
         $service->stream('Hello', 'conv-exhaust');

--- a/tests/Unit/Shared/AI/Platform/OpenAiCompatibleUrlNormalizerTest.php
+++ b/tests/Unit/Shared/AI/Platform/OpenAiCompatibleUrlNormalizerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\AI\Platform;
+
+use App\Shared\AI\Platform\OpenAiCompatibleUrlNormalizer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OpenAiCompatibleUrlNormalizer::class)]
+final class OpenAiCompatibleUrlNormalizerTest extends TestCase
+{
+    #[DataProvider('normalizeProvider')]
+    public function testNormalize(string $input, string $expected): void
+    {
+        self::assertSame($expected, OpenAiCompatibleUrlNormalizer::normalize($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function normalizeProvider(): iterable
+    {
+        yield 'strips trailing slash' => ['http://vllm.local/v1/', 'http://vllm.local'];
+        yield 'strips /v1 suffix' => ['http://192.168.30.121:8000/v1', 'http://192.168.30.121:8000'];
+        yield 'keeps host without v1' => ['http://192.168.30.121:8000', 'http://192.168.30.121:8000'];
+    }
+}

--- a/tests/Unit/Shared/AI/Platform/SettingsRoutedPlatformTest.php
+++ b/tests/Unit/Shared/AI/Platform/SettingsRoutedPlatformTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\AI\Platform;
+
+use App\Shared\AI\Platform\SettingsRoutedPlatform;
+use App\Shared\Service\SettingsServiceInterface;
+use App\Shared\ValueObject\AiProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\ModelCatalog\ModelCatalogInterface;
+use Symfony\AI\Platform\PlatformInterface;
+
+#[CoversClass(SettingsRoutedPlatform::class)]
+final class SettingsRoutedPlatformTest extends TestCase
+{
+    private MockObject&SettingsServiceInterface $settings;
+
+    private MockObject&PlatformInterface $openRouterFailover;
+
+    private MockObject&PlatformInterface $openAiPlatform;
+
+    protected function setUp(): void
+    {
+        $this->settings = $this->createMock(SettingsServiceInterface::class);
+        $this->openRouterFailover = $this->createMock(PlatformInterface::class);
+        $this->openAiPlatform = $this->createMock(PlatformInterface::class);
+    }
+
+    public function testInvokeUsesOpenAiPlatformWhenConfigured(): void
+    {
+        $this->settings->method('getAiProvider')->willReturn(AiProvider::OpenAi);
+        $this->settings->method('isOpenAiConfigured')->willReturn(true);
+
+        $this->openAiPlatform->expects(self::once())
+            ->method('invoke')
+            ->with('openrouter/free', 'prompt', [])
+            ->willThrowException(new \RuntimeException('openai-called'));
+
+        $this->openRouterFailover->expects(self::never())->method('invoke');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('openai-called');
+
+        $this->createPlatform()->invoke('openrouter/free', 'prompt');
+    }
+
+    public function testInvokeUsesOpenRouterWhenProviderIsOpenRouter(): void
+    {
+        $this->settings->method('getAiProvider')->willReturn(AiProvider::OpenRouter);
+        $this->settings->method('isOpenAiConfigured')->willReturn(false);
+
+        $this->openRouterFailover->expects(self::once())
+            ->method('invoke')
+            ->with('openrouter/free', 'prompt', [])
+            ->willThrowException(new \RuntimeException('openrouter-called'));
+
+        $this->openAiPlatform->expects(self::never())->method('invoke');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('openrouter-called');
+
+        $this->createPlatform()->invoke('openrouter/free', 'prompt');
+    }
+
+    public function testGetModelCatalogDelegatesToActivePlatform(): void
+    {
+        $catalog = $this->createMock(ModelCatalogInterface::class);
+
+        $this->settings->method('getAiProvider')->willReturn(AiProvider::OpenAi);
+        $this->settings->method('isOpenAiConfigured')->willReturn(true);
+
+        $this->openAiPlatform->expects(self::once())
+            ->method('getModelCatalog')
+            ->willReturn($catalog);
+
+        self::assertSame($catalog, $this->createPlatform()->getModelCatalog());
+    }
+
+    private function createPlatform(): SettingsRoutedPlatform
+    {
+        return new SettingsRoutedPlatform(
+            $this->settings,
+            $this->openRouterFailover,
+            $this->openAiPlatform,
+        );
+    }
+}

--- a/tests/Unit/Shared/Controller/TestAiConnectionControllerTest.php
+++ b/tests/Unit/Shared/Controller/TestAiConnectionControllerTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Controller;
+
+use App\Shared\AI\Service\AiConnectionTestServiceInterface;
+use App\Shared\Controller\TestAiConnectionController;
+use App\Shared\Service\SettingsServiceInterface;
+use App\User\Entity\User;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[CoversClass(TestAiConnectionController::class)]
+final class TestAiConnectionControllerTest extends TestCase
+{
+    public function testHtmxSuccessReturnsBadgeWithModelResponse(): void
+    {
+        $connectionTest = $this->createMock(AiConnectionTestServiceInterface::class);
+        $connectionTest->expects(self::once())
+            ->method('testOpenAiCompatible')
+            ->with('http://vllm.local/v1', 'test-model', 'secret')
+            ->willReturn('hello');
+
+        $settings = $this->createStub(SettingsServiceInterface::class);
+
+        $controller = $this->buildController($connectionTest, $settings);
+
+        $request = new Request([], [
+            'ai_openai_base_url' => 'http://vllm.local/v1',
+            'ai_openai_model' => 'test-model',
+            'ai_openai_api_key' => 'secret',
+        ]);
+        $request->headers->set('HX-Request', 'true');
+        $request->headers->set('X-CSRF-Token', 'valid');
+
+        $response = $controller($request);
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertStringContainsString('Connected', (string) $response->getContent());
+        self::assertStringContainsString('hello', (string) $response->getContent());
+        self::assertStringContainsString('badge-success', (string) $response->getContent());
+    }
+
+    public function testHtmxUsesSavedApiKeyWhenFieldEmpty(): void
+    {
+        $connectionTest = $this->createMock(AiConnectionTestServiceInterface::class);
+        $connectionTest->expects(self::once())
+            ->method('testOpenAiCompatible')
+            ->with('http://vllm.local', 'test-model', 'saved-key')
+            ->willReturn('ok');
+
+        $settings = $this->createMock(SettingsServiceInterface::class);
+        $settings->method('getOpenAiApiKey')->willReturn('saved-key');
+
+        $controller = $this->buildController($connectionTest, $settings);
+
+        $request = new Request([], [
+            'ai_openai_base_url' => 'http://vllm.local',
+            'ai_openai_model' => 'test-model',
+            'ai_openai_api_key' => '',
+        ]);
+        $request->headers->set('HX-Request', 'true');
+        $request->headers->set('X-CSRF-Token', 'valid');
+
+        $response = $controller($request);
+
+        self::assertStringContainsString('badge-success', (string) $response->getContent());
+    }
+
+    public function testHtmxMissingFieldsReturnsWarningBadge(): void
+    {
+        $connectionTest = $this->createMock(AiConnectionTestServiceInterface::class);
+        $connectionTest->expects(self::never())->method('testOpenAiCompatible');
+
+        $settings = $this->createStub(SettingsServiceInterface::class);
+
+        $controller = $this->buildController($connectionTest, $settings);
+
+        $request = new Request([], [
+            'ai_openai_base_url' => '',
+            'ai_openai_model' => '',
+        ]);
+        $request->headers->set('HX-Request', 'true');
+        $request->headers->set('X-CSRF-Token', 'valid');
+
+        $response = $controller($request);
+
+        self::assertStringContainsString('Base URL and model are required', (string) $response->getContent());
+        self::assertStringContainsString('badge-warning', (string) $response->getContent());
+    }
+
+    public function testHtmxConnectionFailureReturnsErrorBadge(): void
+    {
+        $connectionTest = $this->createMock(AiConnectionTestServiceInterface::class);
+        $connectionTest->expects(self::once())
+            ->method('testOpenAiCompatible')
+            ->willThrowException(new \RuntimeException('Connection refused'));
+
+        $settings = $this->createStub(SettingsServiceInterface::class);
+
+        $controller = $this->buildController($connectionTest, $settings);
+
+        $request = new Request([], [
+            'ai_openai_base_url' => 'http://vllm.local',
+            'ai_openai_model' => 'test-model',
+            'ai_openai_api_key' => 'secret',
+        ]);
+        $request->headers->set('HX-Request', 'true');
+        $request->headers->set('X-CSRF-Token', 'valid');
+
+        $response = $controller($request);
+
+        self::assertStringContainsString('Connection failed', (string) $response->getContent());
+        self::assertStringContainsString('badge-error', (string) $response->getContent());
+    }
+
+    public function testHtmxInvalidCsrfReturnsForbidden(): void
+    {
+        $connectionTest = $this->createStub(AiConnectionTestServiceInterface::class);
+        $settings = $this->createStub(SettingsServiceInterface::class);
+
+        $helper = $this->createMock(ControllerHelper::class);
+        $helper->method('getUser')->willReturn(new User('test@example.com', 'hashed'));
+        $helper->method('isCsrfTokenValid')->willReturn(false);
+
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+
+        $controller = new TestAiConnectionController($helper, $connectionTest, $settings, $urlGenerator);
+
+        $request = new Request();
+        $request->headers->set('HX-Request', 'true');
+        $request->headers->set('X-CSRF-Token', 'bad-token');
+
+        $response = $controller($request);
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    public function testUnauthenticatedUserRedirectsToLogin(): void
+    {
+        $connectionTest = $this->createStub(AiConnectionTestServiceInterface::class);
+        $settings = $this->createStub(SettingsServiceInterface::class);
+
+        $helper = $this->createMock(ControllerHelper::class);
+        $helper->method('getUser')->willReturn(null);
+
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('/login');
+
+        $controller = new TestAiConnectionController($helper, $connectionTest, $settings, $urlGenerator);
+
+        $response = $controller(new Request());
+
+        self::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+    }
+
+    private function buildController(
+        AiConnectionTestServiceInterface $connectionTest,
+        SettingsServiceInterface $settings,
+    ): TestAiConnectionController {
+        $helper = $this->createMock(ControllerHelper::class);
+        $helper->method('getUser')->willReturn(new User('test@example.com', 'hashed'));
+        $helper->method('isCsrfTokenValid')->willReturn(true);
+
+        $urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+
+        return new TestAiConnectionController($helper, $connectionTest, $settings, $urlGenerator);
+    }
+}

--- a/tests/Unit/Shared/Service/SettingsServiceTest.php
+++ b/tests/Unit/Shared/Service/SettingsServiceTest.php
@@ -117,6 +117,9 @@ final class SettingsServiceTest extends TestCase
         self::assertArrayHasKey('sentiment_slider', $all);
         self::assertFalse($all['sentiment_slider']['isOverridden']);
         self::assertSame('0', $all['sentiment_slider']['value']);
+
+        self::assertArrayHasKey('ai_provider', $all);
+        self::assertSame('openrouter', $all['ai_provider']['value']);
     }
 
     public function testGetAllReturnsDefaultsWhenNoDbOverrides(): void
@@ -230,14 +233,53 @@ final class SettingsServiceTest extends TestCase
         self::assertSame(5, $service->getSentimentSlider());
     }
 
-    private function createService(): SettingsService
+    public function testIsOpenAiConfiguredWhenAllFieldsPresent(): void
     {
+        $this->repository->method('findByKey')->willReturnCallback(
+            static fn (string $key): ?Setting => match ($key) {
+                'ai_openai_base_url' => new Setting($key, 'http://vllm.local/v1'),
+                'ai_openai_model' => new Setting($key, 'test-model'),
+                'ai_openai_api_key' => new Setting($key, 'secret'),
+                default => null,
+            },
+        );
+
+        $service = $this->createService(defaultAiProvider: 'openai');
+
+        self::assertTrue($service->isOpenAiConfigured());
+        self::assertTrue($service->isAiConfigured(''));
+    }
+
+    public function testGetAllMasksOpenAiApiKeyValue(): void
+    {
+        $this->repository->method('findAll')->willReturn([
+            new Setting('ai_openai_api_key', 'secret'),
+        ]);
+
+        $service = $this->createService();
+        $all = $service->getAll();
+
+        self::assertArrayHasKey('ai_openai_api_key', $all);
+        self::assertSame('', $all['ai_openai_api_key']['value']);
+        self::assertTrue($all['ai_openai_api_key']['isOverridden']);
+    }
+
+    private function createService(
+        string $defaultAiProvider = 'openrouter',
+        string $defaultAiOpenAiBaseUrl = '',
+        string $defaultAiOpenAiApiKey = '',
+        string $defaultAiOpenAiModel = '',
+    ): SettingsService {
         return new SettingsService(
             $this->repository,
             'en',
             60,
             90,
             30,
+            $defaultAiProvider,
+            $defaultAiOpenAiBaseUrl,
+            $defaultAiOpenAiApiKey,
+            $defaultAiOpenAiModel,
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds a second AI provider option alongside OpenRouter: any **OpenAI-compatible HTTP API** (vLLM, LocalAI, Ollama with OpenAI shim, etc.). Configuration is available in **Settings → AI Provider** and persisted in the database (API key masked at rest).

- **Provider routing**: new `SettingsRoutedPlatform` delegates all AI services (enrichment, chat, embeddings, digests, alerts) to either OpenRouter failover or the configured local endpoint
- **Settings UI**: Base URL, model ID, API key fields + **Test Connection** button (HTMX, CSRF-protected)
- **Save feedback**: visible alert + badge on successful settings save
- **Bare-metal / LAN fixes**:
  - Optional env vars default to empty string (no container boot crash when unset)
  - Chat works over plain HTTP (UUID fallback for non-secure contexts)
  - Streaming chat routed through `settings_routed` (was hardwired to OpenRouter)
  - Chat uses configured local model; falls back to non-streaming if SSE fails

## Motivation

Self-hosted deployments often run a local LLM via vLLM on the LAN without an OpenRouter key. Previously the app required `OPENROUTER_API_KEY` for all AI features. This PR makes local inference a first-class, UI-configurable path while keeping OpenRouter as the default.

## Configuration

**Via Settings UI** (recommended): select *OpenAI-compatible API*, fill Base URL / Model / API Key, click *Test Connection*, then *Save Settings*.

**Via env defaults** (optional, overridable in UI):

```env
AI_PROVIDER=openai
AI_OPENAI_BASE_URL=http://192.168.30.121:8000/v1
AI_OPENAI_API_KEY=changeme
AI_OPENAI_MODEL=your-model-id
```

Model ID must match `GET /v1/models` on the endpoint. Base URL accepts with or without trailing `/v1`.

## Architecture

```
Settings UI → SettingsService (DB)
                    ↓
         SettingsRoutedPlatform
           ├─ OpenRouter (ModelFailoverPlatform)  ← default
           └─ OpenAiCompatiblePlatform (GenericPlatformFactory)
```

New files: `AiProvider`, `OpenAiCompatiblePlatform`, `SettingsRoutedPlatform`, `AiConnectionTestService`, `TestAiConnectionController`.

## Test plan

- [x] Unit tests: `SettingsRoutedPlatform`, `SettingsService` (OpenAI keys), `TestAiConnectionController`, `ChatModelResolver`, `StreamingChatService`
- [x] PHPStan + ECS clean on touched files
- [x] Manual (bare-metal): Settings → OpenAI-compatible → Test Connection against vLLM → Save → badge/feedback visible
- [x] Manual (bare-metal): Chat sends message over HTTP LAN without OpenRouter key
- [x] Manual (bare-metal): Streaming chat uses configured local model
- [x] Manual (bare-metal): `/settings` loads after aligning AI Provider template + backend (fixes broken Settings when only partial changes were deployed)
- [ ] Manual: Switch back to OpenRouter provider — enrichment and chat still work with `OPENROUTER_API_KEY`
- [ ] Manual: `php bin/console app:ai-smoke-test` with each provider selected
- [ ] CI (GitHub Actions on PR)

## Notes

- Embeddings still require a compatible embeddings endpoint; vLLM deployments without embeddings may need OpenRouter for embedding-only features until a follow-up.